### PR TITLE
Remove duplicate .gitignore entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ composer.lock
 /vendor/
 /logs/
 /reports/
-composer.lock


### PR DESCRIPTION
`composer.lock` is ignored twice.