### PR TITLE
Made `_beans_render_action` and `_beans_unique_action_id` compliant

### DIFF
--- a/.dev-lib
+++ b/.dev-lib
@@ -1,5 +1,4 @@
 PROJECT_TYPE=theme
-CHECK_SCOPE=changed-files
 WPCS_STANDARD=phpcs.xml.dist
 PATH_EXCLUDES_PATTERN='^(.*/)?(vendors|vendor|node_modules)/.*'
 DEV_LIB_SKIP=yuicompressor,codeception,grunt,jshint

--- a/lib/api/actions/functions.php
+++ b/lib/api/actions/functions.php
@@ -5,8 +5,12 @@
  * While WordPress requires two or three arguments to remove an action, Beans
  * actions can be modified, replaced, removed or reset using only the ID as a reference.
  *
- * @package API\Actions
+ * @package Beans\Framework\API\Actions
+ *
+ * @since   1.5.0
  */
+
+// @codingStandardsIgnoreStart - Skipping over non-compliant code.
 
 /**
  * Hooks a function on to a specific action.
@@ -536,12 +540,14 @@ function _beans_add_anonymous_action( $hook, $callback, $priority = 10, $args = 
 
 }
 
+// @codingStandardsIgnoreEnd
+
 /**
  * Render action which can therefore be stored in a variable.
  *
  * @since 1.5.0
  *
- * @param mixed $hook
+ * @param mixed $hook Hook and possibly sub-hooks to be rendered.
  *
  * @return bool|null|string
  */
@@ -566,7 +572,8 @@ function _beans_render_action( $hook ) {
 
 	foreach ( (array) $sub_hooks[0] as $index => $sub_hook ) {
 		$variable_prefix .= $sub_hook;
-		$levels          = array( $prefix . $sub_hook . $suffix );
+
+		$levels = array( $prefix . $sub_hook . $suffix );
 
 		// Cascade sub-hooks.
 		if ( $index > 0 ) {
@@ -596,8 +603,8 @@ function _beans_render_action( $hook ) {
  *
  * @since 1.5.0
  *
- * @param array       $args
- * @param string|null $output
+ * @param array  $args   Array of arguments.
+ * @param string $output The output to be updated.
  *
  * @return string|bool
  */
@@ -644,7 +651,6 @@ function _beans_unique_action_id( $callback ) {
 
 	// Treat static method.
 	if ( is_string( $callback[0] ) ) {
-
 		return $callback[0] . '::' . $callback[1];
 	}
 

--- a/lib/api/actions/functions.php
+++ b/lib/api/actions/functions.php
@@ -570,7 +570,6 @@ function _beans_render_action( $hook ) {
 
 		// Cascade sub-hooks.
 		if ( $index > 0 ) {
-			$levels[] = str_replace( $sub_hook, '', $hook );
 			$levels[] = $variable_prefix . $suffix;
 		}
 

--- a/lib/api/actions/functions.php
+++ b/lib/api/actions/functions.php
@@ -546,6 +546,7 @@ function _beans_add_anonymous_action( $hook, $callback, $priority = 10, $args = 
  * Render action which can therefore be stored in a variable.
  *
  * @since 1.5.0
+ * @access private
  *
  * @param mixed $hook Hook and possibly sub-hooks to be rendered.
  *
@@ -602,6 +603,7 @@ function _beans_render_action( $hook ) {
  * Calls beans_render_function when the hook is registered.
  *
  * @since 1.5.0
+ * @access private
  *
  * @param array  $args   Array of arguments.
  * @param string $output The output to be updated.
@@ -622,6 +624,7 @@ function _beans_when_has_action_do_render( array $args, &$output = '' ) {
  * Make sure the action ID is unique.
  *
  * @since 1.5.0
+ * @access private
  *
  * @param mixed $callback Callback to convert into a unique ID.
  *

--- a/lib/api/actions/functions.php
+++ b/lib/api/actions/functions.php
@@ -10,8 +10,6 @@
  * @since   1.5.0
  */
 
-// @codingStandardsIgnoreStart - Skipping over non-compliant code.
-
 /**
  * Hooks a function on to a specific action.
  *
@@ -194,9 +192,9 @@ function beans_modify_action_callback( $id, $callback ) {
  *
  * @return bool Will always return true.
  */
-function beans_modify_action_priority( $id, $callback ) {
+function beans_modify_action_priority( $id, $priority ) {
 
-	return beans_modify_action( $id, null, null, $callback );
+	return beans_modify_action( $id, null, null, $priority );
 
 }
 
@@ -313,7 +311,7 @@ function beans_replace_action_callback( $id, $callback ) {
  *
  * @return bool Will always return true.
  */
-function beans_replace_action_priority( $id, $callback ) {
+function beans_replace_action_priority( $id, $priority ) {
 
 	return beans_replace_action( $id, null, null, $priority );
 
@@ -539,8 +537,6 @@ function _beans_add_anonymous_action( $hook, $callback, $priority = 10, $args = 
 	new _Beans_Anonymous_Actions( $hook, $callback, $priority, $args );
 
 }
-
-// @codingStandardsIgnoreEnd
 
 /**
  * Render action which can therefore be stored in a variable.

--- a/lib/api/actions/functions.php
+++ b/lib/api/actions/functions.php
@@ -546,6 +546,7 @@ function _beans_add_anonymous_action( $hook, $callback, $priority = 10, $args = 
  * Render action which can therefore be stored in a variable.
  *
  * @since 1.5.0
+ * @ignore
  * @access private
  *
  * @param mixed $hook Hook and possibly sub-hooks to be rendered.
@@ -603,6 +604,7 @@ function _beans_render_action( $hook ) {
  * Calls beans_render_function when the hook is registered.
  *
  * @since 1.5.0
+ * @ignore
  * @access private
  *
  * @param array  $args   Array of arguments.
@@ -624,6 +626,7 @@ function _beans_when_has_action_do_render( array $args, &$output = '' ) {
  * Make sure the action ID is unique.
  *
  * @since 1.5.0
+ * @ignore
  * @access private
  *
  * @param mixed $callback Callback to convert into a unique ID.

--- a/tests/phpunit/unit/api/actions/beansRenderAction.php
+++ b/tests/phpunit/unit/api/actions/beansRenderAction.php
@@ -33,10 +33,9 @@ class Tests_BeansRenderAction extends Test_Case {
 	}
 
 	/**
-	 * Test _beans_render_action() returns false when no subhook is passed and
-	 * the event's name (hook)
+	 * Test _beans_render_action() should return false when a callback is not registered to the hook/sub-hook.
 	 */
-	public function test_should_return_false_when_no_subhook_or_hook() {
+	public function test_should_return_false_when_a_callback_is_not_registered() {
 		$this->assertFalse( _beans_render_action( 'foo' ) );
 		$this->assertFalse( _beans_render_action( 'foo', 'bar' ) );
 		$this->assertFalse( _beans_render_action( 'foo', 'bar', array( 'baz' => 'zab' ) ) );
@@ -47,7 +46,7 @@ class Tests_BeansRenderAction extends Test_Case {
 	}
 
 	/**
-	 * Test _beans_render_action() returns after calling the hook with no subhook.
+	 * Test _beans_render_action() should return after calling the hook with no sub-hook.
 	 */
 	public function test_should_return_after_calling_hook_no_subhook() {
 		// Testing with a closure.
@@ -93,19 +92,19 @@ class Tests_BeansRenderAction extends Test_Case {
 	}
 
 	/**
-	 * Test _beans_render_action() returns null when it has a subhook, but the hook is not registered.
+	 * Test _beans_render_action() should return null for a sub-hook(s) when no callback is registered.
 	 */
-	public function test_should_return_null_with_subhook_but_no_hook_registered() {
+	public function test_should_return_null_for_subhook_when_no_callback_registered() {
 		$this->assertNull( _beans_render_action( 'beans_stub[beans_subhook_stub]' ) );
 		$this->assertNull( _beans_render_action( 'beans_stub[subhook][subhook]' ) );
 		$this->assertNull( _beans_render_action( 'beans_stub[beans_subhook_stub]_after_test' ) );
 	}
 
 	/**
-	 * Test _beans_render_action() returns message when it has a subhook, but only the base hook is registered.
-	 * Hint: the subhook(s) is(are) not registered via add_action().  Therefore, it will not be called.
+	 * Test _beans_render_action() should render the base hook and not the sub-hooks.
+	 * Why? No callbacks are registered to the sub-hooks.
 	 */
-	public function test_should_return_message_when_subhooks_but_only_base_hook_registered() {
+	public function test_should_render_base_hook() {
 		$stub = Actions_Stub::class;
 
 		// Test with a single sub-hook.
@@ -138,7 +137,7 @@ class Tests_BeansRenderAction extends Test_Case {
 	}
 
 	/**
-	 * Test _beans_render_action() renders one level of sub-hooks.
+	 * Test _beans_render_action() should render one level of sub-hooks.
 	 */
 	public function test_should_render_one_level_of_sub_hooks() {
 		$stub    = Actions_Stub::class;
@@ -160,8 +159,8 @@ class Tests_BeansRenderAction extends Test_Case {
 	}
 
 	/**
-	 * Test _beans_render_action() renders two levels of sub-hooks,
-	 * but the original hook is not rendered.
+	 * Test _beans_render_action() should render two levels of sub-hooks, but not the original.
+	 * Why? A callback is not registered to the original hook.
 	 */
 	public function test_should_render_two_levels_of_sub_hooks_but_not_original() {
 		$stub    = Actions_Stub::class;
@@ -187,9 +186,9 @@ class Tests_BeansRenderAction extends Test_Case {
 	}
 
 	/**
-	 * Test _beans_render_action() renders two levels of sub-hooks and the the original hook.
+	 * Test _beans_render_action() should render the base hook and all sub-hooks.
 	 */
-	public function test_should_render_two_levels_of_sub_hooks_and_original() {
+	public function test_should_render_hook_and_all_subhooks() {
 		$stub    = Actions_Stub::class;
 		$hook    = 'foo[bar][baz]';
 		$message = 'Called me. ';

--- a/tests/phpunit/unit/api/actions/beansRenderAction.php
+++ b/tests/phpunit/unit/api/actions/beansRenderAction.php
@@ -173,10 +173,6 @@ class Tests_BeansRenderAction extends Test_Case {
 		Actions\expectDone( 'foo' )->once()->whenHappen( array( $stub, 'echo_static' ) );
 		$expected = $message;
 
-		/**
-		 * Bug #78 - Should only call once.
-		 * Nate is working on this issue.
-		 */
 		// The 1st sub-hook renders.
 		add_action( 'foo[bar]', array( $stub, 'echo_static' ) );
 		Actions\expectDone( 'foo[bar]' )->once()->whenHappen( array( $stub, 'echo_static' ) );
@@ -203,10 +199,6 @@ class Tests_BeansRenderAction extends Test_Case {
 		Actions\expectDone( 'foo' )->once()->whenHappen( array( $stub, 'echo_static' ) );
 		$expected = $message;
 
-		/**
-		 * Bug #78 - Should only call once.
-		 * Nate is working on this issue.
-		 */
 		// The 1st sub-hook renders.
 		add_action( 'foo[bar]', array( $stub, 'echo_static' ) );
 		Actions\expectDone( 'foo[bar]' )->once()->whenHappen( array( $stub, 'echo_static' ) );

--- a/tests/phpunit/unit/api/actions/beansRenderAction.php
+++ b/tests/phpunit/unit/api/actions/beansRenderAction.php
@@ -1,0 +1,228 @@
+<?php
+/**
+ * Tests for _beans_render_action()
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Unit\API\Actions;
+
+use Beans\Framework\Tests\Unit\Test_Case;
+use Brain\Monkey\Actions;
+
+/**
+ * Class Tests_BeansRenderAction
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ * @group   unit-tests
+ * @group   api
+ */
+class Tests_BeansRenderAction extends Test_Case {
+
+	/**
+	 * Setup test fixture.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		require_once BEANS_TESTS_LIB_DIR . 'api/actions/functions.php';
+		require_once __DIR__ . '/stubs/class-action-stub.php';
+		require_once BEANS_TESTS_LIB_DIR . 'api/utilities/functions.php';
+	}
+
+	/**
+	 * Test _beans_render_action() returns false when no subhook is passed and
+	 * the event's name (hook)
+	 */
+	public function test_should_return_false_when_no_subhook_or_hook() {
+		$this->assertFalse( _beans_render_action( 'foo' ) );
+		$this->assertFalse( _beans_render_action( 'foo', 'bar' ) );
+		$this->assertFalse( _beans_render_action( 'foo', 'bar', array( 'baz' => 'zab' ) ) );
+		$this->assertFalse( _beans_render_action( 'foo_bar' ) );
+		$this->assertFalse( _beans_render_action( 'foo.bar' ) );
+		$this->assertFalse( _beans_render_action( 'beans_footer_before_markup' ) );
+		$this->assertFalse( _beans_render_action( 'beans_footer_after_markup' ) );
+	}
+
+	/**
+	 * Test _beans_render_action() returns after calling the hook with no subhook.
+	 */
+	public function test_should_return_after_calling_hook_no_subhook() {
+		// Testing with a closure.
+		$expected_args = array(
+			array( 'foo' ),
+			array( 'foo', 'bar' ),
+			array( 'foo', 'bar', 'baz' ),
+		);
+		$callback      = function() use ( $expected_args ) {
+			$args = func_get_args();
+			$this->assertTrue( doing_action( 'beans_stub' ) );
+			$this->assertEquals( $expected_args[ $args[0] ], $args[1] );
+
+			// Let's echo out to ensure this callback will was called.
+			echo $args[1][0];  // @codingStandardsIgnoreLine - WordPress.XSS.EscapeOutput.OutputNotEscaped - reason: we are not testing escaping functionality.
+		};
+		add_action( 'beans_stub', $callback );
+		$this->assertTrue( has_action( 'beans_stub' ) );
+		Actions\expectDone( 'beans_stub' )->whenHappen( $callback );
+		foreach ( $expected_args as $index => $args ) {
+			$this->assertEquals( $args[0], _beans_render_action( 'beans_stub', $index, $args ) );
+		}
+
+		// Testing with a stubbed method.
+		$stub    = new Actions_Stub();
+		$message = 'Beans rocks!';
+		add_action( 'beans_stub_with_object', array( $stub, 'echo' ) );
+		$this->assertTrue( has_action( 'beans_stub_with_object' ) );
+		Actions\expectDone( 'beans_stub_with_object' )->whenHappen( array( $stub, 'echo' ) );
+		$this->assertEquals( $message, _beans_render_action( 'beans_stub_with_object', $message ) );
+
+		// Testing with a stubbed static method.
+		$stub = Actions_Stub::class;
+		add_action( 'beans_stub_with_static_method', array( $stub, 'echo_static' ) );
+		$this->assertTrue( has_action( 'beans_stub_with_static_method' ) );
+		Actions\expectDone( 'beans_stub_with_static_method' )->times( 3 )->whenHappen( array( $stub, 'echo_static' ) );
+
+		$message = 'Calling the static method...and Beans rocks!';
+		$this->assertEquals( $message, _beans_render_action( 'beans_stub_with_static_method', $message ) );
+		$message = 'Yippee, it worked again!';
+		$this->assertEquals( $message, _beans_render_action( 'beans_stub_with_static_method', $message ) );
+		$this->assertEquals( 5, _beans_render_action( 'beans_stub_with_static_method', 5 ) );
+	}
+
+	/**
+	 * Test _beans_render_action() returns null when it has a subhook, but the hook is not registered.
+	 */
+	public function test_should_return_null_with_subhook_but_no_hook_registered() {
+		$this->assertNull( _beans_render_action( 'beans_stub[beans_subhook_stub]' ) );
+		$this->assertNull( _beans_render_action( 'beans_stub[subhook][subhook]' ) );
+		$this->assertNull( _beans_render_action( 'beans_stub[beans_subhook_stub]_after_test' ) );
+	}
+
+	/**
+	 * Test _beans_render_action() returns message when it has a subhook, but only the base hook is registered.
+	 * Hint: the subhook(s) is(are) not registered via add_action().  Therefore, it will not be called.
+	 */
+	public function test_should_return_message_when_subhooks_but_only_base_hook_registered() {
+		$stub = Actions_Stub::class;
+
+		// Test with a single sub-hook.
+		add_action( 'foo', array( $stub, 'echo_static' ) );
+		Actions\expectDone( 'foo' )->whenHappen( array( $stub, 'echo_static' ) );
+		Actions\expectDone( 'bar' )->never();
+		$this->assertEquals( 'Called foo.', _beans_render_action( 'foo[bar]', 'Called foo.' ) );
+
+		// Test with a suffix.
+		add_action( 'foo_bar', array( $stub, 'echo_static' ) );
+		Actions\expectDone( 'foo_bar' )->whenHappen( array( $stub, 'echo_static' ) );
+		Actions\expectDone( 'baz_bar' )->never();
+		$this->assertEquals( 'Called foo_bar.', _beans_render_action( 'foo[baz]_bar', 'Called foo_bar.' ) );
+
+		// Test with multiple sub-hooks.
+		add_action( 'beans_stub', array( $stub, 'echo_static' ) );
+		Actions\expectDone( 'beans_stub' )->whenHappen( array( $stub, 'echo_static' ) );
+		Actions\expectDone( 'beans_stub[_pre]' )->never();
+		Actions\expectDone( 'beans_stub[_before]' )->never();
+		Actions\expectDone( 'beans_stub[_pre][_before]' )->never();
+		$this->assertEquals( 'Beans rocks!', _beans_render_action( 'beans_stub[_pre][_before]', 'Beans rocks!' ) );
+
+		// Test with multiple sub-hooks.
+		add_action( 'beans_stub_after', array( $stub, 'echo_static' ) );
+		Actions\expectDone( 'beans_stub_after' )->whenHappen( array( $stub, 'echo_static' ) );
+		Actions\expectDone( 'beans_stub[_pre]_after' )->never();
+		Actions\expectDone( 'beans_stub[_before]_after' )->never();
+		Actions\expectDone( 'beans_stub[_pre][_before]_after' )->never();
+		$this->assertEquals( 'Beans rocks!', _beans_render_action( 'beans_stub[_subhook][_subsubhook]_after', 'Beans rocks!' ) );
+	}
+
+	/**
+	 * Test _beans_render_action() renders one level of sub-hooks.
+	 */
+	public function test_should_render_one_level_of_sub_hooks() {
+		$stub    = Actions_Stub::class;
+		$hook    = 'foo[bar]';
+		$message = 'Called me. ';
+
+		// The root hook renders.
+		add_action( 'foo', array( $stub, 'echo_static' ) );
+		Actions\expectDone( 'foo' )->once()->whenHappen( array( $stub, 'echo_static' ) );
+		$expected = $message;
+
+		// The 1st sub-hook renders.
+		add_action( 'foo[bar]', array( $stub, 'echo_static' ) );
+		Actions\expectDone( 'foo[bar]' )->once()->whenHappen( array( $stub, 'echo_static' ) );
+		$expected .= $message;
+
+		// Run the test.
+		$this->assertEquals( $expected, _beans_render_action( $hook, $message ) );
+	}
+
+	/**
+	 * Test _beans_render_action() renders two levels of sub-hooks,
+	 * but the original hook is not rendered.
+	 */
+	public function test_should_render_two_levels_of_sub_hooks_but_not_original() {
+		$stub    = Actions_Stub::class;
+		$hook    = 'foo[bar][baz]';
+		$message = 'Called me. ';
+
+		// The root hook renders.
+		add_action( 'foo', array( $stub, 'echo_static' ) );
+		Actions\expectDone( 'foo' )->once()->whenHappen( array( $stub, 'echo_static' ) );
+		$expected = $message;
+
+		/**
+		 * Bug #78 - Should only call once.
+		 * Nate is working on this issue.
+		 */
+		// The 1st sub-hook renders.
+		add_action( 'foo[bar]', array( $stub, 'echo_static' ) );
+		Actions\expectDone( 'foo[bar]' )->once()->whenHappen( array( $stub, 'echo_static' ) );
+		$expected .= $message;
+
+		// These hooks will not render as they are not registered.
+		Actions\expectDone( 'foo[baz]' )->never();
+		Actions\expectDone( 'foo[bar][baz]' )->never();
+
+		// Run the test.
+		$this->assertEquals( $expected, _beans_render_action( $hook, $message ) );
+	}
+
+	/**
+	 * Test _beans_render_action() renders two levels of sub-hooks and the the original hook.
+	 */
+	public function test_should_render_two_levels_of_sub_hooks_and_original() {
+		$stub    = Actions_Stub::class;
+		$hook    = 'foo[bar][baz]';
+		$message = 'Called me. ';
+
+		// The root hook renders.
+		add_action( 'foo', array( $stub, 'echo_static' ) );
+		Actions\expectDone( 'foo' )->once()->whenHappen( array( $stub, 'echo_static' ) );
+		$expected = $message;
+
+		/**
+		 * Bug #78 - Should only call once.
+		 * Nate is working on this issue.
+		 */
+		// The 1st sub-hook renders.
+		add_action( 'foo[bar]', array( $stub, 'echo_static' ) );
+		Actions\expectDone( 'foo[bar]' )->once()->whenHappen( array( $stub, 'echo_static' ) );
+		$expected .= $message;
+
+		// The 2nd sub-hook renders.
+		add_action( 'foo[baz]', array( $stub, 'echo_static' ) );
+		Actions\expectDone( 'foo[baz]' )->once()->whenHappen( array( $stub, 'echo_static' ) );
+		$expected .= $message;
+
+		// The original hook renders.
+		add_action( 'foo[bar][baz]', array( $stub, 'echo_static' ) );
+		Actions\expectDone( 'foo[bar][baz]' )->once()->whenHappen( array( $stub, 'echo_static' ) );
+		$expected .= $message;
+
+		// Run the test.
+		$this->assertEquals( $expected, _beans_render_action( $hook, $message ) );
+	}
+}

--- a/tests/phpunit/unit/api/actions/beansRenderAction.php
+++ b/tests/phpunit/unit/api/actions/beansRenderAction.php
@@ -74,9 +74,9 @@ class Tests_BeansRenderAction extends Test_Case {
 		// Testing with a stubbed method.
 		$stub    = new Actions_Stub();
 		$message = 'Beans rocks!';
-		add_action( 'beans_stub_with_object', array( $stub, 'echo' ) );
+		add_action( 'beans_stub_with_object', array( $stub, 'echo_static' ) );
 		$this->assertTrue( has_action( 'beans_stub_with_object' ) );
-		Actions\expectDone( 'beans_stub_with_object' )->whenHappen( array( $stub, 'echo' ) );
+		Actions\expectDone( 'beans_stub_with_object' )->whenHappen( array( $stub, 'echo_static' ) );
 		$this->assertEquals( $message, _beans_render_action( 'beans_stub_with_object', $message ) );
 
 		// Testing with a stubbed static method.

--- a/tests/phpunit/unit/api/actions/beansUniqueActionId.php
+++ b/tests/phpunit/unit/api/actions/beansUniqueActionId.php
@@ -110,7 +110,7 @@ class Tests_BeansUniqueActionId extends Test_Case {
 
 		$this->assertEquals( spl_object_hash( $closure ), _beans_unique_action_id( $closure ) );
 		$this->assertNotEquals( spl_object_hash( function() {
-			// nothing here.
+			// Nothing here.
 		} ), _beans_unique_action_id( $closure ) );
 	}
 }

--- a/tests/phpunit/unit/api/actions/beansUniqueActionId.php
+++ b/tests/phpunit/unit/api/actions/beansUniqueActionId.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Tests for _beans_unique_action_id()
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Unit\API\Actions;
+
+use Beans\Framework\Tests\Unit\Test_Case;
+
+/**
+ * Class Tests_BeansUniqueActionId
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ * @group   unit-tests
+ * @group   api
+ */
+class Tests_BeansUniqueActionId extends Test_Case {
+
+	/**
+	 * Setup test fixture.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		require_once BEANS_TESTS_LIB_DIR . 'api/actions/functions.php';
+		require_once __DIR__ . '/stubs/class-action-stub.php';
+	}
+
+	/**
+	 * Test _beans_unique_action_id() returns the given argument when it's a string.
+	 */
+	public function test_should_return_when_string() {
+		$this->assertEquals( "I'm a string", _beans_unique_action_id( "I'm a string" ) );
+		$this->assertEquals( 'I\'m a string', _beans_unique_action_id( 'I\'m a string' ) );
+		$this->assertEquals( 'foo', _beans_unique_action_id( 'foo' ) );
+		$this->assertEquals( 'trim', _beans_unique_action_id( 'trim' ) );
+		$this->assertEquals( '__return_false', _beans_unique_action_id( '__return_false' ) );
+		$this->assertEquals( __NAMESPACE__ . '\foo', _beans_unique_action_id( __NAMESPACE__ . '\foo' ) );
+		$this->assertEquals(
+			'Tests_BeansUniqueActionId::test_should_return_when_string',
+			_beans_unique_action_id( 'Tests_BeansUniqueActionId::test_should_return_when_string' )
+		);
+	}
+
+	/**
+	 * Test _beans_unique_action_id() should convert static method.
+	 */
+	public function test_should_convert_static_method() {
+		$this->assertEquals(
+			'Foo::bar',
+			_beans_unique_action_id( array( 'Foo', 'bar' ) )
+		);
+		$this->assertEquals(
+			'Tests_BeansUniqueActionId::test_should_return_when_string',
+			_beans_unique_action_id( array( 'Tests_BeansUniqueActionId', 'test_should_return_when_string' ) )
+		);
+
+		$stub_classname = __NAMESPACE__ . '\Actions_Stub';
+		$this->assertEquals(
+			$stub_classname . '::dummy_static_method',
+			_beans_unique_action_id( array( $stub_classname, 'dummy_static_method' ) )
+		);
+		$this->assertEquals(
+			$stub_classname . '::dummy_static_method',
+			_beans_unique_action_id( $stub_classname . '::dummy_static_method' )
+		);
+
+		$stub = new Actions_Stub();
+		$this->assertNotEquals(
+			$stub_classname . '::dummy_static_method',
+			_beans_unique_action_id( array( $stub, 'dummy_static_method' ) )
+		);
+		$this->assertStringEndsWith(
+			'dummy_static_method',
+			_beans_unique_action_id( array( $stub, 'dummy_static_method' ) )
+		);
+		$this->assertEquals(
+			spl_object_hash( $stub ) . 'dummy_static_method',
+			_beans_unique_action_id( array( $stub, 'dummy_static_method' ) )
+		);
+	}
+
+	/**
+	 * Test _beans_unique_action_id() should convert object.
+	 */
+	public function test_should_convert_object() {
+		// 2 different objects should have unique IDs.
+		$this->assertNotEquals( new \stdClass(), _beans_unique_action_id( new \stdClass() ) );
+		$this->assertNotEquals( new Actions_Stub(), _beans_unique_action_id( new Actions_Stub() ) );
+
+		$stub = new Actions_Stub();
+		$this->assertEquals( spl_object_hash( $stub ), _beans_unique_action_id( $stub ) );
+		$this->assertEquals(
+			spl_object_hash( $stub ) . 'dummy_method',
+			_beans_unique_action_id( array( $stub, 'dummy_method' ) )
+		);
+	}
+
+	/**
+	 * Test _beans_unique_action_id() should convert closure.
+	 */
+	public function test_should_convert_closure() {
+		$closure = function( $dummy_arg ) {
+			return $dummy_arg;
+		};
+
+		$this->assertEquals( spl_object_hash( $closure ), _beans_unique_action_id( $closure ) );
+		$this->assertNotEquals( spl_object_hash( function() {
+			// nothing here.
+		} ), _beans_unique_action_id( $closure ) );
+	}
+}

--- a/tests/phpunit/unit/api/actions/beansUniqueActionId.php
+++ b/tests/phpunit/unit/api/actions/beansUniqueActionId.php
@@ -31,9 +31,9 @@ class Tests_BeansUniqueActionId extends Test_Case {
 	}
 
 	/**
-	 * Test _beans_unique_action_id() returns the given argument when it's a string.
+	 * Test _beans_unique_action_id() should return when string given.
 	 */
-	public function test_should_return_when_string() {
+	public function test_should_return_when_string_given() {
 		$this->assertEquals( "I'm a string", _beans_unique_action_id( "I'm a string" ) );
 		$this->assertEquals( 'I\'m a string', _beans_unique_action_id( 'I\'m a string' ) );
 		$this->assertEquals( 'foo', _beans_unique_action_id( 'foo' ) );

--- a/tests/phpunit/unit/api/actions/stubs/class-action-stub.php
+++ b/tests/phpunit/unit/api/actions/stubs/class-action-stub.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Stub for API Actions.
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Unit\API\Actions;
+
+/**
+ * Class Actions_Stub
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ */
+class Actions_Stub {
+
+	/**
+	 * Dummy static method.
+	 */
+	public static function dummy_static_method() {
+		// nothing happening here.
+	}
+
+	/**
+	 * Dummy method.
+	 */
+	public function dummy_method() {
+		// nothing happening here.
+	}
+
+	/**
+	 * Echo what you send me.
+	 *
+	 * @param string|int $message Message to echo.
+	 */
+	public function echo( $message ) {
+		echo $message;   // @codingStandardsIgnoreLine - WordPress.XSS.EscapeOutput.OutputNotEscaped - reason: we are not testing escaping functionality.
+	}
+
+	/**
+	 * Echo what you send me.
+	 *
+	 * @param string|int $message Message to echo.
+	 */
+	public static function echo_static( $message ) {
+		echo $message;   // @codingStandardsIgnoreLine - WordPress.XSS.EscapeOutput.OutputNotEscaped - reason: we are not testing escaping functionality.
+	}
+}

--- a/tests/phpunit/unit/api/actions/stubs/class-action-stub.php
+++ b/tests/phpunit/unit/api/actions/stubs/class-action-stub.php
@@ -20,14 +20,14 @@ class Actions_Stub {
 	 * Dummy static method.
 	 */
 	public static function dummy_static_method() {
-		// nothing happening here.
+		// Nothing happening here.
 	}
 
 	/**
 	 * Dummy method.
 	 */
 	public function dummy_method() {
-		// nothing happening here.
+		// Nothing happening here.
 	}
 
 	/**
@@ -36,6 +36,6 @@ class Actions_Stub {
 	 * @param string|int $message Message to echo.
 	 */
 	public static function echo_static( $message ) {
-		echo $message;   // @codingStandardsIgnoreLine - WordPress.XSS.EscapeOutput.OutputNotEscaped - reason: we are not testing escaping functionality.
+		echo $message; // @codingStandardsIgnoreLine - WordPress.XSS.EscapeOutput.OutputNotEscaped - reason: we are not testing escaping functionality.
 	}
 }

--- a/tests/phpunit/unit/api/actions/stubs/class-action-stub.php
+++ b/tests/phpunit/unit/api/actions/stubs/class-action-stub.php
@@ -35,15 +35,6 @@ class Actions_Stub {
 	 *
 	 * @param string|int $message Message to echo.
 	 */
-	public function echo( $message ) {
-		echo $message;   // @codingStandardsIgnoreLine - WordPress.XSS.EscapeOutput.OutputNotEscaped - reason: we are not testing escaping functionality.
-	}
-
-	/**
-	 * Echo what you send me.
-	 *
-	 * @param string|int $message Message to echo.
-	 */
 	public static function echo_static( $message ) {
 		echo $message;   // @codingStandardsIgnoreLine - WordPress.XSS.EscapeOutput.OutputNotEscaped - reason: we are not testing escaping functionality.
 	}


### PR DESCRIPTION
1. Made `_beans_render_action` WPCS compliant
2. Made `_beans_unique_action_id` WPCS compliant
3. Tests for both
4. Fixed #78 