### PR TITLE
Added breadcrumbs filter.

### DIFF
--- a/lib/templates/fragments/breadcrumb.php
+++ b/lib/templates/fragments/breadcrumb.php
@@ -99,6 +99,13 @@ function beans_breadcrumb() {
 		$breadcrumbs[] = __( '404', 'tm-beans' );
 
 	}
+	
+	/**
+	 * Filter the breadcrumbs prior to Beans output.
+	 *
+	 * @param array $breadcrumbs An array of breadcrumbs which Beans will output.
+	 */
+	$breadcrumbs = apply_filters( 'beans_breadcrumbs', $breadcrumbs );
 
 	// Open breadcrumb.
 	beans_open_markup_e( 'beans_breadcrumb', 'ul', array( 'class' => 'uk-breadcrumb uk-width-1-1' ) );


### PR DESCRIPTION
Hi, Theirry!

First off, I want to say Beans is an amazing framework and I've really enjoyed using it in quite a few client projects lately.

A recent client wanted the breadcrumbs to display something other than "Home" as the breadcrumb root, so I needed to make this workaround to modify the output:

```
// Capture the output of beans_breadcrumb:
ob_start();
beans_breadcrumb();
    
// Replace 'Home' with the WordPress site name: 
$output = str_replace(
    esc_html__('Home', 'tm-beans'),
    esc_attr(get_bloginfo('name')),
    ob_get_clean()
);
    
// Output the modified breadcrumbs:
echo $output;
```

It's a really ugly solution so I'm proposing adding a filter to lib/fragments/breadcrumb.php which allows filtering the breadcrumbs array before Beans output.

Let me know if I need to make any changes to the code before you accept the merge.

Thanks,
Dan Reed