### PR TITLE
Made private functions compliant

### DIFF
--- a/lib/api/actions/functions.php
+++ b/lib/api/actions/functions.php
@@ -413,7 +413,8 @@ if ( ! isset( $_beans_registered_actions ) ) {
  * Get the action's configuration for the given ID and status. Returns `false` if the action is not registered with
  * Beans.
  *
- * @since  1.5.0
+ * @since  1.0.0
+ * @since  1.5.0 Made WPCS compliant.
  * @ignore
  * @access private
  *
@@ -449,7 +450,8 @@ function _beans_get_action( $id, $status ) {
  * then the new action's configuration is stored, overwriting the previous one. Else, the registered action's
  * configuration is returned.
  *
- * @since  1.5.0
+ * @since  1.0.0
+ * @since  1.5.0 Made WPCS compliant.
  * @ignore
  * @access private
  *
@@ -483,7 +485,8 @@ function _beans_set_action( $id, array $action, $status, $overwrite = false ) {
  * Unset the action's configuration for the given ID and status. Returns `false` if there are is no action
  * registered with Beans actions for the given ID and status. Else, returns true when complete.
  *
- * @since  1.5.0
+ * @since  1.0.0
+ * @since  1.5.0 Made WPCS compliant.
  * @ignore
  * @access private
  *
@@ -509,9 +512,10 @@ function _beans_unset_action( $id, $status ) {
 /**
  * Merge the action's configuration and then store it for the given ID and status.
  *
- * If the action's configuration has not already be registered with Beans, just store it.
+ * If the action's configuration has not already been registered with Beans, just store it.
  *
- * @since  1.5.0
+ * @since  1.0.0
+ * @since  1.5.0 Made WPCS compliant.
  * @ignore
  * @access private
  *
@@ -537,7 +541,8 @@ function _beans_merge_action( $id, array $action, $status ) {
 /**
  * Get the current action, meaning get from the "added" and/or "modified" statuses.
  *
- * @since  1.5.0
+ * @since  1.0.0
+ * @since  1.5.0 Made WPCS compliant.
  * @ignore
  * @access private
  *

--- a/lib/api/actions/functions.php
+++ b/lib/api/actions/functions.php
@@ -456,15 +456,15 @@ function _beans_get_action( $id, $status ) {
  * @ignore
  * @access private
  *
- * @param string $id        The action's Beans ID, a unique ID tracked within Beans for this action.
- * @param array  $action    The action configuration to store.
- * @param string $status    Status for which to store the action.
- * @param bool   $overwrite Optional. When set to `true`, the new action's configuration is stored, overwriting a
- *                          previously stored configuration (if one exists).
+ * @param string      $id        The action's Beans ID, a unique ID tracked within Beans for this action.
+ * @param array|mixed $action    The action configuration to store.
+ * @param string      $status    Status for which to store the action.
+ * @param bool        $overwrite Optional. When set to `true`, the new action's configuration is stored, overwriting a
+ *                               previously stored configuration (if one exists).
  *
- * @return array
+ * @return array|mixed
  */
-function _beans_set_action( $id, array $action, $status, $overwrite = false ) {
+function _beans_set_action( $id, $action, $status, $overwrite = false ) {
 	$id = _beans_unique_action_id( $id );
 
 	// Get the action, if it's already registered.

--- a/lib/api/actions/functions.php
+++ b/lib/api/actions/functions.php
@@ -414,7 +414,6 @@ if ( ! isset( $_beans_registered_actions ) ) {
  * Beans.
  *
  * @since  1.0.0
- * @since  1.5.0
  * @ignore
  * @access private
  *
@@ -452,7 +451,6 @@ function _beans_get_action( $id, $status ) {
  * configuration is returned.
  *
  * @since  1.0.0
- * @since  1.5.0
  * @ignore
  * @access private
  *
@@ -487,7 +485,6 @@ function _beans_set_action( $id, $action, $status, $overwrite = false ) {
  * registered with Beans actions for the given ID and status. Else, returns true when complete.
  *
  * @since  1.0.0
- * @since  1.5.0
  * @ignore
  * @access private
  *
@@ -516,7 +513,6 @@ function _beans_unset_action( $id, $status ) {
  * If the action's configuration has not already been registered with Beans, just store it.
  *
  * @since  1.0.0
- * @since  1.5.0
  * @ignore
  * @access private
  *
@@ -543,7 +539,6 @@ function _beans_merge_action( $id, array $action, $status ) {
  * Get the current action, meaning get from the "added" and/or "modified" statuses.
  *
  * @since  1.0.0
- * @since  1.5.0
  * @ignore
  * @access private
  *

--- a/lib/api/actions/functions.php
+++ b/lib/api/actions/functions.php
@@ -435,8 +435,9 @@ function _beans_get_action( $id, $status ) {
 	}
 
 	$action = beans_get( $id, $registered_actions );
-	// If the action is null, return false.
-	if ( is_null( $action ) ) {
+
+	// If the action is empty, return false.
+	if ( empty( $action ) ) {
 		return false;
 	}
 
@@ -551,7 +552,6 @@ function _beans_merge_action( $id, array $action, $status ) {
  * @return array|bool
  */
 function _beans_get_current_action( $id ) {
-
 	// Bail out if the action is "removed".
 	if ( _beans_get_action( $id, 'removed' ) ) {
 		return false;
@@ -565,6 +565,7 @@ function _beans_get_current_action( $id ) {
 	}
 
 	$modified = _beans_get_action( $id, 'modified' );
+
 	if ( false !== $modified ) {
 		$action = is_array( $action )
 			? array_merge( $action, $modified )

--- a/lib/api/actions/functions.php
+++ b/lib/api/actions/functions.php
@@ -535,33 +535,43 @@ function _beans_merge_action( $id, array $action, $status ) {
 }
 
 /**
- * Check all action status and return the current action.
+ * Get the current action, meaning get from the "added" and/or "modified" statuses.
  *
+ * @since  1.5.0
  * @ignore
+ * @access private
+ *
+ * @param string $id A unique string used as a reference.
+ *
+ * @return array|bool
  */
 function _beans_get_current_action( $id ) {
 
-	$action = array();
-
+	// Bail out if the action is "removed".
 	if ( _beans_get_action( $id, 'removed' ) ) {
 		return false;
 	}
 
-	if ( $added = _beans_get_action( $id, 'added' ) ) {
+	$action = array();
+
+	$added = _beans_get_action( $id, 'added' );
+	if ( false !== $added ) {
 		$action = $added;
 	}
 
-	if ( $modified = _beans_get_action( $id, 'modified' ) ) {
-		$action = array_merge( $action, $modified );
+	$modified = _beans_get_action( $id, 'modified' );
+	if ( false !== $modified ) {
+		$action = is_array( $action )
+			? array_merge( $action, $modified )
+			: $modified;
 	}
 
 	// Stop here if the action is invalid.
-	if ( 4 != count( $action ) ) {
+	if ( 4 !== count( $action ) ) {
 		return false;
 	}
 
 	return $action;
-
 }
 
 /**

--- a/lib/api/actions/functions.php
+++ b/lib/api/actions/functions.php
@@ -575,6 +575,22 @@ function _beans_get_current_action( $id ) {
 }
 
 /**
+ * Validates the action's configuration to ensure "hook", "callback", "priority", and "args" are
+ * set and not null.
+ *
+ * @since  1.5.0
+ * @ignore
+ * @access private
+ *
+ * @param array $action Action's configuration.
+ *
+ * @return bool
+ */
+function _beans_is_action_valid( array $action ) {
+	return isset( $action['hook'], $action['callback'], $action['priority'], $action['args'] );
+}
+
+/**
  * Add anonymous callback using a class since php 5.2 is still supported.
  *
  * @since  1.5.0

--- a/lib/api/actions/functions.php
+++ b/lib/api/actions/functions.php
@@ -414,7 +414,7 @@ if ( ! isset( $_beans_registered_actions ) ) {
  * Beans.
  *
  * @since  1.0.0
- * @since  1.5.0 Made WPCS compliant.
+ * @since  1.5.0
  * @ignore
  * @access private
  *
@@ -452,7 +452,7 @@ function _beans_get_action( $id, $status ) {
  * configuration is returned.
  *
  * @since  1.0.0
- * @since  1.5.0 Made WPCS compliant.
+ * @since  1.5.0
  * @ignore
  * @access private
  *
@@ -487,7 +487,7 @@ function _beans_set_action( $id, array $action, $status, $overwrite = false ) {
  * registered with Beans actions for the given ID and status. Else, returns true when complete.
  *
  * @since  1.0.0
- * @since  1.5.0 Made WPCS compliant.
+ * @since  1.5.0
  * @ignore
  * @access private
  *
@@ -516,7 +516,7 @@ function _beans_unset_action( $id, $status ) {
  * If the action's configuration has not already been registered with Beans, just store it.
  *
  * @since  1.0.0
- * @since  1.5.0 Made WPCS compliant.
+ * @since  1.5.0
  * @ignore
  * @access private
  *
@@ -543,7 +543,7 @@ function _beans_merge_action( $id, array $action, $status ) {
  * Get the current action, meaning get from the "added" and/or "modified" statuses.
  *
  * @since  1.0.0
- * @since  1.5.0 Made WPCS compliant.
+ * @since  1.5.0
  * @ignore
  * @access private
  *

--- a/lib/api/actions/functions.php
+++ b/lib/api/actions/functions.php
@@ -567,7 +567,7 @@ function _beans_get_current_action( $id ) {
 	}
 
 	// Stop here if the action is invalid.
-	if ( 4 !== count( $action ) ) {
+	if ( ! _beans_is_action_valid( $action ) ) {
 		return false;
 	}
 

--- a/lib/api/actions/functions.php
+++ b/lib/api/actions/functions.php
@@ -423,7 +423,6 @@ if ( ! isset( $_beans_registered_actions ) ) {
  * @return array|bool
  */
 function _beans_get_action( $id, $status ) {
-
 	global $_beans_registered_actions;
 
 	$id = _beans_unique_action_id( $id );
@@ -463,7 +462,6 @@ function _beans_get_action( $id, $status ) {
  * @return array
  */
 function _beans_set_action( $id, array $action, $status, $overwrite = false ) {
-
 	$id = _beans_unique_action_id( $id );
 
 	// Get the action, if it's already registered.
@@ -483,25 +481,31 @@ function _beans_set_action( $id, array $action, $status, $overwrite = false ) {
 }
 
 /**
- * Unset action.
+ * Unset the action's configuration for the given ID and status. Returns `false` if there are is no action
+ * registered with Beans actions for the given ID and status. Else, returns true when complete.
  *
+ * @since  1.5.0
  * @ignore
+ * @access private
+ *
+ * @param string $id     A unique string used as a reference.
+ * @param string $status Status for which to get the action.
+ *
+ * @return bool
  */
 function _beans_unset_action( $id, $status ) {
-
-	global $_beans_registered_actions;
-
 	$id = _beans_unique_action_id( $id );
 
-	// Stop here if the action doesn't exist.
-	if ( ! _beans_get_action( $id, $status ) ) {
+	// Bail out if the ID is not registered for the given status.
+	if ( false === _beans_get_action( $id, $status ) ) {
 		return false;
 	}
+
+	global $_beans_registered_actions;
 
 	unset( $_beans_registered_actions[ $status ][ $id ] );
 
 	return true;
-
 }
 
 /**

--- a/lib/api/actions/functions.php
+++ b/lib/api/actions/functions.php
@@ -560,6 +560,7 @@ function _beans_get_current_action( $id ) {
 	$action = array();
 
 	$added = _beans_get_action( $id, 'added' );
+
 	if ( false !== $added ) {
 		$action = $added;
 	}

--- a/lib/api/actions/functions.php
+++ b/lib/api/actions/functions.php
@@ -418,7 +418,7 @@ if ( ! isset( $_beans_registered_actions ) ) {
  * @ignore
  * @access private
  *
- * @param string $id     A unique string used as a reference.
+ * @param string $id     The action's Beans ID, a unique ID tracked within Beans for this action.
  * @param string $status Status for which to get the action.
  *
  * @return array|bool
@@ -456,7 +456,7 @@ function _beans_get_action( $id, $status ) {
  * @ignore
  * @access private
  *
- * @param string $id        A unique string used as a reference.
+ * @param string $id        The action's Beans ID, a unique ID tracked within Beans for this action.
  * @param array  $action    The action configuration to store.
  * @param string $status    Status for which to store the action.
  * @param bool   $overwrite Optional. When set to `true`, the new action's configuration is stored, overwriting a
@@ -491,7 +491,7 @@ function _beans_set_action( $id, array $action, $status, $overwrite = false ) {
  * @ignore
  * @access private
  *
- * @param string $id     A unique string used as a reference.
+ * @param string $id     The action's Beans ID, a unique ID tracked within Beans for this action.
  * @param string $status Status for which to get the action.
  *
  * @return bool
@@ -520,7 +520,7 @@ function _beans_unset_action( $id, $status ) {
  * @ignore
  * @access private
  *
- * @param string $id     A unique string used as a reference.
+ * @param string $id     The action's Beans ID, a unique ID tracked within Beans for this action.
  * @param array  $action The new action's configuration to merge and then store.
  * @param string $status Status for which to merge/store this action.
  *
@@ -547,7 +547,7 @@ function _beans_merge_action( $id, array $action, $status ) {
  * @ignore
  * @access private
  *
- * @param string $id A unique string used as a reference.
+ * @param string $id The action's Beans ID, a unique ID tracked within Beans for this action.
  *
  * @return array|bool
  */

--- a/lib/api/actions/functions.php
+++ b/lib/api/actions/functions.php
@@ -410,9 +410,16 @@ if ( ! isset( $_beans_registered_actions ) ) {
 }
 
 /**
- * Get action.
+ * Get the action's configuration for the given ID and status. Returns `false` if the action is not registered with Beans.
  *
+ * @since  1.5.0
  * @ignore
+ * @access private
+ *
+ * @param string $id     A unique string used as a reference.
+ * @param string $status Status for which to get the action.
+ *
+ * @return array|bool
  */
 function _beans_get_action( $id, $status ) {
 
@@ -420,16 +427,19 @@ function _beans_get_action( $id, $status ) {
 
 	$id = _beans_unique_action_id( $id );
 
-	if ( ! $registered = beans_get( $status, $_beans_registered_actions ) ) {
+	$registered_actions = beans_get( $status, $_beans_registered_actions );
+	// If the status is empty, return false, as no actions are registered.
+	if ( empty( $registered_actions ) ) {
 		return false;
 	}
 
-	if ( ! $action = beans_get( $id, $registered ) ) {
+	$action = beans_get( $id, $registered_actions );
+	// If the action is null, return false.
+	if ( is_null( $action ) ) {
 		return false;
 	}
 
 	return (array) json_decode( $action );
-
 }
 
 /**

--- a/lib/api/actions/functions.php
+++ b/lib/api/actions/functions.php
@@ -425,9 +425,9 @@ if ( ! isset( $_beans_registered_actions ) ) {
 function _beans_get_action( $id, $status ) {
 	global $_beans_registered_actions;
 
-	$id = _beans_unique_action_id( $id );
-
+	$id                 = _beans_unique_action_id( $id );
 	$registered_actions = beans_get( $status, $_beans_registered_actions );
+
 	// If the status is empty, return false, as no actions are registered.
 	if ( empty( $registered_actions ) ) {
 		return false;
@@ -455,7 +455,7 @@ function _beans_get_action( $id, $status ) {
  *
  * @param string $id        A unique string used as a reference.
  * @param array  $action    The action configuration to store.
- * @param string $status    Status for which to get the action.
+ * @param string $status    Status for which to store the action.
  * @param bool   $overwrite Optional. When set to `true`, the new action's configuration is stored, overwriting a
  *                          previously stored configuration (if one exists).
  *
@@ -474,7 +474,6 @@ function _beans_set_action( $id, array $action, $status, $overwrite = false ) {
 
 	// Let's set (or overwrite) the action.
 	global $_beans_registered_actions;
-
 	$_beans_registered_actions[ $status ][ $id ] = wp_json_encode( $action );
 
 	return $action;
@@ -502,29 +501,37 @@ function _beans_unset_action( $id, $status ) {
 	}
 
 	global $_beans_registered_actions;
-
 	unset( $_beans_registered_actions[ $status ][ $id ] );
 
 	return true;
 }
 
 /**
- * Merge action.
+ * Merge the action's configuration and then store it for the given ID and status.
  *
+ * If the action's configuration has not already be registered with Beans, just store it.
+ *
+ * @since  1.5.0
  * @ignore
+ * @access private
+ *
+ * @param string $id     A unique string used as a reference.
+ * @param array  $action The new action's configuration to merge and then store.
+ * @param string $status Status for which to merge/store this action.
+ *
+ * @return array
  */
-function _beans_merge_action( $id, $action, $status ) {
+function _beans_merge_action( $id, array $action, $status ) {
+	$id                = _beans_unique_action_id( $id );
+	$registered_action = _beans_get_action( $id, $status );
 
-	global $_beans_registered_actions;
-
-	$id = _beans_unique_action_id( $id );
-
-	if ( $_action = _beans_get_action( $id, $status ) ) {
-		$action = array_merge( $_action, $action );
+	// If the action's configuration is already registered with Beans, merge the new configuration with it.
+	if ( false !== $registered_action ) {
+		$action = array_merge( $registered_action, $action );
 	}
 
+	// Now store/register it.
 	return _beans_set_action( $id, $action, $status, true );
-
 }
 
 /**

--- a/lib/api/actions/functions.php
+++ b/lib/api/actions/functions.php
@@ -410,7 +410,8 @@ if ( ! isset( $_beans_registered_actions ) ) {
 }
 
 /**
- * Get the action's configuration for the given ID and status. Returns `false` if the action is not registered with Beans.
+ * Get the action's configuration for the given ID and status. Returns `false` if the action is not registered with
+ * Beans.
  *
  * @since  1.5.0
  * @ignore
@@ -443,25 +444,42 @@ function _beans_get_action( $id, $status ) {
 }
 
 /**
- * Set action.
+ * Store the action's configuration for the given ID and status.
  *
+ * What happens if the action's configuration is already registered?  If the `$overwrite` flag is set to `true`,
+ * then the new action's configuration is stored, overwriting the previous one. Else, the registered action's
+ * configuration is returned.
+ *
+ * @since  1.5.0
  * @ignore
+ * @access private
+ *
+ * @param string $id        A unique string used as a reference.
+ * @param array  $action    The action configuration to store.
+ * @param string $status    Status for which to get the action.
+ * @param bool   $overwrite Optional. When set to `true`, the new action's configuration is stored, overwriting a
+ *                          previously stored configuration (if one exists).
+ *
+ * @return array
  */
-function _beans_set_action( $id, $action, $status, $overwrite = false ) {
-
-	global $_beans_registered_actions;
+function _beans_set_action( $id, array $action, $status, $overwrite = false ) {
 
 	$id = _beans_unique_action_id( $id );
 
-	// Return action which already exist unless overwrite is set to true.
-	if ( ! $overwrite && ( $_action = _beans_get_action( $id, $status ) ) ) {
-		return $_action;
+	// Get the action, if it's already registered.
+	$registered_action = _beans_get_action( $id, $status );
+
+	// If the action is registered and we are not overwriting, return it.
+	if ( true !== $overwrite && ! empty( $registered_action ) ) {
+		return $registered_action;
 	}
 
-	$_beans_registered_actions[ $status ][ $id ] = json_encode( $action );
+	// Let's set (or overwrite) the action.
+	global $_beans_registered_actions;
+
+	$_beans_registered_actions[ $status ][ $id ] = wp_json_encode( $action );
 
 	return $action;
-
 }
 
 /**

--- a/tests/phpunit/unit/api/actions/beansGetAction.php
+++ b/tests/phpunit/unit/api/actions/beansGetAction.php
@@ -12,7 +12,7 @@ namespace Beans\Framework\Tests\Unit\API\Actions;
 use Beans\Framework\Tests\Unit\Test_Case;
 
 /**
- * Class Tests_BeansRenderAction
+ * Class Tests_BeansGetAction
  *
  * @package Beans\Framework\Tests\Unit\API\Actions
  * @group   unit-tests

--- a/tests/phpunit/unit/api/actions/beansGetAction.php
+++ b/tests/phpunit/unit/api/actions/beansGetAction.php
@@ -28,6 +28,20 @@ class Tests_BeansGetAction extends Test_Case {
 	protected $action_status;
 
 	/**
+	 * Action to be/is registered.
+	 *
+	 * @var array
+	 */
+	protected $action;
+
+	/**
+	 * The json_encode() version of the above action.
+	 *
+	 * @var string
+	 */
+	protected $encoded_action;
+
+	/**
 	 * Setup test fixture.
 	 */
 	protected function setUp() {
@@ -36,6 +50,14 @@ class Tests_BeansGetAction extends Test_Case {
 		$this->action_status = array( 'added', 'modified', 'removed', 'replaced' );
 		require_once BEANS_TESTS_LIB_DIR . 'api/actions/functions.php';
 		require_once BEANS_TESTS_LIB_DIR . 'api/utilities/functions.php';
+
+		$this->action         = array(
+			'hook'     => 'foo',
+			'callback' => 'callback',
+			'priority' => 10,
+			'args'     => 1,
+		);
+		$this->encoded_action = wp_json_encode( $this->action );
 	}
 
 	/**
@@ -68,13 +90,7 @@ class Tests_BeansGetAction extends Test_Case {
 	 */
 	public function test_should_return_false_when_action_is_not_registered() {
 		global $_beans_registered_actions;
-		// @codingStandardsIgnoreLine - WordPress.WP.AlternativeFunctions.json_encode_json_encode as json_encode is appropriate here for testing.
-		$_beans_registered_actions['added']['foo'] = json_encode( array(
-			'hook'     => 'foo',
-			'callback' => 'callback',
-			'priority' => 10,
-			'args'     => 1,
-		) );
+		$_beans_registered_actions['added']['foo'] = $this->encoded_action;
 
 		$this->assertFalse( _beans_get_action( 'foobar', 'added' ) );
 
@@ -96,16 +112,9 @@ class Tests_BeansGetAction extends Test_Case {
 	public function test_should_return_action_when_registered() {
 		global $_beans_registered_actions;
 
-		$action_configuration = array(
-			'hook'     => 'foo',
-			'callback' => 'callback',
-			'priority' => 10,
-			'args'     => 1,
-		);
-
 		foreach ( $this->action_status as $action_status ) {
-			$_beans_registered_actions[ $action_status ]['foo'] = json_encode( $action_configuration ); // @codingStandardsIgnoreLine - WordPress.WP.AlternativeFunctions.json_encode_json_encode as json_encode is appropriate here for testing.
-			$this->assertEquals( $action_configuration, _beans_get_action( 'foo', $action_status ) );
+			$_beans_registered_actions[ $action_status ]['foo'] = $this->encoded_action;
+			$this->assertEquals( $this->action, _beans_get_action( 'foo', $action_status ) );
 		}
 	}
 }

--- a/tests/phpunit/unit/api/actions/beansGetAction.php
+++ b/tests/phpunit/unit/api/actions/beansGetAction.php
@@ -79,7 +79,6 @@ class Tests_BeansGetAction extends Test_Case {
 	 * Test _beans_get_action() should return false when the status is empty, i.e. no actions are registered.
 	 */
 	public function test_should_return_false_when_status_is_empty() {
-
 		foreach ( $this->action_status as $action_status ) {
 			$this->assertFalse( _beans_get_action( 'foo', $action_status ) );
 		}

--- a/tests/phpunit/unit/api/actions/beansGetAction.php
+++ b/tests/phpunit/unit/api/actions/beansGetAction.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Tests for _beans_get_action()
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Unit\API\Actions;
+
+use Beans\Framework\Tests\Unit\Test_Case;
+
+/**
+ * Class Tests_BeansRenderAction
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ * @group   unit-tests
+ * @group   api
+ */
+class Tests_BeansGetAction extends Test_Case {
+
+	/**
+	 * Available action statuses.
+	 *
+	 * @var array
+	 */
+	protected $action_status;
+
+	/**
+	 * Setup test fixture.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		$this->action_status = array( 'added', 'modified', 'removed', 'replaced' );
+		require_once BEANS_TESTS_LIB_DIR . 'api/actions/functions.php';
+		require_once BEANS_TESTS_LIB_DIR . 'api/utilities/functions.php';
+	}
+
+	/**
+	 * Reset the test fixture.
+	 */
+	protected function tearDown() {
+		parent::tearDown();
+
+		global $_beans_registered_actions;
+		$_beans_registered_actions = array(
+			'added'    => array(),
+			'modified' => array(),
+			'removed'  => array(),
+			'replaced' => array(),
+		);
+	}
+
+	/**
+	 * Test _beans_get_action() should return false when the status is empty, i.e. no actions are registered.
+	 */
+	public function test_should_return_false_when_status_is_empty() {
+
+		foreach ( $this->action_status as $action_status ) {
+			$this->assertFalse( _beans_get_action( 'foo', $action_status ) );
+		}
+	}
+
+	/**
+	 * Test _beans_get_action() should return false when the action is not registered.
+	 */
+	public function test_should_return_false_when_action_is_not_registered() {
+		global $_beans_registered_actions;
+		// @codingStandardsIgnoreLine - WordPress.WP.AlternativeFunctions.json_encode_json_encode as json_encode is appropriate here for testing.
+		$_beans_registered_actions['added']['foo'] = json_encode( array(
+			'hook'     => 'foo',
+			'callback' => 'callback',
+			'priority' => 10,
+			'args'     => 1,
+		) );
+
+		$this->assertFalse( _beans_get_action( 'foobar', 'added' ) );
+
+		// Make sure we get false on the other statuses.
+		foreach ( $this->action_status as $action_status ) {
+
+			// Skip the 'added' status.
+			if ( 'added' === $action_status ) {
+				continue;
+			}
+
+			$this->assertFalse( _beans_get_action( 'foo', $action_status ) );
+		}
+	}
+
+	/**
+	 * Test _beans_get_action() should return the action's configuration when it's registered.
+	 */
+	public function test_should_return_action_when_registered() {
+		global $_beans_registered_actions;
+
+		$action_configuration = array(
+			'hook'     => 'foo',
+			'callback' => 'callback',
+			'priority' => 10,
+			'args'     => 1,
+		);
+
+		foreach ( $this->action_status as $action_status ) {
+			$_beans_registered_actions[ $action_status ]['foo'] = json_encode( $action_configuration ); // @codingStandardsIgnoreLine - WordPress.WP.AlternativeFunctions.json_encode_json_encode as json_encode is appropriate here for testing.
+			$this->assertEquals( $action_configuration, _beans_get_action( 'foo', $action_status ) );
+		}
+	}
+}

--- a/tests/phpunit/unit/api/actions/beansGetCurrentAction.php
+++ b/tests/phpunit/unit/api/actions/beansGetCurrentAction.php
@@ -61,7 +61,7 @@ class Tests_BeansGetCurrentAction extends Test_Case {
 	}
 
 	/**
-	 * Test _beans_get_current_action() should return false when the ID is registered with the "removed" status.
+	 * Test _beans_get_current_action() should return false when the action is invalid.
 	 */
 	public function test_should_return_false_when_action_is_invalid() {
 		global $_beans_registered_actions;

--- a/tests/phpunit/unit/api/actions/beansGetCurrentAction.php
+++ b/tests/phpunit/unit/api/actions/beansGetCurrentAction.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Tests for _beans_get_current_action()
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Unit\API\Actions;
+
+use Beans\Framework\Tests\Unit\Test_Case;
+
+/**
+ * Class Tests_BeansGetCurrentAction
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ * @group   unit-tests
+ * @group   api
+ */
+class Tests_BeansGetCurrentAction extends Test_Case {
+
+	/**
+	 * Setup test fixture.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		require_once BEANS_TESTS_LIB_DIR . 'api/actions/functions.php';
+		require_once BEANS_TESTS_LIB_DIR . 'api/utilities/functions.php';
+	}
+
+	/**
+	 * Reset the test fixture.
+	 */
+	protected function tearDown() {
+		parent::tearDown();
+
+		global $_beans_registered_actions;
+		$_beans_registered_actions = array(
+			'added'    => array(),
+			'modified' => array(),
+			'removed'  => array(),
+			'replaced' => array(),
+		);
+	}
+
+	/**
+	 * Test _beans_get_current_action() should return false when the ID is registered with the "removed" status.
+	 */
+	public function test_should_return_false_when_removed_status() {
+		global $_beans_registered_actions;
+		$_beans_registered_actions['removed']['foo'] = wp_json_encode( array(
+			'hook'     => 'foo',
+			'callback' => 'callback',
+			'priority' => 10,
+			'args'     => 1,
+		) );
+
+		$this->assertFalse( _beans_get_current_action( 'foo' ) );
+	}
+
+	/**
+	 * Test _beans_get_current_action() should return false when the ID is registered with the "removed" status.
+	 */
+	public function test_should_return_false_when_action_is_invalid() {
+		global $_beans_registered_actions;
+
+		// Test "added" status.
+		$_beans_registered_actions['added']['foo'] = wp_json_encode( array( 'hook' => 'foo' ) );
+		$this->assertFalse( _beans_get_current_action( 'foo' ) );
+
+		// Test "modified" status.
+		$_beans_registered_actions['modified']['bar'] = wp_json_encode( array(
+			'hook'     => 'bar',
+			'priority' => 1,
+		) );
+		$this->assertFalse( _beans_get_current_action( 'bar' ) );
+
+		// Test merging "modified" into "added" status.
+		$_beans_registered_actions['modified']['foo'] = wp_json_encode( array( 'callback' => 'foo_cb' ) );
+		$this->assertFalse( _beans_get_current_action( 'foo' ) );
+	}
+
+	/**
+	 * Test _beans_get_current_action() should return the "added" configuration.
+	 */
+	public function test_should_return_added_action() {
+		global $_beans_registered_actions;
+		$action                                    = array(
+			'hook'     => 'foo',
+			'callback' => 'callback',
+			'priority' => 10,
+			'args'     => 1,
+		);
+		$_beans_registered_actions['added']['foo'] = wp_json_encode( $action );
+		$this->assertEquals( $action, _beans_get_current_action( 'foo' ) );
+	}
+
+	/**
+	 * Test _beans_get_current_action() should return the "modified" configuration.
+	 */
+	public function test_should_return_modified_action() {
+		global $_beans_registered_actions;
+		$action                                       = array(
+			'hook'     => 'foo',
+			'callback' => 'callback',
+			'priority' => 10,
+			'args'     => 1,
+		);
+		$_beans_registered_actions['modified']['foo'] = wp_json_encode( $action );
+		$this->assertEquals( $action, _beans_get_current_action( 'foo' ) );
+	}
+
+	/**
+	 * Test _beans_get_current_action() should merge "modified" action's configuration with the "added" configuration.
+	 */
+	public function test_should_merge_modified_with_added() {
+		global $_beans_registered_actions;
+
+		$_beans_registered_actions['added']['foo'] = wp_json_encode( array(
+			'hook'     => 'foo',
+			'callback' => 'callback',
+			'priority' => 10,
+			'args'     => 1,
+		) );
+
+		$_beans_registered_actions['modified']['foo'] = wp_json_encode( array(
+			'priority' => 1,
+		) );
+
+		$expected = array(
+			'hook'     => 'foo',
+			'callback' => 'callback',
+			'priority' => 1,
+			'args'     => 1,
+		);
+		$this->assertEquals( $expected, _beans_get_current_action( 'foo' ) );
+	}
+}

--- a/tests/phpunit/unit/api/actions/beansIsActionValid.php
+++ b/tests/phpunit/unit/api/actions/beansIsActionValid.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Tests for _beans_is_action_valid()
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Unit\API\Actions;
+
+use Beans\Framework\Tests\Unit\Test_Case;
+
+/**
+ * Class Tests_BeansIsActionValid
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ * @group   unit-tests
+ * @group   api
+ */
+class Tests_BeansIsActionValid extends Test_Case {
+
+	/**
+	 * Setup test fixture.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		require_once BEANS_TESTS_LIB_DIR . 'api/actions/functions.php';
+	}
+
+	/**
+	 * Test _beans_is_action_valid() should return false when one or more of the the required parameter(s)
+	 * is(are) missing.
+	 */
+	public function test_should_return_false_when_parameter_missing() {
+		$this->assertFalse( _beans_is_action_valid( array( 'hook' => 'foo' ) ) );
+		$this->assertFalse( _beans_is_action_valid( array( 'callback' => 'cb' ) ) );
+
+		$this->assertFalse( _beans_is_action_valid( array(
+			'hook'     => 'foo',
+			'callback' => 'cb',
+		) ) );
+
+		$this->assertFalse( _beans_is_action_valid( array(
+			'hook'     => 'foo',
+			'callback' => 'cb',
+			'priority' => 10,
+		) ) );
+
+		$this->assertFalse( _beans_is_action_valid( array(
+			'hook'     => 'foo',
+			'callback' => 'cb',
+			'args'     => 2,
+		) ) );
+
+		$this->assertFalse( _beans_is_action_valid( array(
+			'hook'     => 'foo',
+			'priority' => 10,
+			'args'     => 2,
+		) ) );
+
+		$this->assertFalse( _beans_is_action_valid( array(
+			'callback' => 'cb',
+			'priority' => 10,
+			'args'     => 2,
+		) ) );
+
+		$this->assertFalse( _beans_is_action_valid( array(
+			'callback' => 'cb',
+			'priority' => 10,
+			'args'     => 2,
+			'foo'      => 'bar',
+		) ) );
+	}
+
+	/**
+	 * Test _beans_is_action_valid() should return false when one or more of the required parameters is set to null.
+	 */
+	public function test_should_return_false_when_parameter_is_null() {
+		$this->assertFalse( _beans_is_action_valid( array(
+			'hook'     => 'foo',
+			'callback' => null,
+			'priority' => 10,
+			'args'     => 2,
+		) ) );
+	}
+
+	/**
+	 * Test _beans_is_action_valid() should return true when the action's configuration is valid.
+	 */
+	public function test_should_return_true_when_action_is_valid() {
+		$this->assertTrue( _beans_is_action_valid( array(
+			'hook'     => 'foo',
+			'callback' => 'cb',
+			'priority' => 10,
+			'args'     => 2,
+		) ) );
+
+		$this->assertTrue( _beans_is_action_valid( array(
+			'hook'     => 'start_loop',
+			'callback' => 'foo_callback',
+			'priority' => 20,
+			'args'     => 1,
+		) ) );
+
+		$object = new \stdClass();
+		$this->assertTrue( _beans_is_action_valid( array(
+			'hook'     => 'some_hook[_some_subhook]',
+			'callback' => [ $object, 'callback_method' ],
+			'priority' => 10,
+			'args'     => 2,
+		) ) );
+
+		$this->assertTrue( _beans_is_action_valid( array(
+			'hook'     => 'post_title',
+			'callback' => 'Some_Object::some_method',
+			'priority' => 50,
+			'args'     => 3,
+		) ) );
+	}
+}

--- a/tests/phpunit/unit/api/actions/beansMergeAction.php
+++ b/tests/phpunit/unit/api/actions/beansMergeAction.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Tests for _beans_merge_action()
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Unit\API\Actions;
+
+use Beans\Framework\Tests\Unit\Test_Case;
+
+/**
+ * Class Tests_BeansMergeAction
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ * @group   unit-tests
+ * @group   api
+ */
+class Tests_BeansMergeAction extends Test_Case {
+
+	/**
+	 * Available action statuses.
+	 *
+	 * @var array
+	 */
+	protected $action_status;
+
+	/**
+	 * Action to be/is registered.
+	 *
+	 * @var array
+	 */
+	protected $action;
+
+	/**
+	 * The json_encode() version of the above action.
+	 *
+	 * @var string
+	 */
+	protected $encoded_action;
+
+	/**
+	 * Setup test fixture.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		$this->action_status = array( 'added', 'modified', 'removed', 'replaced' );
+		require_once BEANS_TESTS_LIB_DIR . 'api/actions/functions.php';
+		require_once BEANS_TESTS_LIB_DIR . 'api/utilities/functions.php';
+
+		$this->action         = array(
+			'hook'     => 'foo',
+			'callback' => 'callback',
+			'priority' => 10,
+			'args'     => 1,
+		);
+		$this->encoded_action = wp_json_encode( $this->action );
+	}
+
+	/**
+	 * Reset the test fixture.
+	 */
+	protected function tearDown() {
+		parent::tearDown();
+
+		global $_beans_registered_actions;
+		$_beans_registered_actions = array(
+			'added'    => array(),
+			'modified' => array(),
+			'removed'  => array(),
+			'replaced' => array(),
+		);
+	}
+
+	/**
+	 * Test _beans_set_action() should merge the new action's configuration with the registered one and then return it.
+	 */
+	public function test_should_merge_and_return() {
+		global $_beans_registered_actions;
+
+		$expected             = $this->action;
+		$expected['priority'] = 20;
+
+		foreach ( $this->action_status as $action_status ) {
+			// Set the original action configuration.
+			_beans_set_action( 'foo', $this->action, $action_status );
+
+			// Now test that it does properly merge the action for the given status.
+			$this->assertEquals( $expected, _beans_merge_action( 'foo', array( 'priority' => 20 ), $action_status ) );
+			$this->assertEquals( wp_json_encode( $expected ), $_beans_registered_actions[ $action_status ]['foo'] );
+		}
+	}
+
+	/**
+	 * Test _beans_merge_action() should store new action's configuration, when it's not already registered.
+	 */
+	public function test_should_store_new_action() {
+		global $_beans_registered_actions;
+
+		foreach ( $this->action_status as $action_status ) {
+			$this->assertEquals( $this->action, _beans_merge_action( 'foo', $this->action, $action_status ) );
+			$this->assertEquals( $this->encoded_action, $_beans_registered_actions[ $action_status ]['foo'] );
+		}
+	}
+}

--- a/tests/phpunit/unit/api/actions/beansSetAction.php
+++ b/tests/phpunit/unit/api/actions/beansSetAction.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * Tests for _beans_set_action()
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Unit\API\Actions;
+
+use Beans\Framework\Tests\Unit\Test_Case;
+
+/**
+ * Class Tests_BeansSetAction
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ * @group   unit-tests
+ * @group   api
+ */
+class Tests_BeansSetAction extends Test_Case {
+
+	/**
+	 * Available action statuses.
+	 *
+	 * @var array
+	 */
+	protected $action_status;
+
+	/**
+	 * Action to be/is registered.
+	 *
+	 * @var array
+	 */
+	protected $action;
+
+	/**
+	 * The json_encode() version of the above action.
+	 *
+	 * @var string
+	 */
+	protected $encoded_action;
+
+	/**
+	 * Setup test fixture.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		$this->action_status = array( 'added', 'modified', 'removed', 'replaced' );
+		require_once BEANS_TESTS_LIB_DIR . 'api/actions/functions.php';
+		require_once BEANS_TESTS_LIB_DIR . 'api/utilities/functions.php';
+
+		$this->action         = array(
+			'hook'     => 'foo',
+			'callback' => 'callback',
+			'priority' => 10,
+			'args'     => 1,
+		);
+		$this->encoded_action = wp_json_encode( $this->action );
+	}
+
+	/**
+	 * Reset the test fixture.
+	 */
+	protected function tearDown() {
+		parent::tearDown();
+
+		global $_beans_registered_actions;
+		$_beans_registered_actions = array(
+			'added'    => array(),
+			'modified' => array(),
+			'removed'  => array(),
+			'replaced' => array(),
+		);
+	}
+
+	/**
+	 * Test _beans_set_action() should set the action into the registered actions and then return it.
+	 */
+	public function test_should_set_and_return_action() {
+		global $_beans_registered_actions;
+
+		foreach ( $this->action_status as $action_status ) {
+			// Check that it's not set before we start.
+			$this->assertFalse( isset( $_beans_registered_actions[ $action_status ]['foo'] ) );
+
+			// Now test that it does properly set the action for the given status.
+			$this->assertEquals( $this->action, _beans_set_action( 'foo', $this->action, $action_status ) );
+			$this->assertArrayHasKey( 'foo', $_beans_registered_actions[ $action_status ] );
+			$this->assertEquals( $this->encoded_action, $_beans_registered_actions[ $action_status ]['foo'] );
+		}
+	}
+
+	/**
+	 * Test _beans_set_action() should not overwrite an existing registered action.
+	 */
+	public function test_should_not_overwrite_existing_registered_action() {
+		global $_beans_registered_actions;
+
+		$new_action = array(
+			'hook'     => 'bar',
+			'callback' => 'callback_bar',
+			'priority' => 20,
+			'args'     => 2,
+		);
+
+		foreach ( $this->action_status as $action_status ) {
+
+			// Register the original one first.
+			_beans_set_action( 'foo', $this->action, $action_status );
+
+			// Now test that it does not overwrite the previously registered action.
+			$this->assertEquals( $this->action, _beans_set_action( 'foo', $new_action, $action_status ) );
+			$this->assertEquals( $this->encoded_action, $_beans_registered_actions[ $action_status ]['foo'] );
+		}
+	}
+
+	/**
+	 * Test _beans_set_action() should overwrite an existing registered action.
+	 */
+	public function test_should_overwrite_existing_registered_action() {
+		global $_beans_registered_actions;
+
+		$new_action         = array(
+			'hook'     => 'bar',
+			'callback' => 'callback_bar',
+			'priority' => 20,
+			'args'     => 2,
+		);
+		$encoded_new_action = wp_json_encode( $new_action );
+
+		foreach ( $this->action_status as $action_status ) {
+
+			// Register the original one first.
+			_beans_set_action( 'foo', $this->action, $action_status );
+
+			// Now test that it does overwrite the previously registered action.
+			$this->assertEquals( $new_action, _beans_set_action( 'foo', $new_action, $action_status, true ) );
+			$this->assertEquals( $encoded_new_action, $_beans_registered_actions[ $action_status ]['foo'] );
+		}
+	}
+}

--- a/tests/phpunit/unit/api/actions/beansSetAction.php
+++ b/tests/phpunit/unit/api/actions/beansSetAction.php
@@ -117,7 +117,8 @@ class Tests_BeansSetAction extends Test_Case {
 	}
 
 	/**
-	 * Test _beans_set_action() should overwrite an existing registered action.
+	 * Test _beans_set_action() should overwrite the existing registered action when the "overwrite"
+	 * argument is set to true.
 	 */
 	public function test_should_overwrite_existing_registered_action() {
 		global $_beans_registered_actions;

--- a/tests/phpunit/unit/api/actions/beansUnsetAction.php
+++ b/tests/phpunit/unit/api/actions/beansUnsetAction.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Tests for _beans_unset_action()
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Unit\API\Actions;
+
+use Beans\Framework\Tests\Unit\Test_Case;
+
+/**
+ * Class Tests_BeansUnsetAction
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ * @group   unit-tests
+ * @group   api
+ */
+class Tests_BeansUnsetAction extends Test_Case {
+
+	/**
+	 * Available action statuses.
+	 *
+	 * @var array
+	 */
+	protected $action_status;
+
+	/**
+	 * Action to be/is registered.
+	 *
+	 * @var array
+	 */
+	protected $action;
+
+	/**
+	 * The json_encode() version of the above action.
+	 *
+	 * @var string
+	 */
+	protected $encoded_action;
+
+	/**
+	 * Setup test fixture.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		$this->action_status = array( 'added', 'modified', 'removed', 'replaced' );
+		require_once BEANS_TESTS_LIB_DIR . 'api/actions/functions.php';
+		require_once BEANS_TESTS_LIB_DIR . 'api/utilities/functions.php';
+
+		$this->action         = array(
+			'hook'     => 'foo',
+			'callback' => 'callback',
+			'priority' => 10,
+			'args'     => 1,
+		);
+		$this->encoded_action = wp_json_encode( $this->action );
+	}
+
+	/**
+	 * Reset the test fixture.
+	 */
+	protected function tearDown() {
+		parent::tearDown();
+
+		global $_beans_registered_actions;
+		$_beans_registered_actions = array(
+			'added'    => array(),
+			'modified' => array(),
+			'removed'  => array(),
+			'replaced' => array(),
+		);
+	}
+
+	/**
+	 * Test _beans_unset_action() should return false when action's configuration is not registered.
+	 */
+	public function test_should_set_and_return_action() {
+
+		foreach ( $this->action_status as $action_status ) {
+			$this->assertFalse( _beans_unset_action( 'foo', $action_status ) );
+		}
+	}
+
+	/**
+	 * Test _beans_unset_action() should unset the registered action's configuration.
+	 */
+	public function test_should_unset_registered_action() {
+		global $_beans_registered_actions;
+
+		foreach ( $this->action_status as $action_status ) {
+
+			// First, register the action.
+			_beans_set_action( 'foo', $this->action, $action_status );
+			$this->assertTrue( isset( $_beans_registered_actions[ $action_status ]['foo'] ) );
+
+			// Then test that unset does it's job.
+			$this->assertTrue( _beans_unset_action( 'foo', $action_status ) );
+			$this->assertFalse( isset( $_beans_registered_actions[ $action_status ]['foo'] ) );
+		}
+	}
+
+	/**
+	 * Test _beans_unset_action() should return false when the status is invalid.
+	 */
+	public function test_should_return_false_when_status_is_invalid() {
+		$this->assertFalse( _beans_unset_action( 'foo', 'invalid_status' ) );
+		$this->assertFalse( _beans_unset_action( 'foo', 'foo' ) );
+		$this->assertFalse( _beans_unset_action( 'foo', 'not_valid_either' ) );
+
+		// Now store some configurations and test it again.
+		foreach ( $this->action_status as $action_status ) {
+			_beans_set_action( 'foo', $this->action, $action_status );
+		}
+
+		$this->assertFalse( _beans_unset_action( 'foo', 'invalid_status' ) );
+		$this->assertFalse( _beans_unset_action( 'foo', 'foo' ) );
+		$this->assertFalse( _beans_unset_action( 'foo', 'not_valid_either' ) );
+	}
+}

--- a/tests/phpunit/unit/api/actions/beansUnsetAction.php
+++ b/tests/phpunit/unit/api/actions/beansUnsetAction.php
@@ -78,7 +78,7 @@ class Tests_BeansUnsetAction extends Test_Case {
 	/**
 	 * Test _beans_unset_action() should return false when action's configuration is not registered.
 	 */
-	public function test_should_set_and_return_action() {
+	public function test_should_return_false_when_not_registered() {
 
 		foreach ( $this->action_status as $action_status ) {
 			$this->assertFalse( _beans_unset_action( 'foo', $action_status ) );
@@ -97,7 +97,7 @@ class Tests_BeansUnsetAction extends Test_Case {
 			_beans_set_action( 'foo', $this->action, $action_status );
 			$this->assertTrue( isset( $_beans_registered_actions[ $action_status ]['foo'] ) );
 
-			// Then test that unset does it's job.
+			// Then test that unset does its job.
 			$this->assertTrue( _beans_unset_action( 'foo', $action_status ) );
 			$this->assertFalse( isset( $_beans_registered_actions[ $action_status ]['foo'] ) );
 		}

--- a/tests/phpunit/unit/class-test-case.php
+++ b/tests/phpunit/unit/class-test-case.php
@@ -37,6 +37,11 @@ abstract class Test_Case extends TestCase {
 
 			return $path;
 		} );
+
+		Functions\when( 'wp_json_encode' )->alias( function ( $array ) {
+			// @codingStandardsIgnoreLine - WordPress.WP.AlternativeFunctions.json_encode_json_encode - we are mocking the function here.
+			return json_encode( $array );
+		} );
 	}
 
 	/**


### PR DESCRIPTION
This PR is for the private functions which interact directly with the global `$_beans_registered_actions`. 

1. Made WPCS compliant
2. Added unit tests.
3. Added DocBlock.