### PR TITLE
Made beans_modify_action compliant

### DIFF
--- a/lib/api/actions/functions.php
+++ b/lib/api/actions/functions.php
@@ -161,22 +161,21 @@ function beans_modify_action_hook( $id, $hook ) {
 }
 
 /**
- * Modify an action callback.
+ * Modify callback for the given action, i.e. referenced by its Bean's ID.
  *
  * This function is a shortcut of {@see beans_modify_action()}.
  *
  * @since 1.0.0
+ * @since 1.5.0 Made WPCS compliant.
  *
- * @param string $id       The action ID.
- * @param string $callback Optional. The name of the new function you wish to be called. Use NULL to keep
- *                         the original value.
+ * @param string        $id       The action's Beans ID, a unique ID tracked within Beans for this action.
+ * @param callable|null $callback Optional. The new callback (function or method) you wish to be called.
+ *                                Use NULL to keep the original value.
  *
  * @return bool Will always return true.
  */
 function beans_modify_action_callback( $id, $callback ) {
-
 	return beans_modify_action( $id, null, $callback );
-
 }
 
 /**

--- a/lib/api/actions/functions.php
+++ b/lib/api/actions/functions.php
@@ -114,12 +114,7 @@ function beans_add_smart_action( $hook, $callback, $priority = 10, $args = 1 ) {
  * @return bool
  */
 function beans_modify_action( $id, $hook = null, $callback = null, $priority = null, $args = null ) {
-	$action = array_filter( array(
-		'hook'     => $hook,
-		'callback' => $callback,
-		'priority' => $priority,
-		'args'     => $args,
-	) );
+	$action = _beans_build_action_for_valid_args( $hook, $callback, $priority, $args );
 	// If no changes were passed in, there's nothing to modify. Bail out.
 	if ( empty( $action ) ) {
 		return false;
@@ -195,9 +190,7 @@ function beans_modify_action_callback( $id, $callback ) {
  * @return bool Will always return true.
  */
 function beans_modify_action_priority( $id, $priority ) {
-
 	return beans_modify_action( $id, null, null, $priority );
-
 }
 
 /**
@@ -525,6 +518,45 @@ function _beans_get_current_action( $id ) {
 
 	return $action;
 
+}
+
+/**
+ * Build the action's array for only the valid given arguments.  Valid arguments are:
+ *
+ * @since 1.5.0
+ *
+ * @param string|null   $hook     Optional. The action event's name to which the $callback is hooked.
+ *                                Valid when not falsey,
+ *                                i.e. (meaning not `null`, `false`, `0`, `0.0`, an empty string, or empty array).
+ * @param callable|null $callback Optional. The callback (function or method) you wish to be called when the event
+ *                                fires. Valid when not falsey, i.e. (meaning not `null`, `false`, `0`, `0.0`, an empty
+ *                                string, or empty array).
+ * @param int|null      $priority Optional. Used to specify the order in which the functions associated with a
+ *                                particular action are executed. Valid when it's numeric, including 0.
+ * @param int|null      $args     Optional. The number of arguments the callback accepts.
+ *                                Valid when it's numeric, including 0.
+ *
+ * @return array
+ */
+function _beans_build_action_for_valid_args( $hook = null, $callback = null, $priority = null, $args = null ) {
+	$action = array();
+
+	if ( ! empty( $hook ) ) {
+		$action['hook'] = $hook;
+	}
+
+	if ( ! empty( $callback ) ) {
+		$action['callback'] = $callback;
+	}
+
+	foreach ( array( 'priority', 'args' ) as $arg_name ) {
+		$arg = ${$arg_name};
+		if ( is_numeric( $arg ) ) {
+			$action[ $arg_name ] = (int) $arg;
+		}
+	}
+
+	return $action;
 }
 
 /**

--- a/lib/api/actions/functions.php
+++ b/lib/api/actions/functions.php
@@ -99,7 +99,7 @@ function beans_add_smart_action( $hook, $callback, $priority = 10, $args = 1 ) {
  * The original action can be reset using {@see beans_reset_action()}.
  *
  * @since 1.0.0
- * @since 1.5.0 Made WPCS compliant.
+ * @since 1.5.0 Made WPCS compliant and improved action parameter filtering.
  *
  * @param string        $id       The action's Beans ID, a unique ID tracked within Beans for this action.
  * @param string|null   $hook     Optional. The new action's event name to which the $callback is hooked.
@@ -160,7 +160,7 @@ function beans_modify_action_hook( $id, $hook ) {
 }
 
 /**
- * Modify callback for the given action, i.e. referenced by its Bean's ID.
+ * Modify the callback of the given action, i.e. referenced by its Bean's ID.
  *
  * This function is a shortcut of {@see beans_modify_action()}.
  *
@@ -178,38 +178,39 @@ function beans_modify_action_callback( $id, $callback ) {
 }
 
 /**
- * Modify an action priority.
+ * Modify the priority of the given action, i.e. referenced by its Bean's ID.
  *
  * This function is a shortcut of {@see beans_modify_action()}.
  *
  * @since 1.0.0
+ * @since 1.5.0 Made WPCS compliant.
  *
- * @param string $id       The action ID.
- * @param int    $priority Optional. The new priority. Use NULL to keep the original value.
+ * @param string   $id            The action's Beans ID, a unique ID tracked within Beans for this action.
+ * @param int|null $priority      Optional. The new priority.
+ *                                Use NULL to keep the original value.
  *
- * @return bool Will always return true.
+ * @return bool
  */
 function beans_modify_action_priority( $id, $priority ) {
 	return beans_modify_action( $id, null, null, $priority );
 }
 
 /**
- * Modify an action arguments.
+ * Modify the number of arguments of the given action, i.e. referenced by its Bean's ID.
  *
  * This function is a shortcut of {@see beans_modify_action()}.
  *
  * @since 1.0.0
+ * @since 1.5.0 Made WPCS compliant.
  *
- * @param string $id   The action ID.
- * @param int    $args Optional. The new number of arguments the function accepts. Use NULL to keep the
- *                     original value.
+ * @param string   $id            The action's Beans ID, a unique ID tracked within Beans for this action.
+ * @param int|null $args          Optional. The new number of arguments the $callback accepts.
+ *                                Use NULL to keep the original value.
  *
- * @return bool Will always return true.
+ * @return bool
  */
 function beans_modify_action_arguments( $id, $args ) {
-
 	return beans_modify_action( $id, null, null, null, $args );
-
 }
 
 /**
@@ -521,7 +522,7 @@ function _beans_get_current_action( $id ) {
 }
 
 /**
- * Build the action's array for only the valid given arguments.  Valid arguments are:
+ * Build the action's array for only the valid given arguments.
  *
  * @since 1.5.0
  *

--- a/lib/api/actions/functions.php
+++ b/lib/api/actions/functions.php
@@ -91,7 +91,7 @@ function beans_add_smart_action( $hook, $callback, $priority = 10, $args = 1 ) {
 }
 
 /**
- * Modify an action.
+ * Modify one or more of the arguments for the given action, i.e. referenced by its Bean's ID.
  *
  * This function modifies a registered action using {@see beans_add_action()} or
  * {@see beans_add_smart_action()}. Each optional argument must be set to NULL to keep the original value.
@@ -101,14 +101,14 @@ function beans_add_smart_action( $hook, $callback, $priority = 10, $args = 1 ) {
  * @since 1.0.0
  * @since 1.5.0 Made WPCS compliant.
  *
- * @param string        $id       The action ID.
- * @param string|null   $hook     Optional. The name of the new action to which the $callback is hooked.
+ * @param string        $id       The action's Beans ID, a unique ID for tracked within Beans for this action.
+ * @param string|null   $hook     Optional. The new action's event name to which the $callback is hooked.
  *                                Use NULL to keep the original value.
- * @param callable|null $callback Optional. The name of the new function you wish to be called.
+ * @param callable|null $callback Optional. The new callback (function or method) you wish to be called.
  *                                Use NULL to keep the original value.
  * @param int|null      $priority Optional. The new priority.
  *                                Use NULL to keep the original value.
- * @param int|null      $args     Optional. The new number of arguments the function accept.
+ * @param int|null      $args     Optional. The new number of arguments the $callback accepts.
  *                                Use NULL to keep the original value.
  *
  * @return bool

--- a/lib/api/actions/functions.php
+++ b/lib/api/actions/functions.php
@@ -99,7 +99,7 @@ function beans_add_smart_action( $hook, $callback, $priority = 10, $args = 1 ) {
  * The original action can be reset using {@see beans_reset_action()}.
  *
  * @since 1.0.0
- * @since 1.5.0 Made WPCS compliant and improved action parameter filtering.
+ * @since 1.5.0 Improved action parameter filtering.
  *
  * @param string        $id       The action's Beans ID, a unique ID tracked within Beans for this action.
  * @param string|null   $hook     Optional. The new action's event name to which the $callback is hooked.
@@ -114,7 +114,8 @@ function beans_add_smart_action( $hook, $callback, $priority = 10, $args = 1 ) {
  * @return bool
  */
 function beans_modify_action( $id, $hook = null, $callback = null, $priority = null, $args = null ) {
-	$action = _beans_build_action_for_valid_args( $hook, $callback, $priority, $args );
+	$action = _beans_build_action_array( $hook, $callback, $priority, $args );
+
 	// If no changes were passed in, there's nothing to modify. Bail out.
 	if ( empty( $action ) ) {
 		return false;
@@ -147,7 +148,6 @@ function beans_modify_action( $id, $hook = null, $callback = null, $priority = n
  * This function is a shortcut of {@see beans_modify_action()}.
  *
  * @since 1.0.0
- * @since 1.5.0 Made WPCS compliant.
  *
  * @param string $id   The action's Beans ID, a unique ID tracked within Beans for this action.
  * @param string $hook The new action's event name to which the callback is hooked.
@@ -164,7 +164,6 @@ function beans_modify_action_hook( $id, $hook ) {
  * This function is a shortcut of {@see beans_modify_action()}.
  *
  * @since 1.0.0
- * @since 1.5.0 Made WPCS compliant.
  *
  * @param string   $id       The action's Beans ID, a unique ID tracked within Beans for this action.
  * @param callable $callback The new callback (function or method) you wish to be called.
@@ -181,7 +180,6 @@ function beans_modify_action_callback( $id, $callback ) {
  * This function is a shortcut of {@see beans_modify_action()}.
  *
  * @since 1.0.0
- * @since 1.5.0 Made WPCS compliant.
  *
  * @param string     $id       The action's Beans ID, a unique ID tracked within Beans for this action.
  * @param int|string $priority The new priority.
@@ -198,7 +196,6 @@ function beans_modify_action_priority( $id, $priority ) {
  * This function is a shortcut of {@see beans_modify_action()}.
  *
  * @since 1.0.0
- * @since 1.5.0 Made WPCS compliant.
  *
  * @param string     $id             The action's Beans ID, a unique ID tracked within Beans for this action.
  * @param int|string $number_of_args The new number of arguments the $callback accepts.
@@ -602,7 +599,7 @@ function _beans_is_action_valid( array $action ) {
  *
  * @return array
  */
-function _beans_build_action_for_valid_args( $hook = null, $callback = null, $priority = null, $args = null ) {
+function _beans_build_action_array( $hook = null, $callback = null, $priority = null, $args = null ) {
 	$action = array();
 
 	if ( ! empty( $hook ) ) {
@@ -615,6 +612,7 @@ function _beans_build_action_for_valid_args( $hook = null, $callback = null, $pr
 
 	foreach ( array( 'priority', 'args' ) as $arg_name ) {
 		$arg = ${$arg_name};
+
 		if ( is_numeric( $arg ) ) {
 			$action[ $arg_name ] = (int) $arg;
 		}

--- a/lib/api/actions/functions.php
+++ b/lib/api/actions/functions.php
@@ -149,9 +149,8 @@ function beans_modify_action( $id, $hook = null, $callback = null, $priority = n
  * @since 1.0.0
  * @since 1.5.0 Made WPCS compliant.
  *
- * @param string      $id         The action's Beans ID, a unique ID tracked within Beans for this action.
- * @param string|null $hook       Optional. The new action's event name to which the $callback is hooked.
- *                                Use NULL to keep the original value.
+ * @param string $id   The action's Beans ID, a unique ID tracked within Beans for this action.
+ * @param string $hook The new action's event name to which the callback is hooked.
  *
  * @return bool
  */
@@ -167,11 +166,10 @@ function beans_modify_action_hook( $id, $hook ) {
  * @since 1.0.0
  * @since 1.5.0 Made WPCS compliant.
  *
- * @param string        $id       The action's Beans ID, a unique ID tracked within Beans for this action.
- * @param callable|null $callback Optional. The new callback (function or method) you wish to be called.
- *                                Use NULL to keep the original value.
+ * @param string   $id       The action's Beans ID, a unique ID tracked within Beans for this action.
+ * @param callable $callback The new callback (function or method) you wish to be called.
  *
- * @return bool Will always return true.
+ * @return bool
  */
 function beans_modify_action_callback( $id, $callback ) {
 	return beans_modify_action( $id, null, $callback );
@@ -185,9 +183,8 @@ function beans_modify_action_callback( $id, $callback ) {
  * @since 1.0.0
  * @since 1.5.0 Made WPCS compliant.
  *
- * @param string   $id            The action's Beans ID, a unique ID tracked within Beans for this action.
- * @param int|null $priority      Optional. The new priority.
- *                                Use NULL to keep the original value.
+ * @param string     $id       The action's Beans ID, a unique ID tracked within Beans for this action.
+ * @param int|string $priority The new priority.
  *
  * @return bool
  */
@@ -203,14 +200,13 @@ function beans_modify_action_priority( $id, $priority ) {
  * @since 1.0.0
  * @since 1.5.0 Made WPCS compliant.
  *
- * @param string   $id            The action's Beans ID, a unique ID tracked within Beans for this action.
- * @param int|null $args          Optional. The new number of arguments the $callback accepts.
- *                                Use NULL to keep the original value.
+ * @param string     $id             The action's Beans ID, a unique ID tracked within Beans for this action.
+ * @param int|string $number_of_args The new number of arguments the $callback accepts.
  *
  * @return bool
  */
-function beans_modify_action_arguments( $id, $args ) {
-	return beans_modify_action( $id, null, null, null, $args );
+function beans_modify_action_arguments( $id, $number_of_args ) {
+	return beans_modify_action( $id, null, null, null, $number_of_args );
 }
 
 /**

--- a/lib/api/actions/functions.php
+++ b/lib/api/actions/functions.php
@@ -101,7 +101,7 @@ function beans_add_smart_action( $hook, $callback, $priority = 10, $args = 1 ) {
  * @since 1.0.0
  * @since 1.5.0 Made WPCS compliant.
  *
- * @param string        $id       The action's Beans ID, a unique ID for tracked within Beans for this action.
+ * @param string        $id       The action's Beans ID, a unique ID tracked within Beans for this action.
  * @param string|null   $hook     Optional. The new action's event name to which the $callback is hooked.
  *                                Use NULL to keep the original value.
  * @param callable|null $callback Optional. The new callback (function or method) you wish to be called.

--- a/lib/api/actions/functions.php
+++ b/lib/api/actions/functions.php
@@ -143,22 +143,21 @@ function beans_modify_action( $id, $hook = null, $callback = null, $priority = n
 }
 
 /**
- * Modify an action hook.
+ * Modify one or more of the arguments for the given action, i.e. referenced by its Bean's ID.
  *
  * This function is a shortcut of {@see beans_modify_action()}.
  *
  * @since 1.0.0
+ * @since 1.5.0 Made WPCS compliant.
  *
- * @param string $id   The action ID.
- * @param string $hook Optional. The name of the new action to which the $callback is hooked. Use NULL to
- *                     keep the original value.
+ * @param string      $id         The action's Beans ID, a unique ID tracked within Beans for this action.
+ * @param string|null $hook       Optional. The new action's event name to which the $callback is hooked.
+ *                                Use NULL to keep the original value.
  *
- * @return bool Will always return true.
+ * @return bool
  */
 function beans_modify_action_hook( $id, $hook ) {
-
 	return beans_modify_action( $id, $hook );
-
 }
 
 /**

--- a/lib/api/actions/functions.php
+++ b/lib/api/actions/functions.php
@@ -114,6 +114,17 @@ function beans_add_smart_action( $hook, $callback, $priority = 10, $args = 1 ) {
  * @return bool
  */
 function beans_modify_action( $id, $hook = null, $callback = null, $priority = null, $args = null ) {
+	$action = array_filter( array(
+		'hook'     => $hook,
+		'callback' => $callback,
+		'priority' => $priority,
+		'args'     => $args,
+	) );
+	// If no changes were passed in, there's nothing to modify. Bail out.
+	if ( empty( $action ) ) {
+		return false;
+	}
+
 	$current_action     = _beans_get_current_action( $id );
 	$has_current_action = ! empty( $current_action ) && is_array( $current_action );
 
@@ -121,13 +132,6 @@ function beans_modify_action( $id, $hook = null, $callback = null, $priority = n
 	if ( $has_current_action ) {
 		remove_action( $current_action['hook'], $current_action['callback'], $current_action['priority'], $current_action['args'] );
 	}
-
-	$action = array_filter( array(
-		'hook'     => $hook,
-		'callback' => $callback,
-		'priority' => $priority,
-		'args'     => $args,
-	) );
 
 	// Merge the modified parameters and register with Beans.
 	$action = _beans_merge_action( $id, $action, 'modified' );

--- a/tests/phpunit/integration/api/actions/beansModifyAction.php
+++ b/tests/phpunit/integration/api/actions/beansModifyAction.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * Tests for beans_modify_action()
+ *
+ * @package Beans\Framework\Tests\Integration\API\Actions
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Integration\API\Actions;
+
+use WP_UnitTestCase;
+
+/**
+ * Class Tests_BeansModifyAction
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ * @group   unit-integration
+ * @group   api
+ */
+class Tests_BeansModifyAction extends WP_UnitTestCase {
+
+	/**
+	 * Reset the test fixture.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		global $_beans_registered_actions;
+		$_beans_registered_actions = array(
+			'added'    => array(),
+			'modified' => array(),
+			'removed'  => array(),
+			'replaced' => array(),
+		);
+	}
+
+	/**
+	 * Test beans_modify_action() should return false when the ID is not registered.
+	 */
+	public function test_should_return_false_when_id_not_registered() {
+		$this->assertFalse( beans_modify_action( 'foo' ) );
+	}
+
+	/**
+	 * Test beans_modify_action() should register with Beans as modified, but not with WordPress.
+	 */
+	public function test_should_register_with_beans_as_modified_but_not_with_wp() {
+		$action = array(
+			'hook'     => 'foo_hook',
+			'callback' => 'my_callback',
+		);
+
+		$this->check_not_added( 'foo', $action['hook'] );
+
+		$this->assertFalse( beans_modify_action( 'foo', $action['hook'], $action['callback'] ) );
+
+		// Now check that it was not registered in WordPress.
+		$this->assertFalse( has_action( $action['hook'] ) );
+		global $wp_filter;
+		$this->assertFalse( array_key_exists( $action['hook'], $wp_filter ) );
+
+		// Now check in Beans.
+		$this->assertEquals( $action, _beans_get_action( 'foo', 'modified' ) );
+	}
+
+	/**
+	 * Test beans_modify_action() should modify the registered action's callback.
+	 */
+	public function test_should_modify_the_action_callback() {
+		$action          = $this->setup_original_action();
+		$modified_action = array(
+			'callback' => 'my_callback',
+		);
+		$this->assertTrue( beans_modify_action( 'beans', null, $modified_action['callback'] ) );
+		$this->assertEquals( $modified_action, _beans_get_action( 'beans', 'modified' ) );
+		$this->assertTrue( has_action( $action['hook'] ) );
+		$this->check_parameters_registered_in_wp( array_merge( $action, $modified_action ) );
+	}
+
+	/**
+	 * Test beans_modify_action() should modify the registered action's priority level.
+	 */
+	public function test_should_modify_the_action_priority() {
+		$action          = $this->setup_original_action();
+		$modified_action = array(
+			'priority' => 20,
+		);
+		$this->assertTrue( beans_modify_action( 'beans', null, null, $modified_action['priority'] ) );
+		$this->assertEquals( $modified_action, _beans_get_action( 'beans', 'modified' ) );
+		$this->assertTrue( has_action( $action['hook'] ) );
+		$this->check_parameters_registered_in_wp( array_merge( $action, $modified_action ) );
+	}
+
+	/**
+	 * Test beans_modify_action() should modify the registered action's number of arguments.
+	 */
+	public function test_should_modify_the_action_args() {
+		$action          = $this->setup_original_action();
+		$modified_action = array(
+			'args' => 2,
+		);
+		$this->assertTrue( beans_modify_action( 'beans', null, null, null, $modified_action['args'] ) );
+		$this->assertEquals( $modified_action, _beans_get_action( 'beans', 'modified' ) );
+		$this->assertTrue( has_action( $action['hook'] ) );
+		$this->check_parameters_registered_in_wp( array_merge( $action, $modified_action ) );
+	}
+
+	/**
+	 * Check that it is not registered first.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param string $id   The ID to check.
+	 * @param string $hook The hook (event name) to check.
+	 *
+	 * @return void
+	 */
+	protected function check_not_added( $id, $hook ) {
+		$this->assertFalse( _beans_get_action( $id, 'added' ) );
+		$this->assertFalse( has_action( $hook ) );
+	}
+
+	/**
+	 * Check that the right parameters are registered in WordPress.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param array $action The action that should be registered.
+	 *
+	 * @return void
+	 */
+	protected function check_parameters_registered_in_wp( array $action ) {
+		global $wp_filter;
+		$registered_action = $wp_filter[ $action['hook'] ]->callbacks[ $action['priority'] ];
+
+		$this->assertArrayHasKey( $action['callback'], $registered_action );
+		$this->assertEquals( $action['callback'], $registered_action[ $action['callback'] ]['function'] );
+		$this->assertEquals( $action['args'], $registered_action[ $action['callback'] ]['accepted_args'] );
+
+		// Then remove the action.
+		remove_action( $action['hook'], $action['callback'], $action['priority'] );
+	}
+
+	/**
+	 * Setup the original action.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @return array
+	 */
+	protected function setup_original_action() {
+		$action = array(
+			'hook'     => 'beans_hook',
+			'callback' => 'callback_beans',
+			'priority' => 10,
+			'args'     => 1,
+		);
+
+		$this->check_not_added( 'beans', $action['hook'] );
+
+		// Add the original action to get us rolling.
+		beans_add_action( 'beans', $action['hook'], $action['callback'] );
+		$this->assertTrue( has_action( $action['hook'] ) );
+		$this->check_parameters_registered_in_wp( $action );
+
+		return $action;
+	}
+}

--- a/tests/phpunit/integration/api/actions/beansModifyAction.php
+++ b/tests/phpunit/integration/api/actions/beansModifyAction.php
@@ -9,7 +9,9 @@
 
 namespace Beans\Framework\Tests\Integration\API\Actions;
 
-use WP_UnitTestCase;
+use Beans\Framework\Tests\Integration\API\Actions\Includes\Actions_Test_Case;
+
+require_once __DIR__ . '/includes/class-actions-test-case.php';
 
 /**
  * Class Tests_BeansModifyAction
@@ -18,7 +20,7 @@ use WP_UnitTestCase;
  * @group   unit-integration
  * @group   api
  */
-class Tests_BeansModifyAction extends WP_UnitTestCase {
+class Tests_BeansModifyAction extends Actions_Test_Case {
 
 	/**
 	 * Reset the test fixture.
@@ -116,68 +118,5 @@ class Tests_BeansModifyAction extends WP_UnitTestCase {
 		$this->assertEquals( $modified_action, _beans_get_action( 'beans', 'modified' ) );
 		$this->assertTrue( has_action( $action['hook'] ) );
 		$this->check_parameters_registered_in_wp( array_merge( $action, $modified_action ) );
-	}
-
-	/**
-	 * Check that it is not registered first.
-	 *
-	 * @since 1.5.0
-	 *
-	 * @param string $id   The ID to check.
-	 * @param string $hook The hook (event name) to check.
-	 *
-	 * @return void
-	 */
-	protected function check_not_added( $id, $hook ) {
-		$this->assertFalse( _beans_get_action( $id, 'added' ) );
-		$this->assertFalse( has_action( $hook ) );
-	}
-
-	/**
-	 * Check that the right parameters are registered in WordPress.
-	 *
-	 * @since 1.5.0
-	 *
-	 * @param array $action The action that should be registered.
-	 *
-	 * @return void
-	 */
-	protected function check_parameters_registered_in_wp( array $action ) {
-		global $wp_filter;
-		$registered_action = $wp_filter[ $action['hook'] ]->callbacks[ $action['priority'] ];
-
-		$this->assertArrayHasKey( $action['callback'], $registered_action );
-		$this->assertEquals( $action['callback'], $registered_action[ $action['callback'] ]['function'] );
-		$this->assertEquals( $action['args'], $registered_action[ $action['callback'] ]['accepted_args'] );
-
-		// Then remove the action.
-		remove_action( $action['hook'], $action['callback'], $action['priority'] );
-	}
-
-	/**
-	 * Setup the original action.
-	 *
-	 * @since 1.5.0
-	 *
-	 * @param string $id Optional. Beans ID to register. Default is 'foo'.
-	 *
-	 * @return array
-	 */
-	protected function setup_original_action( $id = 'foo' ) {
-		$action = array(
-			'hook'     => "{$id}_hook",
-			'callback' => "callback_{$id}",
-			'priority' => 10,
-			'args'     => 1,
-		);
-
-		$this->check_not_added( $id, $action['hook'] );
-
-		// Add the original action to get us rolling.
-		beans_add_action( $id, $action['hook'], $action['callback'] );
-		$this->assertTrue( has_action( $action['hook'] ) );
-		$this->check_parameters_registered_in_wp( $action );
-
-		return $action;
 	}
 }

--- a/tests/phpunit/integration/api/actions/beansModifyAction.php
+++ b/tests/phpunit/integration/api/actions/beansModifyAction.php
@@ -43,6 +43,18 @@ class Tests_BeansModifyAction extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test beans_modify_action_callback() should return false when there's nothing to modify,
+	 * i.e. no arguments passed.
+	 */
+	public function test_should_return_false_when_nothing_to_modify() {
+		$this->setup_original_action();
+		$this->assertFalse( beans_modify_action( 'foo' ) );
+
+		$this->setup_original_action( 'beans' );
+		$this->assertFalse( beans_modify_action( 'beans' ) );
+	}
+
+	/**
 	 * Test beans_modify_action() should register with Beans as modified, but not with WordPress.
 	 */
 	public function test_should_register_with_beans_as_modified_but_not_with_wp() {
@@ -68,7 +80,7 @@ class Tests_BeansModifyAction extends WP_UnitTestCase {
 	 * Test beans_modify_action() should modify the registered action's callback.
 	 */
 	public function test_should_modify_the_action_callback() {
-		$action          = $this->setup_original_action();
+		$action          = $this->setup_original_action( 'beans' );
 		$modified_action = array(
 			'callback' => 'my_callback',
 		);
@@ -82,7 +94,7 @@ class Tests_BeansModifyAction extends WP_UnitTestCase {
 	 * Test beans_modify_action() should modify the registered action's priority level.
 	 */
 	public function test_should_modify_the_action_priority() {
-		$action          = $this->setup_original_action();
+		$action          = $this->setup_original_action( 'beans' );
 		$modified_action = array(
 			'priority' => 20,
 		);
@@ -96,7 +108,7 @@ class Tests_BeansModifyAction extends WP_UnitTestCase {
 	 * Test beans_modify_action() should modify the registered action's number of arguments.
 	 */
 	public function test_should_modify_the_action_args() {
-		$action          = $this->setup_original_action();
+		$action          = $this->setup_original_action( 'beans' );
 		$modified_action = array(
 			'args' => 2,
 		);
@@ -147,20 +159,22 @@ class Tests_BeansModifyAction extends WP_UnitTestCase {
 	 *
 	 * @since 1.5.0
 	 *
+	 * @param string $id Optional. Beans ID to register. Default is 'foo'.
+	 *
 	 * @return array
 	 */
-	protected function setup_original_action() {
+	protected function setup_original_action( $id = 'foo' ) {
 		$action = array(
-			'hook'     => 'beans_hook',
-			'callback' => 'callback_beans',
+			'hook'     => "{$id}_hook",
+			'callback' => "callback_{$id}",
 			'priority' => 10,
 			'args'     => 1,
 		);
 
-		$this->check_not_added( 'beans', $action['hook'] );
+		$this->check_not_added( $id, $action['hook'] );
 
 		// Add the original action to get us rolling.
-		beans_add_action( 'beans', $action['hook'], $action['callback'] );
+		beans_add_action( $id, $action['hook'], $action['callback'] );
 		$this->assertTrue( has_action( $action['hook'] ) );
 		$this->check_parameters_registered_in_wp( $action );
 

--- a/tests/phpunit/integration/api/actions/beansModifyAction.php
+++ b/tests/phpunit/integration/api/actions/beansModifyAction.php
@@ -16,26 +16,11 @@ require_once __DIR__ . '/includes/class-actions-test-case.php';
 /**
  * Class Tests_BeansModifyAction
  *
- * @package Beans\Framework\Tests\Unit\API\Actions
+ * @package Beans\Framework\Tests\Integration\API\Actions
  * @group   unit-integration
  * @group   api
  */
 class Tests_BeansModifyAction extends Actions_Test_Case {
-
-	/**
-	 * Reset the test fixture.
-	 */
-	public function tearDown() {
-		parent::tearDown();
-
-		global $_beans_registered_actions;
-		$_beans_registered_actions = array(
-			'added'    => array(),
-			'modified' => array(),
-			'removed'  => array(),
-			'replaced' => array(),
-		);
-	}
 
 	/**
 	 * Test beans_modify_action() should return false when the ID is not registered.

--- a/tests/phpunit/integration/api/actions/beansModifyActionArguments.php
+++ b/tests/phpunit/integration/api/actions/beansModifyActionArguments.php
@@ -9,7 +9,9 @@
 
 namespace Beans\Framework\Tests\Integration\API\Actions;
 
-use WP_UnitTestCase;
+use Beans\Framework\Tests\Integration\API\Actions\Includes\Actions_Test_Case;
+
+require_once __DIR__ . '/includes/class-actions-test-case.php';
 
 /**
  * Class Tests_BeansModifyActionArguments
@@ -18,22 +20,7 @@ use WP_UnitTestCase;
  * @group   unit-integration
  * @group   api
  */
-class Tests_BeansModifyActionArguments extends WP_UnitTestCase {
-
-	/**
-	 * Reset the test fixture.
-	 */
-	public function tearDown() {
-		parent::tearDown();
-
-		global $_beans_registered_actions;
-		$_beans_registered_actions = array(
-			'added'    => array(),
-			'modified' => array(),
-			'removed'  => array(),
-			'replaced' => array(),
-		);
-	}
+class Tests_BeansModifyActionArguments extends Actions_Test_Case {
 
 	/**
 	 * Test beans_modify_action_arguments() should return false when the ID is not registered.
@@ -103,71 +90,5 @@ class Tests_BeansModifyActionArguments extends WP_UnitTestCase {
 		$this->assertEquals( $modified_action, _beans_get_action( 'beans', 'modified' ) );
 		$this->assertTrue( has_action( $action['hook'] ) );
 		$this->check_parameters_registered_in_wp( array_merge( $action, $modified_action ) );
-	}
-
-	/**
-	 * Check that it is not registered first.
-	 *
-	 * @since 1.5.0
-	 *
-	 * @param string $id   The ID to check.
-	 * @param string $hook The hook (event name) to check.
-	 *
-	 * @return void
-	 */
-	protected function check_not_added( $id, $hook ) {
-		$this->assertFalse( _beans_get_action( $id, 'added' ) );
-		$this->assertFalse( has_action( $hook ) );
-	}
-
-	/**
-	 * Check that the right parameters are registered in WordPress.
-	 *
-	 * @since 1.5.0
-	 *
-	 * @param array $action        The action that should be registered.
-	 * @param bool  $remove_action When true, it removes the action automatically to clean up this test.
-	 *
-	 * @return void
-	 */
-	protected function check_parameters_registered_in_wp( array $action, $remove_action = true ) {
-		global $wp_filter;
-		$registered_action = $wp_filter[ $action['hook'] ]->callbacks[ $action['priority'] ];
-
-		$this->assertArrayHasKey( $action['callback'], $registered_action );
-		$this->assertEquals( $action['callback'], $registered_action[ $action['callback'] ]['function'] );
-		$this->assertEquals( $action['args'], $registered_action[ $action['callback'] ]['accepted_args'] );
-
-		// Then remove the action.
-		if ( $remove_action ) {
-			remove_action( $action['hook'], $action['callback'], $action['priority'] );
-		}
-	}
-
-	/**
-	 * Setup the original action.
-	 *
-	 * @since 1.5.0
-	 *
-	 * @param string $id Optional. Beans ID to register. Default is 'foo'.
-	 *
-	 * @return array
-	 */
-	protected function setup_original_action( $id = 'foo' ) {
-		$action = array(
-			'hook'     => "{$id}_hook",
-			'callback' => "callback_{$id}",
-			'priority' => 10,
-			'args'     => 1,
-		);
-
-		$this->check_not_added( $id, $action['hook'] );
-
-		// Add the original action to get us rolling.
-		beans_add_action( $id, $action['hook'], $action['callback'] );
-		$this->assertTrue( has_action( $action['hook'] ) );
-		$this->check_parameters_registered_in_wp( $action, false );
-
-		return $action;
 	}
 }

--- a/tests/phpunit/integration/api/actions/beansModifyActionArguments.php
+++ b/tests/phpunit/integration/api/actions/beansModifyActionArguments.php
@@ -16,7 +16,7 @@ require_once __DIR__ . '/includes/class-actions-test-case.php';
 /**
  * Class Tests_BeansModifyActionArguments
  *
- * @package Beans\Framework\Tests\Unit\API\Actions
+ * @package Beans\Framework\Tests\Integration\API\Actions
  * @group   unit-integration
  * @group   api
  */
@@ -32,6 +32,7 @@ class Tests_BeansModifyActionArguments extends Actions_Test_Case {
 			'baz'   => 1,
 			'beans' => '3',
 		);
+
 		foreach ( $ids as $id => $number_of_args ) {
 			$this->assertFalse( beans_modify_action_arguments( $id, $number_of_args ) );
 		}
@@ -47,6 +48,7 @@ class Tests_BeansModifyActionArguments extends Actions_Test_Case {
 			'baz'   => false,
 			'beans' => '',
 		);
+
 		foreach ( $ids as $id => $number_of_args ) {
 			$action = $this->setup_original_action( $id, true );
 
@@ -68,6 +70,7 @@ class Tests_BeansModifyActionArguments extends Actions_Test_Case {
 			'baz'   => '0',
 			'beans' => '0.0',
 		);
+
 		foreach ( $ids as $id => $number_of_args ) {
 			$action = $this->setup_original_action( $id );
 			$this->assertTrue( beans_modify_action_arguments( $id, $number_of_args ) );

--- a/tests/phpunit/integration/api/actions/beansModifyActionArguments.php
+++ b/tests/phpunit/integration/api/actions/beansModifyActionArguments.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Tests for beans_modify_action_arguments()
+ *
+ * @package Beans\Framework\Tests\Integration\API\Actions
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Integration\API\Actions;
+
+use WP_UnitTestCase;
+
+/**
+ * Class Tests_BeansModifyActionArguments
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ * @group   unit-integration
+ * @group   api
+ */
+class Tests_BeansModifyActionArguments extends WP_UnitTestCase {
+
+	/**
+	 * Reset the test fixture.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		global $_beans_registered_actions;
+		$_beans_registered_actions = array(
+			'added'    => array(),
+			'modified' => array(),
+			'removed'  => array(),
+			'replaced' => array(),
+		);
+	}
+
+	/**
+	 * Test beans_modify_action_arguments() should return false when the ID is not registered.
+	 */
+	public function test_should_return_false_when_id_not_registered() {
+		$ids = array(
+			'foo'   => null,
+			'bar'   => 0,
+			'baz'   => 1,
+			'beans' => '3',
+		);
+		foreach ( $ids as $id => $number_of_args ) {
+			$this->assertFalse( beans_modify_action_arguments( $id, $number_of_args ) );
+		}
+	}
+
+	/**
+	 * Test beans_modify_action_arguments() should return false when new args is a non-integer value.
+	 */
+	public function test_should_return_false_when_args_is_non_integer() {
+		$ids = array(
+			'foo'   => null,
+			'bar'   => array( 10 ),
+			'baz'   => false,
+			'beans' => '',
+		);
+		foreach ( $ids as $id => $number_of_args ) {
+			$action = $this->setup_original_action( $id, true );
+
+			$this->assertFalse( beans_modify_action_arguments( $id, $number_of_args ) );
+			$this->assertTrue( has_action( $action['hook'] ) );
+
+			// Check that the parameters did not change.
+			$this->check_parameters_registered_in_wp( $action );
+		}
+	}
+
+	/**
+	 * Test beans_modify_action_arguments() should modify the action's "args" when the new one is zero.
+	 */
+	public function test_should_modify_action_when_args_is_zero() {
+		$ids = array(
+			'foo'   => 0,
+			'bar'   => 0.0,
+			'baz'   => '0',
+			'beans' => '0.0',
+		);
+		foreach ( $ids as $id => $number_of_args ) {
+			$action = $this->setup_original_action( $id );
+			$this->assertTrue( beans_modify_action_arguments( $id, $number_of_args ) );
+
+			// Manually change the original to the new one.  Then test that it did change in WordPress.
+			$action['args'] = (int) $number_of_args;
+			$this->check_parameters_registered_in_wp( $action );
+		}
+	}
+
+	/**
+	 * Test beans_modify_action_arguments() should modify the registered action's args.
+	 */
+	public function test_should_modify_the_action_args() {
+		$action          = $this->setup_original_action( 'beans' );
+		$modified_action = array(
+			'args' => 3,
+		);
+		$this->assertTrue( beans_modify_action_arguments( 'beans', $modified_action['args'] ) );
+		$this->assertEquals( $modified_action, _beans_get_action( 'beans', 'modified' ) );
+		$this->assertTrue( has_action( $action['hook'] ) );
+		$this->check_parameters_registered_in_wp( array_merge( $action, $modified_action ) );
+	}
+
+	/**
+	 * Check that it is not registered first.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param string $id   The ID to check.
+	 * @param string $hook The hook (event name) to check.
+	 *
+	 * @return void
+	 */
+	protected function check_not_added( $id, $hook ) {
+		$this->assertFalse( _beans_get_action( $id, 'added' ) );
+		$this->assertFalse( has_action( $hook ) );
+	}
+
+	/**
+	 * Check that the right parameters are registered in WordPress.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param array $action        The action that should be registered.
+	 * @param bool  $remove_action When true, it removes the action automatically to clean up this test.
+	 *
+	 * @return void
+	 */
+	protected function check_parameters_registered_in_wp( array $action, $remove_action = true ) {
+		global $wp_filter;
+		$registered_action = $wp_filter[ $action['hook'] ]->callbacks[ $action['priority'] ];
+
+		$this->assertArrayHasKey( $action['callback'], $registered_action );
+		$this->assertEquals( $action['callback'], $registered_action[ $action['callback'] ]['function'] );
+		$this->assertEquals( $action['args'], $registered_action[ $action['callback'] ]['accepted_args'] );
+
+		// Then remove the action.
+		if ( $remove_action ) {
+			remove_action( $action['hook'], $action['callback'], $action['priority'] );
+		}
+	}
+
+	/**
+	 * Setup the original action.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param string $id Optional. Beans ID to register. Default is 'foo'.
+	 *
+	 * @return array
+	 */
+	protected function setup_original_action( $id = 'foo' ) {
+		$action = array(
+			'hook'     => "{$id}_hook",
+			'callback' => "callback_{$id}",
+			'priority' => 10,
+			'args'     => 1,
+		);
+
+		$this->check_not_added( $id, $action['hook'] );
+
+		// Add the original action to get us rolling.
+		beans_add_action( $id, $action['hook'], $action['callback'] );
+		$this->assertTrue( has_action( $action['hook'] ) );
+		$this->check_parameters_registered_in_wp( $action, false );
+
+		return $action;
+	}
+}

--- a/tests/phpunit/integration/api/actions/beansModifyActionCallback.php
+++ b/tests/phpunit/integration/api/actions/beansModifyActionCallback.php
@@ -9,7 +9,9 @@
 
 namespace Beans\Framework\Tests\Integration\API\Actions;
 
-use WP_UnitTestCase;
+use Beans\Framework\Tests\Integration\API\Actions\Includes\Actions_Test_Case;
+
+require_once __DIR__ . '/includes/class-actions-test-case.php';
 
 /**
  * Class Tests_BeansModifyActionCallback
@@ -18,22 +20,7 @@ use WP_UnitTestCase;
  * @group   unit-integration
  * @group   api
  */
-class Tests_BeansModifyActionCallback extends WP_UnitTestCase {
-
-	/**
-	 * Reset the test fixture.
-	 */
-	public function tearDown() {
-		parent::tearDown();
-
-		global $_beans_registered_actions;
-		$_beans_registered_actions = array(
-			'added'    => array(),
-			'modified' => array(),
-			'removed'  => array(),
-			'replaced' => array(),
-		);
-	}
+class Tests_BeansModifyActionCallback extends Actions_Test_Case {
 
 	/**
 	 * Test beans_modify_action_callback() should return false when the ID is not registered.
@@ -66,68 +53,5 @@ class Tests_BeansModifyActionCallback extends WP_UnitTestCase {
 		$this->assertEquals( $modified_action, _beans_get_action( 'beans', 'modified' ) );
 		$this->assertTrue( has_action( $action['hook'] ) );
 		$this->check_parameters_registered_in_wp( array_merge( $action, $modified_action ) );
-	}
-
-	/**
-	 * Check that it is not registered first.
-	 *
-	 * @since 1.5.0
-	 *
-	 * @param string $id   The ID to check.
-	 * @param string $hook The hook (event name) to check.
-	 *
-	 * @return void
-	 */
-	protected function check_not_added( $id, $hook ) {
-		$this->assertFalse( _beans_get_action( $id, 'added' ) );
-		$this->assertFalse( has_action( $hook ) );
-	}
-
-	/**
-	 * Check that the right parameters are registered in WordPress.
-	 *
-	 * @since 1.5.0
-	 *
-	 * @param array $action The action that should be registered.
-	 *
-	 * @return void
-	 */
-	protected function check_parameters_registered_in_wp( array $action ) {
-		global $wp_filter;
-		$registered_action = $wp_filter[ $action['hook'] ]->callbacks[ $action['priority'] ];
-
-		$this->assertArrayHasKey( $action['callback'], $registered_action );
-		$this->assertEquals( $action['callback'], $registered_action[ $action['callback'] ]['function'] );
-		$this->assertEquals( $action['args'], $registered_action[ $action['callback'] ]['accepted_args'] );
-
-		// Then remove the action.
-		remove_action( $action['hook'], $action['callback'], $action['priority'] );
-	}
-
-	/**
-	 * Setup the original action.
-	 *
-	 * @since 1.5.0
-	 *
-	 * @param string $id Optional. Beans ID to register. Default is 'foo'.
-	 *
-	 * @return array
-	 */
-	protected function setup_original_action( $id = 'foo' ) {
-		$action = array(
-			'hook'     => "{$id}_hook",
-			'callback' => "callback_{$id}",
-			'priority' => 10,
-			'args'     => 1,
-		);
-
-		$this->check_not_added( $id, $action['hook'] );
-
-		// Add the original action to get us rolling.
-		beans_add_action( $id, $action['hook'], $action['callback'] );
-		$this->assertTrue( has_action( $action['hook'] ) );
-		$this->check_parameters_registered_in_wp( $action );
-
-		return $action;
 	}
 }

--- a/tests/phpunit/integration/api/actions/beansModifyActionCallback.php
+++ b/tests/phpunit/integration/api/actions/beansModifyActionCallback.php
@@ -36,6 +36,14 @@ class Tests_BeansModifyActionCallback extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test beans_modify_action_callback() should return false when the ID is not registered.
+	 */
+	public function test_should_return_false_when_id_not_registered() {
+		$this->assertFalse( beans_modify_action_callback( 'foo', null ) );
+		$this->assertFalse( beans_modify_action_callback( 'foo', 'my_new_callback' ) );
+	}
+
+	/**
 	 * Test beans_modify_action_callback() should return false when null is the new callback.
 	 */
 	public function test_should_return_false_when_null_is_new_callback() {
@@ -107,13 +115,13 @@ class Tests_BeansModifyActionCallback extends WP_UnitTestCase {
 	 */
 	protected function setup_original_action( $id = 'foo' ) {
 		$action = array(
-			'hook'     => 'beans_hook',
-			'callback' => 'callback_beans',
+			'hook'     => "{$id}_hook",
+			'callback' => "callback_{$id}",
 			'priority' => 10,
 			'args'     => 1,
 		);
 
-		$this->check_not_added( 'beans', $action['hook'] );
+		$this->check_not_added( $id, $action['hook'] );
 
 		// Add the original action to get us rolling.
 		beans_add_action( $id, $action['hook'], $action['callback'] );

--- a/tests/phpunit/integration/api/actions/beansModifyActionCallback.php
+++ b/tests/phpunit/integration/api/actions/beansModifyActionCallback.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Tests for beans_modify_action_callback()
+ *
+ * @package Beans\Framework\Tests\Integration\API\Actions
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Integration\API\Actions;
+
+use WP_UnitTestCase;
+
+/**
+ * Class Tests_BeansModifyActionCallback
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ * @group   unit-integration
+ * @group   api
+ */
+class Tests_BeansModifyActionCallback extends WP_UnitTestCase {
+
+	/**
+	 * Reset the test fixture.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		global $_beans_registered_actions;
+		$_beans_registered_actions = array(
+			'added'    => array(),
+			'modified' => array(),
+			'removed'  => array(),
+			'replaced' => array(),
+		);
+	}
+
+	/**
+	 * Test beans_modify_action_callback() should return false when null is the new callback.
+	 */
+	public function test_should_return_false_when_null_is_new_callback() {
+		$this->setup_original_action();
+		$this->assertFalse( beans_modify_action_callback( 'foo', null ) );
+
+		$this->setup_original_action( 'beans' );
+		$this->assertFalse( beans_modify_action_callback( 'beans', null ) );
+	}
+
+	/**
+	 * Test beans_modify_action_callback() should modify the registered action's callback.
+	 */
+	public function test_should_modify_the_action_callback() {
+		$action          = $this->setup_original_action( 'beans' );
+		$modified_action = array(
+			'callback' => 'my_new_callback',
+		);
+		$this->assertTrue( beans_modify_action_callback( 'beans', $modified_action['callback'] ) );
+		$this->assertEquals( $modified_action, _beans_get_action( 'beans', 'modified' ) );
+		$this->assertTrue( has_action( $action['hook'] ) );
+		$this->check_parameters_registered_in_wp( array_merge( $action, $modified_action ) );
+	}
+
+	/**
+	 * Check that it is not registered first.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param string $id   The ID to check.
+	 * @param string $hook The hook (event name) to check.
+	 *
+	 * @return void
+	 */
+	protected function check_not_added( $id, $hook ) {
+		$this->assertFalse( _beans_get_action( $id, 'added' ) );
+		$this->assertFalse( has_action( $hook ) );
+	}
+
+	/**
+	 * Check that the right parameters are registered in WordPress.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param array $action The action that should be registered.
+	 *
+	 * @return void
+	 */
+	protected function check_parameters_registered_in_wp( array $action ) {
+		global $wp_filter;
+		$registered_action = $wp_filter[ $action['hook'] ]->callbacks[ $action['priority'] ];
+
+		$this->assertArrayHasKey( $action['callback'], $registered_action );
+		$this->assertEquals( $action['callback'], $registered_action[ $action['callback'] ]['function'] );
+		$this->assertEquals( $action['args'], $registered_action[ $action['callback'] ]['accepted_args'] );
+
+		// Then remove the action.
+		remove_action( $action['hook'], $action['callback'], $action['priority'] );
+	}
+
+	/**
+	 * Setup the original action.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param string $id Optional. Beans ID to register. Default is 'foo'.
+	 *
+	 * @return array
+	 */
+	protected function setup_original_action( $id = 'foo' ) {
+		$action = array(
+			'hook'     => 'beans_hook',
+			'callback' => 'callback_beans',
+			'priority' => 10,
+			'args'     => 1,
+		);
+
+		$this->check_not_added( 'beans', $action['hook'] );
+
+		// Add the original action to get us rolling.
+		beans_add_action( $id, $action['hook'], $action['callback'] );
+		$this->assertTrue( has_action( $action['hook'] ) );
+		$this->check_parameters_registered_in_wp( $action );
+
+		return $action;
+	}
+}

--- a/tests/phpunit/integration/api/actions/beansModifyActionCallback.php
+++ b/tests/phpunit/integration/api/actions/beansModifyActionCallback.php
@@ -31,9 +31,9 @@ class Tests_BeansModifyActionCallback extends Actions_Test_Case {
 	}
 
 	/**
-	 * Test beans_modify_action_callback() should return false when null is the new callback.
+	 * Test beans_modify_action_callback() should return false when the new callback is null.
 	 */
-	public function test_should_return_false_when_null_is_new_callback() {
+	public function test_should_return_false_when_new_callback_is_null() {
 		$this->setup_original_action();
 		$this->assertFalse( beans_modify_action_callback( 'foo', null ) );
 

--- a/tests/phpunit/integration/api/actions/beansModifyActionHook.php
+++ b/tests/phpunit/integration/api/actions/beansModifyActionHook.php
@@ -9,7 +9,9 @@
 
 namespace Beans\Framework\Tests\Integration\API\Actions;
 
-use WP_UnitTestCase;
+use Beans\Framework\Tests\Integration\API\Actions\Includes\Actions_Test_Case;
+
+require_once __DIR__ . '/includes/class-actions-test-case.php';
 
 /**
  * Class Tests_BeansModifyActionHook
@@ -18,22 +20,7 @@ use WP_UnitTestCase;
  * @group   unit-integration
  * @group   api
  */
-class Tests_BeansModifyActionHook extends WP_UnitTestCase {
-
-	/**
-	 * Reset the test fixture.
-	 */
-	public function tearDown() {
-		parent::tearDown();
-
-		global $_beans_registered_actions;
-		$_beans_registered_actions = array(
-			'added'    => array(),
-			'modified' => array(),
-			'removed'  => array(),
-			'replaced' => array(),
-		);
-	}
+class Tests_BeansModifyActionHook extends Actions_Test_Case {
 
 	/**
 	 * Test beans_modify_action_hook() should return false when the ID is not registered.
@@ -89,68 +76,5 @@ class Tests_BeansModifyActionHook extends WP_UnitTestCase {
 		$this->assertFalse( has_action( $action['hook'] ) );
 		$this->assertTrue( has_action( $modified_action['hook'] ) );
 		$this->check_parameters_registered_in_wp( array_merge( $action, $modified_action ) );
-	}
-
-	/**
-	 * Check that it is not registered first.
-	 *
-	 * @since 1.5.0
-	 *
-	 * @param string $id   The ID to check.
-	 * @param string $hook The hook (event name) to check.
-	 *
-	 * @return void
-	 */
-	protected function check_not_added( $id, $hook ) {
-		$this->assertFalse( _beans_get_action( $id, 'added' ) );
-		$this->assertFalse( has_action( $hook ) );
-	}
-
-	/**
-	 * Check that the right parameters are registered in WordPress.
-	 *
-	 * @since 1.5.0
-	 *
-	 * @param array $action The action that should be registered.
-	 *
-	 * @return void
-	 */
-	protected function check_parameters_registered_in_wp( array $action ) {
-		global $wp_filter;
-		$registered_action = $wp_filter[ $action['hook'] ]->callbacks[ $action['priority'] ];
-
-		$this->assertArrayHasKey( $action['callback'], $registered_action );
-		$this->assertEquals( $action['callback'], $registered_action[ $action['callback'] ]['function'] );
-		$this->assertEquals( $action['args'], $registered_action[ $action['callback'] ]['accepted_args'] );
-
-		// Then remove the action.
-		remove_action( $action['hook'], $action['callback'], $action['priority'] );
-	}
-
-	/**
-	 * Setup the original action.
-	 *
-	 * @since 1.5.0
-	 *
-	 * @param string $id Optional. Beans ID to register. Default is 'foo'.
-	 *
-	 * @return array
-	 */
-	protected function setup_original_action( $id = 'foo' ) {
-		$action = array(
-			'hook'     => "{$id}_hook",
-			'callback' => "callback_{$id}",
-			'priority' => 10,
-			'args'     => 1,
-		);
-
-		$this->check_not_added( $id, $action['hook'] );
-
-		// Add the original action to get us rolling.
-		beans_add_action( $id, $action['hook'], $action['callback'] );
-		$this->assertTrue( has_action( $action['hook'] ) );
-		$this->check_parameters_registered_in_wp( $action );
-
-		return $action;
 	}
 }

--- a/tests/phpunit/integration/api/actions/beansModifyActionHook.php
+++ b/tests/phpunit/integration/api/actions/beansModifyActionHook.php
@@ -16,7 +16,7 @@ require_once __DIR__ . '/includes/class-actions-test-case.php';
 /**
  * Class Tests_BeansModifyActionHook
  *
- * @package Beans\Framework\Tests\Unit\API\Actions
+ * @package Beans\Framework\Tests\Integration\API\Actions
  * @group   unit-integration
  * @group   api
  */

--- a/tests/phpunit/integration/api/actions/beansModifyActionHook.php
+++ b/tests/phpunit/integration/api/actions/beansModifyActionHook.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Tests for beans_modify_action_hook()
+ *
+ * @package Beans\Framework\Tests\Integration\API\Actions
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Integration\API\Actions;
+
+use WP_UnitTestCase;
+
+/**
+ * Class Tests_BeansModifyActionHook
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ * @group   unit-integration
+ * @group   api
+ */
+class Tests_BeansModifyActionHook extends WP_UnitTestCase {
+
+	/**
+	 * Reset the test fixture.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		global $_beans_registered_actions;
+		$_beans_registered_actions = array(
+			'added'    => array(),
+			'modified' => array(),
+			'removed'  => array(),
+			'replaced' => array(),
+		);
+	}
+
+	/**
+	 * Test beans_modify_action_hook() should return false when the ID is not registered.
+	 */
+	public function test_should_return_false_when_id_not_registered() {
+		$this->assertFalse( beans_modify_action_hook( 'foo', null ) );
+		$this->assertFalse( beans_modify_action_hook( 'foo', 'foo_hook' ) );
+		$this->assertFalse( beans_modify_action_hook( 'beans', 'beans_hook' ) );
+	}
+
+	/**
+	 * Test beans_modify_action_hook() should return false when new hook is null.
+	 */
+	public function test_should_return_false_when_new_hook_is_null() {
+		$this->setup_original_action();
+		$this->assertFalse( beans_modify_action_hook( 'foo', null ) );
+
+		$this->setup_original_action( 'beans' );
+		$this->assertFalse( beans_modify_action_hook( 'beans', null ) );
+	}
+
+	/**
+	 * Test beans_modify_action_hook() should register with Beans as modified, but not with WordPress.
+	 */
+	public function test_should_register_with_beans_as_modified_but_not_with_wp() {
+		$action = array(
+			'hook' => 'my_hook',
+		);
+
+		$this->check_not_added( 'foo', $action['hook'] );
+
+		$this->assertFalse( beans_modify_action_hook( 'foo', $action['hook'] ) );
+
+		// Check that it did register with Beans.
+		$this->assertEquals( $action, _beans_get_action( 'foo', 'modified' ) );
+
+		// Check that it did not add the action.
+		$this->assertFalse( has_action( $action['hook'] ) );
+	}
+
+	/**
+	 * Test beans_modify_action_hook() should modify the registered action's hook.
+	 */
+	public function test_should_modify_the_action_hook() {
+		$action          = $this->setup_original_action( 'beans' );
+		$modified_action = array(
+			'hook' => 'my_hook',
+		);
+		$this->assertTrue( beans_modify_action_hook( 'beans', $modified_action['hook'] ) );
+		$this->assertEquals( $modified_action, _beans_get_action( 'beans', 'modified' ) );
+
+		// Now check that it overwrote the "hook".
+		$this->assertFalse( has_action( $action['hook'] ) );
+		$this->assertTrue( has_action( $modified_action['hook'] ) );
+		$this->check_parameters_registered_in_wp( array_merge( $action, $modified_action ) );
+	}
+
+	/**
+	 * Check that it is not registered first.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param string $id   The ID to check.
+	 * @param string $hook The hook (event name) to check.
+	 *
+	 * @return void
+	 */
+	protected function check_not_added( $id, $hook ) {
+		$this->assertFalse( _beans_get_action( $id, 'added' ) );
+		$this->assertFalse( has_action( $hook ) );
+	}
+
+	/**
+	 * Check that the right parameters are registered in WordPress.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param array $action The action that should be registered.
+	 *
+	 * @return void
+	 */
+	protected function check_parameters_registered_in_wp( array $action ) {
+		global $wp_filter;
+		$registered_action = $wp_filter[ $action['hook'] ]->callbacks[ $action['priority'] ];
+
+		$this->assertArrayHasKey( $action['callback'], $registered_action );
+		$this->assertEquals( $action['callback'], $registered_action[ $action['callback'] ]['function'] );
+		$this->assertEquals( $action['args'], $registered_action[ $action['callback'] ]['accepted_args'] );
+
+		// Then remove the action.
+		remove_action( $action['hook'], $action['callback'], $action['priority'] );
+	}
+
+	/**
+	 * Setup the original action.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param string $id Optional. Beans ID to register. Default is 'foo'.
+	 *
+	 * @return array
+	 */
+	protected function setup_original_action( $id = 'foo' ) {
+		$action = array(
+			'hook'     => "{$id}_hook",
+			'callback' => "callback_{$id}",
+			'priority' => 10,
+			'args'     => 1,
+		);
+
+		$this->check_not_added( $id, $action['hook'] );
+
+		// Add the original action to get us rolling.
+		beans_add_action( $id, $action['hook'], $action['callback'] );
+		$this->assertTrue( has_action( $action['hook'] ) );
+		$this->check_parameters_registered_in_wp( $action );
+
+		return $action;
+	}
+}

--- a/tests/phpunit/integration/api/actions/beansModifyActionPriority.php
+++ b/tests/phpunit/integration/api/actions/beansModifyActionPriority.php
@@ -16,7 +16,7 @@ require_once __DIR__ . '/includes/class-actions-test-case.php';
 /**
  * Class Tests_BeansModifyActionPriority
  *
- * @package Beans\Framework\Tests\Unit\API\Actions
+ * @package Beans\Framework\Tests\Integration\API\Actions
  * @group   unit-integration
  * @group   api
  */
@@ -32,6 +32,7 @@ class Tests_BeansModifyActionPriority extends Actions_Test_Case {
 			'baz'   => 10,
 			'beans' => '20',
 		);
+
 		foreach ( $ids as $id => $priority ) {
 			$this->assertFalse( beans_modify_action_priority( $id, $priority ) );
 		}
@@ -47,6 +48,7 @@ class Tests_BeansModifyActionPriority extends Actions_Test_Case {
 			'baz'   => false,
 			'beans' => '',
 		);
+
 		foreach ( $ids as $id => $priority ) {
 			$action = $this->setup_original_action( $id, true );
 
@@ -68,6 +70,7 @@ class Tests_BeansModifyActionPriority extends Actions_Test_Case {
 			'baz'   => '0',
 			'beans' => '0.0',
 		);
+
 		foreach ( $ids as $id => $priority ) {
 			$action = $this->setup_original_action( $id );
 			$this->assertTrue( beans_modify_action_priority( $id, $priority ) );

--- a/tests/phpunit/integration/api/actions/beansModifyActionPriority.php
+++ b/tests/phpunit/integration/api/actions/beansModifyActionPriority.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * Tests for beans_modify_action_priority()
+ *
+ * @package Beans\Framework\Tests\Integration\API\Actions
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Integration\API\Actions;
+
+use WP_UnitTestCase;
+
+/**
+ * Class Tests_BeansModifyActionPriority
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ * @group   unit-integration
+ * @group   api
+ */
+class Tests_BeansModifyActionPriority extends WP_UnitTestCase {
+
+	/**
+	 * Reset the test fixture.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		global $_beans_registered_actions;
+		$_beans_registered_actions = array(
+			'added'    => array(),
+			'modified' => array(),
+			'removed'  => array(),
+			'replaced' => array(),
+		);
+	}
+
+	/**
+	 * Test beans_modify_action_priority() should return false when the ID is not registered.
+	 */
+	public function test_should_return_false_when_id_not_registered() {
+		$ids = array(
+			'foo'   => null,
+			'bar'   => 0,
+			'baz'   => 10,
+			'beans' => '20',
+		);
+		foreach ( $ids as $id => $priority ) {
+			$this->assertFalse( beans_modify_action_priority( $id, $priority ) );
+		}
+	}
+
+	/**
+	 * Test beans_modify_action_callback() should return false when null is new priority.
+	 */
+	public function test_should_return_false_when_priority_is_non_integer() {
+		$ids = array(
+			'foo'   => null,
+			'bar'   => array( 10 ),
+			'baz'   => false,
+			'beans' => '',
+		);
+		foreach ( $ids as $id => $priority ) {
+			$action = $this->setup_original_action( $id, true );
+
+			$this->assertFalse( beans_modify_action_priority( $id, $priority ) );
+			$this->assertTrue( has_action( $action['hook'] ) );
+
+			// Check that the parameters did not change.
+			$this->check_parameters_registered_in_wp( $action );
+		}
+	}
+
+	/**
+	 * Test beans_modify_action_priority() should modify the action's priority when the new one is zero.
+	 */
+	public function test_should_modify_action_when_priority_is_zero() {
+		$ids = array(
+			'foo'   => 0,
+			'bar'   => 0.0,
+			'baz'   => '0',
+			'beans' => '0.0',
+		);
+		foreach ( $ids as $id => $priority ) {
+			$action = $this->setup_original_action( $id );
+			$this->assertTrue( beans_modify_action_priority( $id, $priority ) );
+
+			// Manually change the original to the new one.  Then test that it did change in WordPress.
+			$action['priority'] = (int) $priority;
+			$this->check_parameters_registered_in_wp( $action );
+		}
+	}
+
+	/**
+	 * Test beans_modify_action_priority() should modify the registered action's priority.
+	 */
+	public function test_should_modify_the_action_priority() {
+		$action          = $this->setup_original_action( 'beans' );
+		$modified_action = array(
+			'priority' => 20,
+		);
+		$this->assertTrue( beans_modify_action_priority( 'beans', $modified_action['priority'] ) );
+		$this->assertEquals( $modified_action, _beans_get_action( 'beans', 'modified' ) );
+		$this->assertTrue( has_action( $action['hook'] ) );
+		$this->check_parameters_registered_in_wp( array_merge( $action, $modified_action ) );
+	}
+
+	/**
+	 * Check that it is not registered first.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param string $id   The ID to check.
+	 * @param string $hook The hook (event name) to check.
+	 *
+	 * @return void
+	 */
+	protected function check_not_added( $id, $hook ) {
+		$this->assertFalse( _beans_get_action( $id, 'added' ) );
+		$this->assertFalse( has_action( $hook ) );
+	}
+
+	/**
+	 * Check that the right parameters are registered in WordPress.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param array $action        The action that should be registered.
+	 * @param bool  $remove_action When true, it removes the action automatically to clean up this test.
+	 *
+	 * @return void
+	 */
+	protected function check_parameters_registered_in_wp( array $action, $remove_action = true ) {
+		global $wp_filter;
+		$registered_action = $wp_filter[ $action['hook'] ]->callbacks[ $action['priority'] ];
+
+		$this->assertArrayHasKey( $action['callback'], $registered_action );
+		$this->assertEquals( $action['callback'], $registered_action[ $action['callback'] ]['function'] );
+		$this->assertEquals( $action['args'], $registered_action[ $action['callback'] ]['accepted_args'] );
+
+		// Then remove the action.
+		if ( $remove_action ) {
+			remove_action( $action['hook'], $action['callback'], $action['priority'] );
+		}
+	}
+
+	/**
+	 * Setup the original action.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param string $id Optional. Beans ID to register. Default is 'foo'.
+	 *
+	 * @return array
+	 */
+	protected function setup_original_action( $id = 'foo' ) {
+		$action = array(
+			'hook'     => "{$id}_hook",
+			'callback' => "callback_{$id}",
+			'priority' => 10,
+			'args'     => 1,
+		);
+
+		$this->check_not_added( $id, $action['hook'] );
+
+		// Add the original action to get us rolling.
+		beans_add_action( $id, $action['hook'], $action['callback'] );
+		$this->assertTrue( has_action( $action['hook'] ) );
+		$this->check_parameters_registered_in_wp( $action, false );
+
+		return $action;
+	}
+}

--- a/tests/phpunit/integration/api/actions/beansModifyActionPriority.php
+++ b/tests/phpunit/integration/api/actions/beansModifyActionPriority.php
@@ -38,7 +38,7 @@ class Tests_BeansModifyActionPriority extends Actions_Test_Case {
 	}
 
 	/**
-	 * Test beans_modify_action_callback() should return false when new priority is a non-integer.
+	 * Test beans_modify_action_priority() should return false when new priority is a non-integer.
 	 */
 	public function test_should_return_false_when_priority_is_non_integer() {
 		$ids = array(

--- a/tests/phpunit/integration/api/actions/beansModifyActionPriority.php
+++ b/tests/phpunit/integration/api/actions/beansModifyActionPriority.php
@@ -38,7 +38,7 @@ class Tests_BeansModifyActionPriority extends Actions_Test_Case {
 	}
 
 	/**
-	 * Test beans_modify_action_callback() should return false when null is new priority.
+	 * Test beans_modify_action_callback() should return false when new priority is a non-integer.
 	 */
 	public function test_should_return_false_when_priority_is_non_integer() {
 		$ids = array(

--- a/tests/phpunit/integration/api/actions/beansModifyActionPriority.php
+++ b/tests/phpunit/integration/api/actions/beansModifyActionPriority.php
@@ -9,7 +9,9 @@
 
 namespace Beans\Framework\Tests\Integration\API\Actions;
 
-use WP_UnitTestCase;
+use Beans\Framework\Tests\Integration\API\Actions\Includes\Actions_Test_Case;
+
+require_once __DIR__ . '/includes/class-actions-test-case.php';
 
 /**
  * Class Tests_BeansModifyActionPriority
@@ -18,22 +20,7 @@ use WP_UnitTestCase;
  * @group   unit-integration
  * @group   api
  */
-class Tests_BeansModifyActionPriority extends WP_UnitTestCase {
-
-	/**
-	 * Reset the test fixture.
-	 */
-	public function tearDown() {
-		parent::tearDown();
-
-		global $_beans_registered_actions;
-		$_beans_registered_actions = array(
-			'added'    => array(),
-			'modified' => array(),
-			'removed'  => array(),
-			'replaced' => array(),
-		);
-	}
+class Tests_BeansModifyActionPriority extends Actions_Test_Case {
 
 	/**
 	 * Test beans_modify_action_priority() should return false when the ID is not registered.
@@ -103,71 +90,5 @@ class Tests_BeansModifyActionPriority extends WP_UnitTestCase {
 		$this->assertEquals( $modified_action, _beans_get_action( 'beans', 'modified' ) );
 		$this->assertTrue( has_action( $action['hook'] ) );
 		$this->check_parameters_registered_in_wp( array_merge( $action, $modified_action ) );
-	}
-
-	/**
-	 * Check that it is not registered first.
-	 *
-	 * @since 1.5.0
-	 *
-	 * @param string $id   The ID to check.
-	 * @param string $hook The hook (event name) to check.
-	 *
-	 * @return void
-	 */
-	protected function check_not_added( $id, $hook ) {
-		$this->assertFalse( _beans_get_action( $id, 'added' ) );
-		$this->assertFalse( has_action( $hook ) );
-	}
-
-	/**
-	 * Check that the right parameters are registered in WordPress.
-	 *
-	 * @since 1.5.0
-	 *
-	 * @param array $action        The action that should be registered.
-	 * @param bool  $remove_action When true, it removes the action automatically to clean up this test.
-	 *
-	 * @return void
-	 */
-	protected function check_parameters_registered_in_wp( array $action, $remove_action = true ) {
-		global $wp_filter;
-		$registered_action = $wp_filter[ $action['hook'] ]->callbacks[ $action['priority'] ];
-
-		$this->assertArrayHasKey( $action['callback'], $registered_action );
-		$this->assertEquals( $action['callback'], $registered_action[ $action['callback'] ]['function'] );
-		$this->assertEquals( $action['args'], $registered_action[ $action['callback'] ]['accepted_args'] );
-
-		// Then remove the action.
-		if ( $remove_action ) {
-			remove_action( $action['hook'], $action['callback'], $action['priority'] );
-		}
-	}
-
-	/**
-	 * Setup the original action.
-	 *
-	 * @since 1.5.0
-	 *
-	 * @param string $id Optional. Beans ID to register. Default is 'foo'.
-	 *
-	 * @return array
-	 */
-	protected function setup_original_action( $id = 'foo' ) {
-		$action = array(
-			'hook'     => "{$id}_hook",
-			'callback' => "callback_{$id}",
-			'priority' => 10,
-			'args'     => 1,
-		);
-
-		$this->check_not_added( $id, $action['hook'] );
-
-		// Add the original action to get us rolling.
-		beans_add_action( $id, $action['hook'], $action['callback'] );
-		$this->assertTrue( has_action( $action['hook'] ) );
-		$this->check_parameters_registered_in_wp( $action, false );
-
-		return $action;
 	}
 }

--- a/tests/phpunit/integration/api/actions/includes/class-actions-test-case.php
+++ b/tests/phpunit/integration/api/actions/includes/class-actions-test-case.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Tests Case for Beans' Action API integration tests.
+ *
+ * @package Beans\Framework\Tests\Integration\API\Actions\Includes
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Integration\API\Actions\Includes;
+
+use WP_UnitTestCase;
+
+/**
+ * Abstract Class Actions_Test_Case
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions\Includes
+ */
+abstract class Actions_Test_Case extends WP_UnitTestCase {
+
+	/**
+	 * Reset the test fixture.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		global $_beans_registered_actions;
+		$_beans_registered_actions = array(
+			'added'    => array(),
+			'modified' => array(),
+			'removed'  => array(),
+			'replaced' => array(),
+		);
+	}
+
+	/**
+	 * Check that it is not registered first.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param string $id   The ID to check.
+	 * @param string $hook The hook (event name) to check.
+	 *
+	 * @return void
+	 */
+	protected function check_not_added( $id, $hook ) {
+		$this->assertFalse( _beans_get_action( $id, 'added' ) );
+		$this->assertFalse( has_action( $hook ) );
+	}
+
+	/**
+	 * Check that the right parameters are registered in WordPress.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param array $action        The action that should be registered.
+	 * @param bool  $remove_action When true, it removes the action automatically to clean up this test.
+	 *
+	 * @return void
+	 */
+	protected function check_parameters_registered_in_wp( array $action, $remove_action = true ) {
+		global $wp_filter;
+		$registered_action = $wp_filter[ $action['hook'] ]->callbacks[ $action['priority'] ];
+
+		$this->assertArrayHasKey( $action['callback'], $registered_action );
+		$this->assertEquals( $action['callback'], $registered_action[ $action['callback'] ]['function'] );
+		$this->assertEquals( $action['args'], $registered_action[ $action['callback'] ]['accepted_args'] );
+
+		// Then remove the action.
+		if ( $remove_action ) {
+			remove_action( $action['hook'], $action['callback'], $action['priority'] );
+		}
+	}
+
+	/**
+	 * Setup the original action.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param string $id Optional. Beans ID to register. Default is 'foo'.
+	 *
+	 * @return array
+	 */
+	protected function setup_original_action( $id = 'foo' ) {
+		$action = array(
+			'hook'     => "{$id}_hook",
+			'callback' => "callback_{$id}",
+			'priority' => 10,
+			'args'     => 1,
+		);
+
+		$this->check_not_added( $id, $action['hook'] );
+
+		// Add the original action to get us rolling.
+		beans_add_action( $id, $action['hook'], $action['callback'] );
+		$this->assertTrue( has_action( $action['hook'] ) );
+		$this->check_parameters_registered_in_wp( $action, false );
+
+		return $action;
+	}
+}

--- a/tests/phpunit/unit/api/actions/beansBuildActionArray.php
+++ b/tests/phpunit/unit/api/actions/beansBuildActionArray.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests for _beans_build_action_for_valid_args()
+ * Tests for _beans_build_action_array()
  *
  * @package Beans\Framework\Tests\Unit\API\Actions
  *
@@ -13,13 +13,13 @@ use Beans\Framework\Tests\Unit\Test_Case;
 use Brain\Monkey;
 
 /**
- * Class Tests_BeansBuildActionForValidArgs
+ * Class Tests_BeansBuildActionArray
  *
  * @package Beans\Framework\Tests\Unit\API\Actions
  * @group   unit-tests
  * @group   api
  */
-class Tests_BeansBuildActionForValidArgs extends Test_Case {
+class Tests_BeansBuildActionArray extends Test_Case {
 
 	/**
 	 * Setup test fixture.
@@ -31,65 +31,68 @@ class Tests_BeansBuildActionForValidArgs extends Test_Case {
 	}
 
 	/**
-	 * Test _beans_build_action_for_valid_args() should return empty array when all of the arguments are invalid.
+	 * Test _beans_build_action_array() should return empty array when all of the arguments are invalid.
 	 */
 	public function test_should_return_empty_array_when_invalid_arguments() {
-		$this->assertEmpty( _beans_build_action_for_valid_args() );
-		$this->assertEmpty( _beans_build_action_for_valid_args( '', '' ) );
-		$this->assertEmpty( _beans_build_action_for_valid_args( null, false, '', array( 1 ) ) );
+		$this->assertEmpty( _beans_build_action_array() );
+		$this->assertEmpty( _beans_build_action_array( '', '' ) );
+		$this->assertEmpty( _beans_build_action_array( null, false, '', array( 1 ) ) );
 	}
 
 	/**
-	 * Test _beans_build_action_for_valid_args() should return only the "hook" parameter.
+	 * Test _beans_build_action_array() should return only the "hook" parameter.
 	 */
 	public function test_should_return_only_hook() {
 		$hooks = array( 'foo', 'bar', 'baz', 'beans' );
+
 		foreach ( $hooks as $hook ) {
-			$this->assertEquals( array( 'hook' => $hook ), _beans_build_action_for_valid_args( $hook ) );
+			$this->assertEquals( array( 'hook' => $hook ), _beans_build_action_array( $hook ) );
 		}
 	}
 
 	/**
-	 * Test _beans_build_action_for_valid_args() should return only the "callback" parameter.
+	 * Test _beans_build_action_array() should return only the "callback" parameter.
 	 */
 	public function test_should_return_only_callback() {
 		$callbacks = array( 'foo_callback', 'my_callback', 'Foo::cb', array( $this, __FUNCTION__ ) );
+
 		foreach ( $callbacks as $callback ) {
 			$this->assertEquals(
 				array( 'callback' => $callback ),
-				_beans_build_action_for_valid_args( null, $callback )
+				_beans_build_action_array( null, $callback )
 			);
 		}
 	}
 
 	/**
-	 * Test _beans_build_action_for_valid_args() should return only the "priority" parameter.
+	 * Test _beans_build_action_array() should return only the "priority" parameter.
 	 */
 	public function test_should_return_only_priority() {
 		$priorities = array( 10, 0, 50, '20' );
+
 		foreach ( $priorities as $priority ) {
 			$this->assertEquals(
 				array( 'priority' => (int) $priority ),
-				_beans_build_action_for_valid_args( null, null, $priority )
+				_beans_build_action_array( null, null, $priority )
 			);
 		}
 	}
 
 	/**
-	 * Test _beans_build_action_for_valid_args() should return only the "args" parameter.
+	 * Test _beans_build_action_array() should return only the "args" parameter.
 	 */
 	public function test_should_return_only_args() {
 
 		foreach ( array( 0, 1, 2, '3', '4.1' ) as $args ) {
 			$this->assertEquals(
 				array( 'args' => (int) $args ),
-				_beans_build_action_for_valid_args( null, null, null, $args )
+				_beans_build_action_array( null, null, null, $args )
 			);
 		}
 	}
 
 	/**
-	 * Test _beans_build_action_for_valid_args() should return only the valid arguments.
+	 * Test _beans_build_action_array() should return only the valid arguments.
 	 */
 	public function test_should_return_valid_args() {
 		$this->assertEquals(
@@ -97,7 +100,7 @@ class Tests_BeansBuildActionForValidArgs extends Test_Case {
 				'hook'     => 'foo',
 				'callback' => 'cb',
 			),
-			_beans_build_action_for_valid_args( 'foo', 'cb', '', false )
+			_beans_build_action_array( 'foo', 'cb', '', false )
 		);
 
 		$this->assertEquals(
@@ -106,7 +109,7 @@ class Tests_BeansBuildActionForValidArgs extends Test_Case {
 				'callback' => 'cb',
 				'args'     => 1,
 			),
-			_beans_build_action_for_valid_args( 'foo', 'cb', '', 1 )
+			_beans_build_action_array( 'foo', 'cb', '', 1 )
 		);
 
 		$this->assertEquals(
@@ -114,7 +117,7 @@ class Tests_BeansBuildActionForValidArgs extends Test_Case {
 				'hook'     => 'foo',
 				'priority' => 50,
 			),
-			_beans_build_action_for_valid_args( 'foo', '', '50' )
+			_beans_build_action_array( 'foo', '', '50' )
 		);
 
 		$this->assertEquals(
@@ -124,7 +127,7 @@ class Tests_BeansBuildActionForValidArgs extends Test_Case {
 				'priority' => 0,
 				'args'     => 0,
 			),
-			_beans_build_action_for_valid_args( 'foo', 'my_callback', 0, '0.0' )
+			_beans_build_action_array( 'foo', 'my_callback', 0, '0.0' )
 		);
 
 		$this->assertEquals(
@@ -134,7 +137,7 @@ class Tests_BeansBuildActionForValidArgs extends Test_Case {
 				'priority' => 20,
 				'args'     => 2,
 			),
-			_beans_build_action_for_valid_args( 'baz', 'baz_cb', 20, 2 )
+			_beans_build_action_array( 'baz', 'baz_cb', 20, 2 )
 		);
 	}
 }

--- a/tests/phpunit/unit/api/actions/beansBuildActionForValidArgs.php
+++ b/tests/phpunit/unit/api/actions/beansBuildActionForValidArgs.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * Tests for _beans_build_action_for_valid_args()
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Unit\API\Actions;
+
+use Beans\Framework\Tests\Unit\Test_Case;
+use Brain\Monkey;
+
+/**
+ * Class Tests_BeansBuildActionForValidArgs
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ * @group   unit-tests
+ * @group   api
+ */
+class Tests_BeansBuildActionForValidArgs extends Test_Case {
+
+	/**
+	 * Setup test fixture.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		require_once BEANS_TESTS_LIB_DIR . 'api/actions/functions.php';
+	}
+
+	/**
+	 * Test _beans_build_action_for_valid_args() should return empty array when all of the arguments are invalid.
+	 */
+	public function test_should_return_empty_array_when_invalid_arguments() {
+		$this->assertEmpty( _beans_build_action_for_valid_args() );
+		$this->assertEmpty( _beans_build_action_for_valid_args( '', '' ) );
+		$this->assertEmpty( _beans_build_action_for_valid_args( null, false, '', array( 1 ) ) );
+	}
+
+	/**
+	 * Test _beans_build_action_for_valid_args() should return only the "hook" parameter.
+	 */
+	public function test_should_return_only_hook() {
+		$hooks = array( 'foo', 'bar', 'baz', 'beans' );
+		foreach ( $hooks as $hook ) {
+			$this->assertEquals( array( 'hook' => $hook ), _beans_build_action_for_valid_args( $hook ) );
+		}
+	}
+
+	/**
+	 * Test _beans_build_action_for_valid_args() should return only the "callback" parameter.
+	 */
+	public function test_should_return_only_callback() {
+		$callbacks = array( 'foo_callback', 'my_callback', 'Foo::cb', array( $this, __FUNCTION__ ) );
+		foreach ( $callbacks as $callback ) {
+			$this->assertEquals(
+				array( 'callback' => $callback ),
+				_beans_build_action_for_valid_args( null, $callback )
+			);
+		}
+	}
+
+	/**
+	 * Test _beans_build_action_for_valid_args() should return only the "priority" parameter.
+	 */
+	public function test_should_return_only_priority() {
+		$priorities = array( 10, 0, 50, '20' );
+		foreach ( $priorities as $priority ) {
+			$this->assertEquals(
+				array( 'priority' => (int) $priority ),
+				_beans_build_action_for_valid_args( null, null, $priority )
+			);
+		}
+	}
+
+	/**
+	 * Test _beans_build_action_for_valid_args() should return only the "args" parameter.
+	 */
+	public function test_should_return_only_args() {
+
+		foreach ( array( 0, 1, 2, '3', '4.1' ) as $args ) {
+			$this->assertEquals(
+				array( 'args' => (int) $args ),
+				_beans_build_action_for_valid_args( null, null, null, $args )
+			);
+		}
+	}
+
+	/**
+	 * Test _beans_build_action_for_valid_args() should return only the valid arguments.
+	 */
+	public function test_should_return_valid_args() {
+		$this->assertEquals(
+			array(
+				'hook'     => 'foo',
+				'callback' => 'cb',
+			),
+			_beans_build_action_for_valid_args( 'foo', 'cb', '', false )
+		);
+
+		$this->assertEquals(
+			array(
+				'hook'     => 'foo',
+				'callback' => 'cb',
+				'args'     => 1,
+			),
+			_beans_build_action_for_valid_args( 'foo', 'cb', '', 1 )
+		);
+
+		$this->assertEquals(
+			array(
+				'hook'     => 'foo',
+				'priority' => 50,
+			),
+			_beans_build_action_for_valid_args( 'foo', '', '50' )
+		);
+
+		$this->assertEquals(
+			array(
+				'hook'     => 'foo',
+				'callback' => 'my_callback',
+				'priority' => 0,
+				'args'     => 0,
+			),
+			_beans_build_action_for_valid_args( 'foo', 'my_callback', 0, '0.0' )
+		);
+
+		$this->assertEquals(
+			array(
+				'hook'     => 'baz',
+				'callback' => 'baz_cb',
+				'priority' => 20,
+				'args'     => 2,
+			),
+			_beans_build_action_for_valid_args( 'baz', 'baz_cb', 20, 2 )
+		);
+	}
+}

--- a/tests/phpunit/unit/api/actions/beansModifyAction.php
+++ b/tests/phpunit/unit/api/actions/beansModifyAction.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * Tests for beans_modify_action()
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Unit\API\Actions;
+
+use Beans\Framework\Tests\Unit\Test_Case;
+use Brain\Monkey;
+
+/**
+ * Class Tests_BeansModifyAction
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ * @group   unit-tests
+ * @group   api
+ */
+class Tests_BeansModifyAction extends Test_Case {
+
+	/**
+	 * Setup test fixture.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		require_once BEANS_TESTS_LIB_DIR . 'api/actions/functions.php';
+		require_once BEANS_TESTS_LIB_DIR . 'api/utilities/functions.php';
+	}
+
+	/**
+	 * Reset the test fixture.
+	 */
+	protected function tearDown() {
+		parent::tearDown();
+
+		global $_beans_registered_actions;
+		$_beans_registered_actions = array(
+			'added'    => array(),
+			'modified' => array(),
+			'removed'  => array(),
+			'replaced' => array(),
+		);
+	}
+
+	/**
+	 * Test beans_modify_action() should return false when the ID is not registered.
+	 */
+	public function test_should_return_false_when_id_not_registered() {
+		$this->assertFalse( beans_modify_action( 'foo' ) );
+	}
+
+	/**
+	 * Test beans_modify_action() should register with Beans as modified, but not with WordPress.
+	 */
+	public function test_should_register_with_beans_as_modified_but_not_with_wp() {
+		$action = array(
+			'hook'     => 'foo_hook',
+			'callback' => 'my_callback',
+		);
+
+		$this->check_not_added( 'foo', $action['hook'] );
+
+		$this->assertFalse( beans_modify_action( 'foo', $action['hook'], $action['callback'] ) );
+
+		// Check that it did register with Beans.
+		$this->assertEquals( $action, _beans_get_action( 'foo', 'modified' ) );
+
+		// Check that it did not add the action.
+		$this->assertFalse( has_action( $action['hook'] ) );
+	}
+
+	/**
+	 * Test beans_modify_action() should modify the registered action's callback.
+	 */
+	public function test_should_modify_the_action_callback() {
+		$container       = Monkey\Container::instance();
+		$action          = $this->setup_original_action();
+		$modified_action = array(
+			'callback' => 'my_callback',
+		);
+		$this->assertTrue( beans_modify_action( 'beans', null, $modified_action['callback'] ) );
+		$this->assertEquals( $modified_action, _beans_get_action( 'beans', 'modified' ) );
+		$this->assertTrue( has_action( $action['hook'] ) );
+		$this->assertTrue( $container->hookStorage()->isHookAdded( Monkey\Hook\HookStorage::ACTIONS, $action['hook'], $modified_action['callback'] ) );
+	}
+
+	/**
+	 * Test beans_modify_action() should modify the registered action's priority level.
+	 */
+	public function test_should_modify_the_action_priority() {
+		$container       = Monkey\Container::instance();
+		$action          = $this->setup_original_action();
+		$modified_action = array(
+			'priority' => 20,
+		);
+		$this->assertTrue( beans_modify_action( 'beans', null, null, $modified_action['priority'] ) );
+		$this->assertEquals( $modified_action, _beans_get_action( 'beans', 'modified' ) );
+		$this->assertTrue( has_action( $action['hook'] ) );
+		$this->assertTrue( $container->hookStorage()->isHookAdded( Monkey\Hook\HookStorage::ACTIONS, $action['hook'], $action['callback'] ) );
+	}
+
+	/**
+	 * Test beans_modify_action() should modify the registered action's number of arguments.
+	 */
+	public function test_should_modify_the_action_args() {
+		$container       = Monkey\Container::instance();
+		$action          = $this->setup_original_action();
+		$modified_action = array(
+			'args' => 2,
+		);
+		$this->assertTrue( beans_modify_action( 'beans', null, null, null, $modified_action['args'] ) );
+		$this->assertEquals( $modified_action, _beans_get_action( 'beans', 'modified' ) );
+		$this->assertTrue( has_action( $action['hook'] ) );
+		$this->assertTrue( $container->hookStorage()->isHookAdded( Monkey\Hook\HookStorage::ACTIONS, $action['hook'], $action['callback'] ) );
+	}
+
+	/**
+	 * Check that is not registered first.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param string $id   The ID to check.
+	 * @param string $hook The hook (event name) to check.
+	 *
+	 * @return void
+	 */
+	protected function check_not_added( $id, $hook ) {
+		$this->assertFalse( _beans_get_action( $id, 'added' ) );
+		$this->assertFalse( has_action( $hook ) );
+	}
+
+	/**
+	 * Setup the original action.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @return array
+	 */
+	protected function setup_original_action() {
+		$container = Monkey\Container::instance();
+		$action    = array(
+			'hook'     => 'beans_hook',
+			'callback' => 'callback_beans',
+			'priority' => 10,
+			'args'     => 1,
+		);
+
+		$this->check_not_added( 'beans', $action['hook'] );
+
+		// Add the original action to get us rolling.
+		beans_add_action( 'beans', $action['hook'], $action['callback'] );
+		$this->assertTrue( has_action( $action['hook'] ) );
+		$this->assertTrue( $container->hookStorage()->isHookAdded( Monkey\Hook\HookStorage::ACTIONS, $action['hook'], $action['callback'] ) );
+
+		return $action;
+	}
+}

--- a/tests/phpunit/unit/api/actions/beansModifyAction.php
+++ b/tests/phpunit/unit/api/actions/beansModifyAction.php
@@ -9,8 +9,10 @@
 
 namespace Beans\Framework\Tests\Unit\API\Actions;
 
-use Beans\Framework\Tests\Unit\Test_Case;
+use Beans\Framework\Tests\Unit\API\Actions\Includes\Actions_Test_Case;
 use Brain\Monkey;
+
+require_once __DIR__ . '/includes/class-actions-test-case.php';
 
 /**
  * Class Tests_BeansModifyAction
@@ -19,32 +21,7 @@ use Brain\Monkey;
  * @group   unit-tests
  * @group   api
  */
-class Tests_BeansModifyAction extends Test_Case {
-
-	/**
-	 * Setup test fixture.
-	 */
-	protected function setUp() {
-		parent::setUp();
-
-		require_once BEANS_TESTS_LIB_DIR . 'api/actions/functions.php';
-		require_once BEANS_TESTS_LIB_DIR . 'api/utilities/functions.php';
-	}
-
-	/**
-	 * Reset the test fixture.
-	 */
-	protected function tearDown() {
-		parent::tearDown();
-
-		global $_beans_registered_actions;
-		$_beans_registered_actions = array(
-			'added'    => array(),
-			'modified' => array(),
-			'removed'  => array(),
-			'replaced' => array(),
-		);
-	}
+class Tests_BeansModifyAction extends Actions_Test_Case {
 
 	/**
 	 * Test beans_modify_action() should return false when the ID is not registered.
@@ -152,54 +129,5 @@ class Tests_BeansModifyAction extends Test_Case {
 		$this->assertEquals( $modified_action, _beans_get_action( 'beans', 'modified' ) );
 		$this->assertTrue( has_action( $action['hook'] ) );
 		$this->assertTrue( $container->hookStorage()->isHookAdded( Monkey\Hook\HookStorage::ACTIONS, $action['hook'], $action['callback'] ) );
-	}
-
-	/**
-	 * Check that is not registered first.
-	 *
-	 * @since 1.5.0
-	 *
-	 * @param string $id   The ID to check.
-	 * @param string $hook The hook (event name) to check.
-	 *
-	 * @return void
-	 */
-	protected function check_not_added( $id, $hook ) {
-		$this->assertFalse( _beans_get_action( $id, 'added' ) );
-		$this->assertFalse( has_action( $hook ) );
-	}
-
-	/**
-	 * Setup the original action.
-	 *
-	 * @since 1.5.0
-	 *
-	 * @param string $id Optional. Beans ID to register. Default is 'foo'.
-	 *
-	 * @return array
-	 */
-	protected function setup_original_action( $id = 'foo' ) {
-		$container = Monkey\Container::instance();
-		$action    = array(
-			'hook'     => "{$id}_hook",
-			'callback' => "callback_{$id}",
-			'priority' => 10,
-			'args'     => 1,
-		);
-
-		$this->check_not_added( $id, $action['hook'] );
-
-		// Add the original action to get us rolling.
-		beans_add_action( $id, $action['hook'], $action['callback'] );
-		$this->assertTrue( has_action( $action['hook'] ) );
-		$this->assertTrue(
-			$container->hookStorage()->isHookAdded(
-				Monkey\Hook\HookStorage::ACTIONS,
-				$action['hook'],
-				$action['callback']
-			)
-		);
-
-		return $action;
 	}
 }

--- a/tests/phpunit/unit/api/actions/beansModifyAction.php
+++ b/tests/phpunit/unit/api/actions/beansModifyAction.php
@@ -33,6 +33,7 @@ class Tests_BeansModifyAction extends Actions_Test_Case {
 			'baz',
 			'beans',
 		);
+
 		foreach ( $ids as $id ) {
 			$this->assertFalse( _beans_get_action( $id, 'modified' ) );
 
@@ -57,6 +58,7 @@ class Tests_BeansModifyAction extends Actions_Test_Case {
 			'baz',
 			'beans',
 		);
+
 		foreach ( $ids as $id ) {
 			$this->assertFalse( beans_modify_action( $id ) );
 

--- a/tests/phpunit/unit/api/actions/beansModifyActionArguments.php
+++ b/tests/phpunit/unit/api/actions/beansModifyActionArguments.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Tests for beans_modify_action_arguments()
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Unit\API\Actions;
+
+use Beans\Framework\Tests\Unit\Test_Case;
+use Brain\Monkey;
+
+/**
+ * Class Tests_BeansModifyActionArguments
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ * @group   unit-tests
+ * @group   api
+ */
+class Tests_BeansModifyActionArguments extends Test_Case {
+
+	/**
+	 * Setup test fixture.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		require_once BEANS_TESTS_LIB_DIR . 'api/actions/functions.php';
+		require_once BEANS_TESTS_LIB_DIR . 'api/utilities/functions.php';
+	}
+
+	/**
+	 * Reset the test fixture.
+	 */
+	protected function tearDown() {
+		parent::tearDown();
+
+		global $_beans_registered_actions;
+		$_beans_registered_actions = array(
+			'added'    => array(),
+			'modified' => array(),
+			'removed'  => array(),
+			'replaced' => array(),
+		);
+	}
+
+	/**
+	 * Test beans_modify_action_arguments() should return false when the ID is not registered.
+	 */
+	public function test_should_return_false_when_id_not_registered() {
+		$ids = array(
+			'foo'   => null,
+			'bar'   => 0,
+			'baz'   => 1,
+			'beans' => '3',
+		);
+		foreach ( $ids as $id => $number_of_args ) {
+			$this->assertFalse( beans_modify_action_arguments( $id, $number_of_args ) );
+		}
+	}
+
+	/**
+	 * Test beans_modify_action_arguments() should return false when new args is a non-integer value.
+	 */
+	public function test_should_return_false_when_args_is_non_integer() {
+		$ids = array(
+			'foo'   => null,
+			'bar'   => array( 10 ),
+			'baz'   => false,
+			'beans' => '',
+		);
+		foreach ( $ids as $id => $number_of_args ) {
+			$action = $this->setup_original_action( $id, true );
+
+			$this->assertFalse( beans_modify_action_arguments( $id, $number_of_args ) );
+			$this->assertTrue( has_action( $action['hook'] ) );
+		}
+	}
+
+	/**
+	 * Test beans_modify_action_priority() should return true when "args" is zero.
+	 */
+	public function test_should_return_true_when_args_is_zero() {
+		$ids = array(
+			'foo'   => 0,
+			'bar'   => 0.0,
+			'baz'   => '0',
+			'beans' => '0.0',
+		);
+		foreach ( $ids as $id => $number_of_args ) {
+			$this->setup_original_action( $id );
+			$this->assertTrue( beans_modify_action_arguments( $id, $number_of_args ) );
+		}
+	}
+
+	/**
+	 * Test beans_modify_action_arguments() should modify the registered action's args.
+	 */
+	public function test_should_modify_the_action_args() {
+		$action          = $this->setup_original_action( 'beans' );
+		$modified_action = array(
+			'args' => 3,
+		);
+		$this->assertTrue( beans_modify_action_arguments( 'beans', $modified_action['args'] ) );
+		$this->assertEquals( $modified_action, _beans_get_action( 'beans', 'modified' ) );
+		$this->assertTrue( has_action( $action['hook'] ) );
+	}
+
+	/**
+	 * Check that is not registered first.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param string $id   The ID to check.
+	 * @param string $hook The hook (event name) to check.
+	 *
+	 * @return void
+	 */
+	protected function check_not_added( $id, $hook ) {
+		$this->assertFalse( _beans_get_action( $id, 'added' ) );
+		$this->assertFalse( has_action( $hook ) );
+	}
+
+	/**
+	 * Setup the original action.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param string $id Optional. Beans ID to register. Default is 'foo'.
+	 *
+	 * @return array
+	 */
+	protected function setup_original_action( $id = 'foo' ) {
+		$container = Monkey\Container::instance();
+		$action    = array(
+			'hook'     => "{$id}_hook",
+			'callback' => "callback_{$id}",
+			'priority' => 10,
+			'args'     => 1,
+		);
+
+		$this->check_not_added( $id, $action['hook'] );
+
+		// Add the original action to get us rolling.
+		beans_add_action( $id, $action['hook'], $action['callback'] );
+		$this->assertTrue( has_action( $action['hook'] ) );
+		$this->assertTrue(
+			$container->hookStorage()->isHookAdded(
+				Monkey\Hook\HookStorage::ACTIONS,
+				$action['hook'],
+				$action['callback']
+			)
+		);
+
+		return $action;
+	}
+}

--- a/tests/phpunit/unit/api/actions/beansModifyActionArguments.php
+++ b/tests/phpunit/unit/api/actions/beansModifyActionArguments.php
@@ -32,6 +32,7 @@ class Tests_BeansModifyActionArguments extends Actions_Test_Case {
 			'baz'   => 1,
 			'beans' => '3',
 		);
+
 		foreach ( $ids as $id => $number_of_args ) {
 			$this->assertFalse( beans_modify_action_arguments( $id, $number_of_args ) );
 		}
@@ -47,6 +48,7 @@ class Tests_BeansModifyActionArguments extends Actions_Test_Case {
 			'baz'   => false,
 			'beans' => '',
 		);
+
 		foreach ( $ids as $id => $number_of_args ) {
 			$action = $this->setup_original_action( $id, true );
 
@@ -65,6 +67,7 @@ class Tests_BeansModifyActionArguments extends Actions_Test_Case {
 			'baz'   => '0',
 			'beans' => '0.0',
 		);
+
 		foreach ( $ids as $id => $number_of_args ) {
 			$this->setup_original_action( $id );
 			$this->assertTrue( beans_modify_action_arguments( $id, $number_of_args ) );

--- a/tests/phpunit/unit/api/actions/beansModifyActionArguments.php
+++ b/tests/phpunit/unit/api/actions/beansModifyActionArguments.php
@@ -9,8 +9,9 @@
 
 namespace Beans\Framework\Tests\Unit\API\Actions;
 
-use Beans\Framework\Tests\Unit\Test_Case;
-use Brain\Monkey;
+use Beans\Framework\Tests\Unit\API\Actions\Includes\Actions_Test_Case;
+
+require_once __DIR__ . '/includes/class-actions-test-case.php';
 
 /**
  * Class Tests_BeansModifyActionArguments
@@ -19,32 +20,7 @@ use Brain\Monkey;
  * @group   unit-tests
  * @group   api
  */
-class Tests_BeansModifyActionArguments extends Test_Case {
-
-	/**
-	 * Setup test fixture.
-	 */
-	protected function setUp() {
-		parent::setUp();
-
-		require_once BEANS_TESTS_LIB_DIR . 'api/actions/functions.php';
-		require_once BEANS_TESTS_LIB_DIR . 'api/utilities/functions.php';
-	}
-
-	/**
-	 * Reset the test fixture.
-	 */
-	protected function tearDown() {
-		parent::tearDown();
-
-		global $_beans_registered_actions;
-		$_beans_registered_actions = array(
-			'added'    => array(),
-			'modified' => array(),
-			'removed'  => array(),
-			'replaced' => array(),
-		);
-	}
+class Tests_BeansModifyActionArguments extends Actions_Test_Case {
 
 	/**
 	 * Test beans_modify_action_arguments() should return false when the ID is not registered.
@@ -106,54 +82,5 @@ class Tests_BeansModifyActionArguments extends Test_Case {
 		$this->assertTrue( beans_modify_action_arguments( 'beans', $modified_action['args'] ) );
 		$this->assertEquals( $modified_action, _beans_get_action( 'beans', 'modified' ) );
 		$this->assertTrue( has_action( $action['hook'] ) );
-	}
-
-	/**
-	 * Check that is not registered first.
-	 *
-	 * @since 1.5.0
-	 *
-	 * @param string $id   The ID to check.
-	 * @param string $hook The hook (event name) to check.
-	 *
-	 * @return void
-	 */
-	protected function check_not_added( $id, $hook ) {
-		$this->assertFalse( _beans_get_action( $id, 'added' ) );
-		$this->assertFalse( has_action( $hook ) );
-	}
-
-	/**
-	 * Setup the original action.
-	 *
-	 * @since 1.5.0
-	 *
-	 * @param string $id Optional. Beans ID to register. Default is 'foo'.
-	 *
-	 * @return array
-	 */
-	protected function setup_original_action( $id = 'foo' ) {
-		$container = Monkey\Container::instance();
-		$action    = array(
-			'hook'     => "{$id}_hook",
-			'callback' => "callback_{$id}",
-			'priority' => 10,
-			'args'     => 1,
-		);
-
-		$this->check_not_added( $id, $action['hook'] );
-
-		// Add the original action to get us rolling.
-		beans_add_action( $id, $action['hook'], $action['callback'] );
-		$this->assertTrue( has_action( $action['hook'] ) );
-		$this->assertTrue(
-			$container->hookStorage()->isHookAdded(
-				Monkey\Hook\HookStorage::ACTIONS,
-				$action['hook'],
-				$action['callback']
-			)
-		);
-
-		return $action;
 	}
 }

--- a/tests/phpunit/unit/api/actions/beansModifyActionCallback.php
+++ b/tests/phpunit/unit/api/actions/beansModifyActionCallback.php
@@ -33,9 +33,9 @@ class Tests_BeansModifyActionCallback extends Actions_Test_Case {
 	}
 
 	/**
-	 * Test beans_modify_action_callback() should return false when null is the new callback.
+	 * Test beans_modify_action_callback() should return false when the new callback is null.
 	 */
-	public function test_should_return_false_when_null_is_new_callback() {
+	public function test_should_return_false_when_new_callback_is_null() {
 		$this->setup_original_action();
 		$this->assertFalse( beans_modify_action_callback( 'foo', null ) );
 

--- a/tests/phpunit/unit/api/actions/beansModifyActionCallback.php
+++ b/tests/phpunit/unit/api/actions/beansModifyActionCallback.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Tests for beans_modify_action_callback()
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Unit\API\Actions;
+
+use Beans\Framework\Tests\Unit\Test_Case;
+use Brain\Monkey;
+
+/**
+ * Class Tests_BeansModifyActionCallback
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ * @group   unit-tests
+ * @group   api
+ */
+class Tests_BeansModifyActionCallback extends Test_Case {
+
+	/**
+	 * Setup test fixture.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		require_once BEANS_TESTS_LIB_DIR . 'api/actions/functions.php';
+		require_once BEANS_TESTS_LIB_DIR . 'api/utilities/functions.php';
+	}
+
+	/**
+	 * Reset the test fixture.
+	 */
+	protected function tearDown() {
+		parent::tearDown();
+
+		global $_beans_registered_actions;
+		$_beans_registered_actions = array(
+			'added'    => array(),
+			'modified' => array(),
+			'removed'  => array(),
+			'replaced' => array(),
+		);
+	}
+
+	/**
+	 * Test beans_modify_action_callback() should return false when the ID is not registered.
+	 */
+	public function test_should_return_false_when_id_not_registered() {
+		$this->assertFalse( beans_modify_action_callback( 'foo', null ) );
+	}
+
+	/**
+	 * Test beans_modify_action_callback() should register with Beans as modified, but not with WordPress.
+	 */
+	public function test_should_register_with_beans_as_modified_but_not_with_wp() {
+		$action = array(
+			'callback' => 'my_callback',
+		);
+
+		$this->check_not_added( 'foo', 'foo_hook' );
+
+		$this->assertFalse( beans_modify_action_callback( 'foo', $action['callback'] ) );
+
+		// Check that it did register with Beans.
+		$this->assertEquals( $action, _beans_get_action( 'foo', 'modified' ) );
+
+		// Check that it did not add the action.
+		$this->assertFalse( has_action( 'foo_hook' ) );
+	}
+
+	/**
+	 * Test beans_modify_action() should modify the registered action's callback.
+	 */
+	public function test_should_modify_the_action_callback() {
+		$container       = Monkey\Container::instance();
+		$action          = $this->setup_original_action( 'beans' );
+		$modified_action = array(
+			'callback' => 'my_callback',
+		);
+		$this->assertTrue( beans_modify_action_callback( 'beans', $modified_action['callback'] ) );
+		$this->assertEquals( $modified_action, _beans_get_action( 'beans', 'modified' ) );
+		$this->assertTrue( has_action( $action['hook'] ) );
+		$this->assertTrue( $container->hookStorage()->isHookAdded( Monkey\Hook\HookStorage::ACTIONS, $action['hook'], $modified_action['callback'] ) );
+	}
+
+	/**
+	 * Check that is not registered first.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param string $id   The ID to check.
+	 * @param string $hook The hook (event name) to check.
+	 *
+	 * @return void
+	 */
+	protected function check_not_added( $id, $hook ) {
+		$this->assertFalse( _beans_get_action( $id, 'added' ) );
+		$this->assertFalse( has_action( $hook ) );
+	}
+
+	/**
+	 * Setup the original action.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param string $id Optional. Beans ID to register. Default is 'foo'.
+	 *
+	 * @return array
+	 */
+	protected function setup_original_action( $id = 'foo' ) {
+		$container = Monkey\Container::instance();
+		$action    = array(
+			'hook'     => 'beans_hook',
+			'callback' => 'callback_beans',
+			'priority' => 10,
+			'args'     => 1,
+		);
+
+		$this->check_not_added( $id, $action['hook'] );
+
+		// Add the original action to get us rolling.
+		beans_add_action( $id, $action['hook'], $action['callback'] );
+		$this->assertTrue( has_action( $action['hook'] ) );
+		$this->assertTrue( $container->hookStorage()->isHookAdded( Monkey\Hook\HookStorage::ACTIONS, $action['hook'], $action['callback'] ) );
+
+		return $action;
+	}
+}

--- a/tests/phpunit/unit/api/actions/beansModifyActionCallback.php
+++ b/tests/phpunit/unit/api/actions/beansModifyActionCallback.php
@@ -51,6 +51,19 @@ class Tests_BeansModifyActionCallback extends Test_Case {
 	 */
 	public function test_should_return_false_when_id_not_registered() {
 		$this->assertFalse( beans_modify_action_callback( 'foo', null ) );
+		$this->assertFalse( beans_modify_action_callback( 'foo', 'my_new_callback' ) );
+		$this->assertFalse( beans_modify_action_callback( 'beans', 'beans_callback' ) );
+	}
+
+	/**
+	 * Test beans_modify_action_callback() should return false when null is the new callback.
+	 */
+	public function test_should_return_false_when_null_is_new_callback() {
+		$this->setup_original_action();
+		$this->assertFalse( beans_modify_action_callback( 'foo', null ) );
+
+		$this->setup_original_action( 'beans' );
+		$this->assertFalse( beans_modify_action_callback( 'beans', null ) );
 	}
 
 	/**
@@ -114,8 +127,8 @@ class Tests_BeansModifyActionCallback extends Test_Case {
 	protected function setup_original_action( $id = 'foo' ) {
 		$container = Monkey\Container::instance();
 		$action    = array(
-			'hook'     => 'beans_hook',
-			'callback' => 'callback_beans',
+			'hook'     => "{$id}_hook",
+			'callback' => "callback_{$id}",
 			'priority' => 10,
 			'args'     => 1,
 		);
@@ -125,7 +138,13 @@ class Tests_BeansModifyActionCallback extends Test_Case {
 		// Add the original action to get us rolling.
 		beans_add_action( $id, $action['hook'], $action['callback'] );
 		$this->assertTrue( has_action( $action['hook'] ) );
-		$this->assertTrue( $container->hookStorage()->isHookAdded( Monkey\Hook\HookStorage::ACTIONS, $action['hook'], $action['callback'] ) );
+		$this->assertTrue(
+			$container->hookStorage()->isHookAdded(
+				Monkey\Hook\HookStorage::ACTIONS,
+				$action['hook'],
+				$action['callback']
+			)
+		);
 
 		return $action;
 	}

--- a/tests/phpunit/unit/api/actions/beansModifyActionCallback.php
+++ b/tests/phpunit/unit/api/actions/beansModifyActionCallback.php
@@ -9,8 +9,10 @@
 
 namespace Beans\Framework\Tests\Unit\API\Actions;
 
-use Beans\Framework\Tests\Unit\Test_Case;
+use Beans\Framework\Tests\Unit\API\Actions\Includes\Actions_Test_Case;
 use Brain\Monkey;
+
+require_once __DIR__ . '/includes/class-actions-test-case.php';
 
 /**
  * Class Tests_BeansModifyActionCallback
@@ -19,32 +21,7 @@ use Brain\Monkey;
  * @group   unit-tests
  * @group   api
  */
-class Tests_BeansModifyActionCallback extends Test_Case {
-
-	/**
-	 * Setup test fixture.
-	 */
-	protected function setUp() {
-		parent::setUp();
-
-		require_once BEANS_TESTS_LIB_DIR . 'api/actions/functions.php';
-		require_once BEANS_TESTS_LIB_DIR . 'api/utilities/functions.php';
-	}
-
-	/**
-	 * Reset the test fixture.
-	 */
-	protected function tearDown() {
-		parent::tearDown();
-
-		global $_beans_registered_actions;
-		$_beans_registered_actions = array(
-			'added'    => array(),
-			'modified' => array(),
-			'removed'  => array(),
-			'replaced' => array(),
-		);
-	}
+class Tests_BeansModifyActionCallback extends Actions_Test_Case {
 
 	/**
 	 * Test beans_modify_action_callback() should return false when the ID is not registered.
@@ -98,54 +75,5 @@ class Tests_BeansModifyActionCallback extends Test_Case {
 		$this->assertEquals( $modified_action, _beans_get_action( 'beans', 'modified' ) );
 		$this->assertTrue( has_action( $action['hook'] ) );
 		$this->assertTrue( $container->hookStorage()->isHookAdded( Monkey\Hook\HookStorage::ACTIONS, $action['hook'], $modified_action['callback'] ) );
-	}
-
-	/**
-	 * Check that is not registered first.
-	 *
-	 * @since 1.5.0
-	 *
-	 * @param string $id   The ID to check.
-	 * @param string $hook The hook (event name) to check.
-	 *
-	 * @return void
-	 */
-	protected function check_not_added( $id, $hook ) {
-		$this->assertFalse( _beans_get_action( $id, 'added' ) );
-		$this->assertFalse( has_action( $hook ) );
-	}
-
-	/**
-	 * Setup the original action.
-	 *
-	 * @since 1.5.0
-	 *
-	 * @param string $id Optional. Beans ID to register. Default is 'foo'.
-	 *
-	 * @return array
-	 */
-	protected function setup_original_action( $id = 'foo' ) {
-		$container = Monkey\Container::instance();
-		$action    = array(
-			'hook'     => "{$id}_hook",
-			'callback' => "callback_{$id}",
-			'priority' => 10,
-			'args'     => 1,
-		);
-
-		$this->check_not_added( $id, $action['hook'] );
-
-		// Add the original action to get us rolling.
-		beans_add_action( $id, $action['hook'], $action['callback'] );
-		$this->assertTrue( has_action( $action['hook'] ) );
-		$this->assertTrue(
-			$container->hookStorage()->isHookAdded(
-				Monkey\Hook\HookStorage::ACTIONS,
-				$action['hook'],
-				$action['callback']
-			)
-		);
-
-		return $action;
 	}
 }

--- a/tests/phpunit/unit/api/actions/beansModifyActionHook.php
+++ b/tests/phpunit/unit/api/actions/beansModifyActionHook.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Tests for beans_modify_action_hook()
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Unit\API\Actions;
+
+use Beans\Framework\Tests\Unit\Test_Case;
+use Brain\Monkey;
+
+/**
+ * Class Tests_BeansModifyActionHook
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ * @group   unit-tests
+ * @group   api
+ */
+class Tests_BeansModifyActionHook extends Test_Case {
+
+	/**
+	 * Setup test fixture.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		require_once BEANS_TESTS_LIB_DIR . 'api/actions/functions.php';
+		require_once BEANS_TESTS_LIB_DIR . 'api/utilities/functions.php';
+	}
+
+	/**
+	 * Reset the test fixture.
+	 */
+	protected function tearDown() {
+		parent::tearDown();
+
+		global $_beans_registered_actions;
+		$_beans_registered_actions = array(
+			'added'    => array(),
+			'modified' => array(),
+			'removed'  => array(),
+			'replaced' => array(),
+		);
+	}
+
+	/**
+	 * Test beans_modify_action_hook() should return false when the ID is not registered.
+	 */
+	public function test_should_return_false_when_id_not_registered() {
+		$this->assertFalse( beans_modify_action_hook( 'foo', null ) );
+		$this->assertFalse( beans_modify_action_hook( 'foo', 'foo_hook' ) );
+		$this->assertFalse( beans_modify_action_hook( 'beans', 'beans_hook' ) );
+	}
+
+	/**
+	 * Test beans_modify_action_hook() should return false when new hook is null.
+	 */
+	public function test_should_return_false_when_new_hook_is_null() {
+		$this->setup_original_action();
+		$this->assertFalse( beans_modify_action_hook( 'foo', null ) );
+
+		$this->setup_original_action( 'beans' );
+		$this->assertFalse( beans_modify_action_hook( 'beans', null ) );
+	}
+
+	/**
+	 * Test beans_modify_action_hook() should register with Beans as modified, but not with WordPress.
+	 */
+	public function test_should_register_with_beans_as_modified_but_not_with_wp() {
+		$action = array(
+			'hook' => 'my_hook',
+		);
+
+		$this->check_not_added( 'foo', $action['hook'] );
+
+		$this->assertFalse( beans_modify_action_hook( 'foo', $action['hook'] ) );
+
+		// Check that it did register with Beans.
+		$this->assertEquals( $action, _beans_get_action( 'foo', 'modified' ) );
+
+		// Check that it did not add the action.
+		$this->assertFalse( has_action( $action['hook'] ) );
+	}
+
+	/**
+	 * Test beans_modify_action_hook() should modify the registered action's hook.
+	 */
+	public function test_should_modify_the_action_hook() {
+		$container       = Monkey\Container::instance();
+		$action          = $this->setup_original_action( 'beans' );
+		$modified_action = array(
+			'hook' => 'my_hook',
+		);
+		$this->assertTrue( beans_modify_action_hook( 'beans', $modified_action['hook'] ) );
+		$this->assertEquals( $modified_action, _beans_get_action( 'beans', 'modified' ) );
+
+		// Now check that it overwrote the "hook".
+		$this->assertFalse( has_action( $action['hook'] ) );
+		$this->assertTrue( has_action( $modified_action['hook'] ) );
+		$this->assertTrue( $container->hookStorage()->isHookAdded( Monkey\Hook\HookStorage::ACTIONS, $modified_action['hook'], $action['callback'] ) );
+	}
+
+	/**
+	 * Check that is not registered first.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param string $id   The ID to check.
+	 * @param string $hook The hook (event name) to check.
+	 *
+	 * @return void
+	 */
+	protected function check_not_added( $id, $hook ) {
+		$this->assertFalse( _beans_get_action( $id, 'added' ) );
+		$this->assertFalse( has_action( $hook ) );
+	}
+
+	/**
+	 * Setup the original action.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param string $id Optional. Beans ID to register. Default is 'foo'.
+	 *
+	 * @return array
+	 */
+	protected function setup_original_action( $id = 'foo' ) {
+		$container = Monkey\Container::instance();
+		$action    = array(
+			'hook'     => "{$id}_hook",
+			'callback' => "callback_{$id}",
+			'priority' => 10,
+			'args'     => 1,
+		);
+
+		$this->check_not_added( $id, $action['hook'] );
+
+		// Add the original action to get us rolling.
+		beans_add_action( $id, $action['hook'], $action['callback'] );
+		$this->assertTrue( has_action( $action['hook'] ) );
+		$this->assertTrue(
+			$container->hookStorage()->isHookAdded(
+				Monkey\Hook\HookStorage::ACTIONS,
+				$action['hook'],
+				$action['callback']
+			)
+		);
+
+		return $action;
+	}
+}

--- a/tests/phpunit/unit/api/actions/beansModifyActionHook.php
+++ b/tests/phpunit/unit/api/actions/beansModifyActionHook.php
@@ -9,8 +9,10 @@
 
 namespace Beans\Framework\Tests\Unit\API\Actions;
 
-use Beans\Framework\Tests\Unit\Test_Case;
+use Beans\Framework\Tests\Unit\API\Actions\Includes\Actions_Test_Case;
 use Brain\Monkey;
+
+require_once __DIR__ . '/includes/class-actions-test-case.php';
 
 /**
  * Class Tests_BeansModifyActionHook
@@ -19,32 +21,7 @@ use Brain\Monkey;
  * @group   unit-tests
  * @group   api
  */
-class Tests_BeansModifyActionHook extends Test_Case {
-
-	/**
-	 * Setup test fixture.
-	 */
-	protected function setUp() {
-		parent::setUp();
-
-		require_once BEANS_TESTS_LIB_DIR . 'api/actions/functions.php';
-		require_once BEANS_TESTS_LIB_DIR . 'api/utilities/functions.php';
-	}
-
-	/**
-	 * Reset the test fixture.
-	 */
-	protected function tearDown() {
-		parent::tearDown();
-
-		global $_beans_registered_actions;
-		$_beans_registered_actions = array(
-			'added'    => array(),
-			'modified' => array(),
-			'removed'  => array(),
-			'replaced' => array(),
-		);
-	}
+class Tests_BeansModifyActionHook extends Actions_Test_Case {
 
 	/**
 	 * Test beans_modify_action_hook() should return false when the ID is not registered.
@@ -101,54 +78,5 @@ class Tests_BeansModifyActionHook extends Test_Case {
 		$this->assertFalse( has_action( $action['hook'] ) );
 		$this->assertTrue( has_action( $modified_action['hook'] ) );
 		$this->assertTrue( $container->hookStorage()->isHookAdded( Monkey\Hook\HookStorage::ACTIONS, $modified_action['hook'], $action['callback'] ) );
-	}
-
-	/**
-	 * Check that is not registered first.
-	 *
-	 * @since 1.5.0
-	 *
-	 * @param string $id   The ID to check.
-	 * @param string $hook The hook (event name) to check.
-	 *
-	 * @return void
-	 */
-	protected function check_not_added( $id, $hook ) {
-		$this->assertFalse( _beans_get_action( $id, 'added' ) );
-		$this->assertFalse( has_action( $hook ) );
-	}
-
-	/**
-	 * Setup the original action.
-	 *
-	 * @since 1.5.0
-	 *
-	 * @param string $id Optional. Beans ID to register. Default is 'foo'.
-	 *
-	 * @return array
-	 */
-	protected function setup_original_action( $id = 'foo' ) {
-		$container = Monkey\Container::instance();
-		$action    = array(
-			'hook'     => "{$id}_hook",
-			'callback' => "callback_{$id}",
-			'priority' => 10,
-			'args'     => 1,
-		);
-
-		$this->check_not_added( $id, $action['hook'] );
-
-		// Add the original action to get us rolling.
-		beans_add_action( $id, $action['hook'], $action['callback'] );
-		$this->assertTrue( has_action( $action['hook'] ) );
-		$this->assertTrue(
-			$container->hookStorage()->isHookAdded(
-				Monkey\Hook\HookStorage::ACTIONS,
-				$action['hook'],
-				$action['callback']
-			)
-		);
-
-		return $action;
 	}
 }

--- a/tests/phpunit/unit/api/actions/beansModifyActionPriority.php
+++ b/tests/phpunit/unit/api/actions/beansModifyActionPriority.php
@@ -9,8 +9,9 @@
 
 namespace Beans\Framework\Tests\Unit\API\Actions;
 
-use Beans\Framework\Tests\Unit\Test_Case;
-use Brain\Monkey;
+use Beans\Framework\Tests\Unit\API\Actions\Includes\Actions_Test_Case;
+
+require_once __DIR__ . '/includes/class-actions-test-case.php';
 
 /**
  * Class Tests_BeansModifyActionPriority
@@ -19,7 +20,7 @@ use Brain\Monkey;
  * @group   unit-tests
  * @group   api
  */
-class Tests_BeansModifyActionPriority extends Test_Case {
+class Tests_BeansModifyActionPriority extends Actions_Test_Case {
 
 	/**
 	 * Setup test fixture.
@@ -104,54 +105,5 @@ class Tests_BeansModifyActionPriority extends Test_Case {
 		$this->assertTrue( beans_modify_action_priority( 'beans', $modified_action['priority'] ) );
 		$this->assertEquals( $modified_action, _beans_get_action( 'beans', 'modified' ) );
 		$this->assertTrue( has_action( $action['hook'] ) );
-	}
-
-	/**
-	 * Check that is not registered first.
-	 *
-	 * @since 1.5.0
-	 *
-	 * @param string $id   The ID to check.
-	 * @param string $hook The hook (event name) to check.
-	 *
-	 * @return void
-	 */
-	protected function check_not_added( $id, $hook ) {
-		$this->assertFalse( _beans_get_action( $id, 'added' ) );
-		$this->assertFalse( has_action( $hook ) );
-	}
-
-	/**
-	 * Setup the original action.
-	 *
-	 * @since 1.5.0
-	 *
-	 * @param string $id Optional. Beans ID to register. Default is 'foo'.
-	 *
-	 * @return array
-	 */
-	protected function setup_original_action( $id = 'foo' ) {
-		$container = Monkey\Container::instance();
-		$action    = array(
-			'hook'     => "{$id}_hook",
-			'callback' => "callback_{$id}",
-			'priority' => 10,
-			'args'     => 1,
-		);
-
-		$this->check_not_added( $id, $action['hook'] );
-
-		// Add the original action to get us rolling.
-		beans_add_action( $id, $action['hook'], $action['callback'] );
-		$this->assertTrue( has_action( $action['hook'] ) );
-		$this->assertTrue(
-			$container->hookStorage()->isHookAdded(
-				Monkey\Hook\HookStorage::ACTIONS,
-				$action['hook'],
-				$action['callback']
-			)
-		);
-
-		return $action;
 	}
 }

--- a/tests/phpunit/unit/api/actions/beansModifyActionPriority.php
+++ b/tests/phpunit/unit/api/actions/beansModifyActionPriority.php
@@ -23,31 +23,6 @@ require_once __DIR__ . '/includes/class-actions-test-case.php';
 class Tests_BeansModifyActionPriority extends Actions_Test_Case {
 
 	/**
-	 * Setup test fixture.
-	 */
-	protected function setUp() {
-		parent::setUp();
-
-		require_once BEANS_TESTS_LIB_DIR . 'api/actions/functions.php';
-		require_once BEANS_TESTS_LIB_DIR . 'api/utilities/functions.php';
-	}
-
-	/**
-	 * Reset the test fixture.
-	 */
-	protected function tearDown() {
-		parent::tearDown();
-
-		global $_beans_registered_actions;
-		$_beans_registered_actions = array(
-			'added'    => array(),
-			'modified' => array(),
-			'removed'  => array(),
-			'replaced' => array(),
-		);
-	}
-
-	/**
 	 * Test beans_modify_action_priority() should return false when the ID is not registered.
 	 */
 	public function test_should_return_false_when_id_not_registered() {
@@ -63,7 +38,7 @@ class Tests_BeansModifyActionPriority extends Actions_Test_Case {
 	}
 
 	/**
-	 * Test beans_modify_action_callback() should return false when null is new priority.
+	 * Test beans_modify_action_callback() should return false new priority is a non-integer.
 	 */
 	public function test_should_return_false_when_priority_is_non_integer() {
 		$ids = array(

--- a/tests/phpunit/unit/api/actions/beansModifyActionPriority.php
+++ b/tests/phpunit/unit/api/actions/beansModifyActionPriority.php
@@ -32,6 +32,7 @@ class Tests_BeansModifyActionPriority extends Actions_Test_Case {
 			'baz'   => 10,
 			'beans' => '20',
 		);
+
 		foreach ( $ids as $id => $priority ) {
 			$this->assertFalse( beans_modify_action_priority( $id, $priority ) );
 		}
@@ -47,6 +48,7 @@ class Tests_BeansModifyActionPriority extends Actions_Test_Case {
 			'baz'   => false,
 			'beans' => '',
 		);
+
 		foreach ( $ids as $id => $priority ) {
 			$this->setup_original_action( $id );
 			$this->assertFalse( beans_modify_action_priority( $id, $priority ) );
@@ -63,6 +65,7 @@ class Tests_BeansModifyActionPriority extends Actions_Test_Case {
 			'baz'   => '0',
 			'beans' => '0.0',
 		);
+
 		foreach ( $ids as $id => $priority ) {
 			$this->setup_original_action( $id );
 			$this->assertTrue( beans_modify_action_priority( $id, $priority ) );

--- a/tests/phpunit/unit/api/actions/beansModifyActionPriority.php
+++ b/tests/phpunit/unit/api/actions/beansModifyActionPriority.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * Tests for beans_modify_action_priority()
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Unit\API\Actions;
+
+use Beans\Framework\Tests\Unit\Test_Case;
+use Brain\Monkey;
+
+/**
+ * Class Tests_BeansModifyActionPriority
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ * @group   unit-tests
+ * @group   api
+ */
+class Tests_BeansModifyActionPriority extends Test_Case {
+
+	/**
+	 * Setup test fixture.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		require_once BEANS_TESTS_LIB_DIR . 'api/actions/functions.php';
+		require_once BEANS_TESTS_LIB_DIR . 'api/utilities/functions.php';
+	}
+
+	/**
+	 * Reset the test fixture.
+	 */
+	protected function tearDown() {
+		parent::tearDown();
+
+		global $_beans_registered_actions;
+		$_beans_registered_actions = array(
+			'added'    => array(),
+			'modified' => array(),
+			'removed'  => array(),
+			'replaced' => array(),
+		);
+	}
+
+	/**
+	 * Test beans_modify_action_priority() should return false when the ID is not registered.
+	 */
+	public function test_should_return_false_when_id_not_registered() {
+		$ids = array(
+			'foo'   => null,
+			'bar'   => 0,
+			'baz'   => 10,
+			'beans' => '20',
+		);
+		foreach ( $ids as $id => $priority ) {
+			$this->assertFalse( beans_modify_action_priority( $id, $priority ) );
+		}
+	}
+
+	/**
+	 * Test beans_modify_action_callback() should return false when null is new priority.
+	 */
+	public function test_should_return_false_when_priority_is_non_integer() {
+		$ids = array(
+			'foo'   => null,
+			'bar'   => array( 10 ),
+			'baz'   => false,
+			'beans' => '',
+		);
+		foreach ( $ids as $id => $priority ) {
+			$this->setup_original_action( $id );
+			$this->assertFalse( beans_modify_action_priority( $id, $priority ) );
+		}
+	}
+
+	/**
+	 * Test beans_modify_action_priority() should return true when priority is zero.
+	 */
+	public function test_should_return_true_when_priority_is_zero() {
+		$ids = array(
+			'foo'   => 0,
+			'bar'   => 0.0,
+			'baz'   => '0',
+			'beans' => '0.0',
+		);
+		foreach ( $ids as $id => $priority ) {
+			$this->setup_original_action( $id );
+			$this->assertTrue( beans_modify_action_priority( $id, $priority ) );
+		}
+	}
+
+	/**
+	 * Test beans_modify_action_priority() should modify the registered action's priority.
+	 */
+	public function test_should_modify_the_action_priority() {
+		$action          = $this->setup_original_action( 'beans' );
+		$modified_action = array(
+			'priority' => 20,
+		);
+		$this->assertTrue( beans_modify_action_priority( 'beans', $modified_action['priority'] ) );
+		$this->assertEquals( $modified_action, _beans_get_action( 'beans', 'modified' ) );
+		$this->assertTrue( has_action( $action['hook'] ) );
+	}
+
+	/**
+	 * Check that is not registered first.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param string $id   The ID to check.
+	 * @param string $hook The hook (event name) to check.
+	 *
+	 * @return void
+	 */
+	protected function check_not_added( $id, $hook ) {
+		$this->assertFalse( _beans_get_action( $id, 'added' ) );
+		$this->assertFalse( has_action( $hook ) );
+	}
+
+	/**
+	 * Setup the original action.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param string $id Optional. Beans ID to register. Default is 'foo'.
+	 *
+	 * @return array
+	 */
+	protected function setup_original_action( $id = 'foo' ) {
+		$container = Monkey\Container::instance();
+		$action    = array(
+			'hook'     => "{$id}_hook",
+			'callback' => "callback_{$id}",
+			'priority' => 10,
+			'args'     => 1,
+		);
+
+		$this->check_not_added( $id, $action['hook'] );
+
+		// Add the original action to get us rolling.
+		beans_add_action( $id, $action['hook'], $action['callback'] );
+		$this->assertTrue( has_action( $action['hook'] ) );
+		$this->assertTrue(
+			$container->hookStorage()->isHookAdded(
+				Monkey\Hook\HookStorage::ACTIONS,
+				$action['hook'],
+				$action['callback']
+			)
+		);
+
+		return $action;
+	}
+}

--- a/tests/phpunit/unit/api/actions/beansModifyActionPriority.php
+++ b/tests/phpunit/unit/api/actions/beansModifyActionPriority.php
@@ -38,7 +38,7 @@ class Tests_BeansModifyActionPriority extends Actions_Test_Case {
 	}
 
 	/**
-	 * Test beans_modify_action_callback() should return false new priority is a non-integer.
+	 * Test beans_modify_action_priority() should return false new priority is a non-integer.
 	 */
 	public function test_should_return_false_when_priority_is_non_integer() {
 		$ids = array(

--- a/tests/phpunit/unit/api/actions/includes/class-actions-test-case.php
+++ b/tests/phpunit/unit/api/actions/includes/class-actions-test-case.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Tests Case for Beans' Action API unit tests.
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions\Includes
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Unit\API\Actions\Includes;
+
+use Beans\Framework\Tests\Unit\Test_Case;
+use Brain\Monkey;
+
+/**
+ * Abstract Class Actions_Test_Case
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions\Includes
+ */
+abstract class Actions_Test_Case extends Test_Case {
+
+	/**
+	 * Setup test fixture.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		require_once BEANS_TESTS_LIB_DIR . 'api/actions/functions.php';
+		require_once BEANS_TESTS_LIB_DIR . 'api/utilities/functions.php';
+	}
+
+	/**
+	 * Reset the test fixture.
+	 */
+	protected function tearDown() {
+		parent::tearDown();
+
+		global $_beans_registered_actions;
+		$_beans_registered_actions = array(
+			'added'    => array(),
+			'modified' => array(),
+			'removed'  => array(),
+			'replaced' => array(),
+		);
+	}
+
+	/**
+	 * Check that is not registered first.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param string $id   The ID to check.
+	 * @param string $hook The hook (event name) to check.
+	 *
+	 * @return void
+	 */
+	protected function check_not_added( $id, $hook ) {
+		$this->assertFalse( _beans_get_action( $id, 'added' ) );
+		$this->assertFalse( has_action( $hook ) );
+	}
+
+	/**
+	 * Setup the original action.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param string $id Optional. Beans ID to register. Default is 'foo'.
+	 *
+	 * @return array
+	 */
+	protected function setup_original_action( $id = 'foo' ) {
+		$container = Monkey\Container::instance();
+		$action    = array(
+			'hook'     => "{$id}_hook",
+			'callback' => "callback_{$id}",
+			'priority' => 10,
+			'args'     => 1,
+		);
+
+		$this->check_not_added( $id, $action['hook'] );
+
+		// Add the original action to get us rolling.
+		beans_add_action( $id, $action['hook'], $action['callback'] );
+		$this->assertTrue( has_action( $action['hook'] ) );
+		$this->assertTrue(
+			$container->hookStorage()->isHookAdded(
+				Monkey\Hook\HookStorage::ACTIONS,
+				$action['hook'],
+				$action['callback']
+			)
+		);
+
+		return $action;
+	}
+}


### PR DESCRIPTION
1. Made WPCS compliant.
2. Added unit tests.
3. Added integration tests.
4. Improved comments and documentation.
5. Bail out if no action to modify.
6. Return add_action instead of true.