### PR TITLE
Made "replace" actions wpcs compliant + tests

### DIFF
--- a/lib/api/actions/functions.php
+++ b/lib/api/actions/functions.php
@@ -208,122 +208,112 @@ function beans_modify_action_arguments( $id, $number_of_args ) {
 }
 
 /**
- * Replace an action.
+ * Replace one or more of the arguments for the given action, i.e. referenced by its Bean's ID.
  *
  * This function replaces an action registered using {@see beans_add_action()} or
  * {@see beans_add_smart_action()}. Each optional argument must be set to NULL to keep
- * the orginal value.
+ * the original value.
  *
- * While {@see beans_modify_action()} will keep the original value registered, this function
- * will overwrite the original action. If the action is reset using {@see beans_reset_action()},
- * the replaced values will be used.
+ * This function is not resettable as it overwrites the original action's argument(s).
+ * That means using {@see beans_reset_action()} will not restore the original action.
  *
  * @since 1.0.0
+ * @since 1.5.0 Returns false when no replacement arguments are passed.
  *
- * @param string   $id       The action ID.
- * @param string   $hook     Optional. The name of the new action to which the $callback is hooked.
- *                           Use NULL to keep the original value.
- * @param callback $callback Optional. The name of the new function you wish to be called.
- *                           Use NULL to keep the original value.
- * @param int      $priority Optional. The new priority.
- *                           Use NULL to keep the original value.
- * @param int      $args     Optional. The new number of arguments the function accepts.
- *                           Use NULL to keep the original value.
+ * @param string        $id       The action's Beans ID, a unique ID tracked within Beans for this action.
+ * @param string|null   $hook     Optional. The new action's event name to which the $callback is hooked.
+ *                                Use NULL to keep the original value.
+ * @param callable|null $callback Optional. The new callback (function or method) you wish to be called.
+ *                                Use NULL to keep the original value.
+ * @param int|null      $priority Optional. The new priority.
+ *                                Use NULL to keep the original value.
+ * @param int|null      $args     Optional. The new number of arguments the $callback accepts.
+ *                                Use NULL to keep the original value.
  *
- * @return bool Will always return true.
+ * @return bool
  */
 function beans_replace_action( $id, $hook = null, $callback = null, $priority = null, $args = null ) {
+	$action = _beans_build_action_array( $hook, $callback, $priority, $args );
 
-	$action = array(
-		'hook'     => $hook,
-		'callback' => $callback,
-		'priority' => $priority,
-		'args'     => $args,
-	);
+	// If no changes were passed in, there's nothing to modify. Bail out.
+	if ( empty( $action ) ) {
+		return false;
+	}
 
-	// Set and get the latest replaced.
-	$action = _beans_merge_action( $id, array_filter( $action ), 'replaced' );
+	// Set and get the latest "replaced" action.
+	$action = _beans_merge_action( $id, $action, 'replaced' );
 
-	// Set and get the latest added.
-	$action = _beans_merge_action( $id, $action, 'added' );
+	// Modify the action.
+	$is_modified = beans_modify_action( $id, $hook, $callback, $priority, $args );
 
-	return beans_modify_action( $id, $hook, $callback, $priority, $args );
+	// Now merge the current action with the replaced one.
+	_beans_merge_action( $id, $action, 'added' );
 
+	return $is_modified;
 }
 
 /**
- * Replace an action hook.
+ * Replace the action's event name (hook) for the given action, i.e. referenced by its Bean's ID.
  *
  * This function is a shortcut of {@see beans_replace_action()}.
  *
  * @since 1.0.0
  *
- * @param string $id   The action ID.
- * @param string $hook Optional. The name of the new action to which the $callback is hooked. Use NULL to keep
- *                     the original value.
+ * @param string $id   The action's Beans ID, a unique ID tracked within Beans for this action.
+ * @param string $hook The new action's event name to which the callback is hooked.
  *
- * @return bool Will always return true.
+ * @return bool
  */
 function beans_replace_action_hook( $id, $hook ) {
-
 	return beans_replace_action( $id, $hook );
-
 }
 
 /**
- * Replace an action callback.
+ * Replace the callback of the given action, i.e. referenced by its Bean's ID.
  *
  * This function is a shortcut of {@see beans_replace_action()}.
  *
  * @since 1.0.0
  *
- * @param string $id       The action ID.
- * @param string $callback Optional. The name of the new function you wish to be called. Use NULL to keep
- *                         the original value.
+ * @param string $id       The action's Beans ID, a unique ID tracked within Beans for this action.
+ * @param string $callback The new callback (function or method) you wish to be called.
  *
- * @return bool Will always return true.
+ * @return bool
  */
 function beans_replace_action_callback( $id, $callback ) {
-
 	return beans_replace_action( $id, null, $callback );
-
 }
 
 /**
- * Replace an action priority.
+ * Replace the priority of the given action, i.e. referenced by its Bean's ID.
  *
  * This function is a shortcut of {@see beans_replace_action()}.
  *
  * @since 1.0.0
  *
- * @param string $id       The action ID.
- * @param int    $priority Optional. The new priority. Use NULL to keep the original value.
+ * @param string $id       The action's Beans ID, a unique ID tracked within Beans for this action.
+ * @param int    $priority The new priority.
  *
- * @return bool Will always return true.
+ * @return bool
  */
 function beans_replace_action_priority( $id, $priority ) {
-
 	return beans_replace_action( $id, null, null, $priority );
-
 }
 
 /**
- * Replace an action argument.
+ * Replace the number of arguments of the given action, i.e. referenced by its Bean's ID.
  *
  * This function is a shortcut of {@see beans_replace_action()}.
  *
  * @since 1.0.0
  *
- * @param string $id   The action ID.
- * @param int    $args Optional. The new number of arguments the function accepts. Use NULL to keep the original
- *                     value.
+ * @param string $id   The action's Beans ID, a unique ID tracked within Beans for this action.
+ * @param int    $args The new number of arguments the $callback accepts.
  *
- * @return bool Will always return true.
+ * @return bool
  */
 function beans_replace_action_arguments( $id, $args ) {
-
 	return beans_replace_action( $id, null, null, null, $args );
-
 }
 
 /**

--- a/tests/phpunit/integration/api/actions/beansReplaceAction.php
+++ b/tests/phpunit/integration/api/actions/beansReplaceAction.php
@@ -1,0 +1,271 @@
+<?php
+/**
+ * Tests for beans_replace_action()
+ *
+ * @package Beans\Framework\Tests\Integration\API\Actions
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Integration\API\Actions;
+
+use Beans\Framework\Tests\Integration\API\Actions\Includes\Replace_Action_Test_Case;
+
+require_once __DIR__ . '/includes/class-replace-action-test-case.php';
+
+/**
+ * Class Tests_BeansReplaceAction
+ *
+ * @package Beans\Framework\Tests\Integration\API\Actions
+ * @group   integration-tests
+ * @group   api
+ */
+class Tests_BeansReplaceAction extends Replace_Action_Test_Case {
+
+	/**
+	 * Test beans_replace_action() should store the "replaced" action when the original action
+	 * has not yet been registered.
+	 *
+	 * Intent: We are testing to ensure Beans is "load order" agnostic.
+	 */
+	public function test_should_store_when_action_is_not_registered() {
+		$replaced_action = array(
+			'callback' => 'my_new_callback',
+		);
+
+		foreach ( array_keys( static::$test_actions ) as $beans_id ) {
+			// Test that the original action has not yet been added.
+			$this->assertFalse( _beans_get_action( $beans_id, 'added' ) );
+
+			// Now store away the "replace" hook.
+			$this->assertFalse( beans_replace_action( $beans_id, null, $replaced_action['callback'] ) );
+
+			// Check that stored.
+			$this->assertEquals( $replaced_action, _beans_get_action( $beans_id, 'modified' ) );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action() should store the "replaced" action when the original action
+	 * has not yet been registered.  Once the original action is registered, then it should be replaced.
+	 *
+	 * Intent: We are testing to ensure Beans is "load order" agnostic.
+	 */
+	public function test_should_store_and_then_replace_action() {
+		$replaced_action = array(
+			'callback' => 'my_new_callback',
+		);
+
+		// Now replace the actions.
+		foreach ( static::$test_ids as $beans_id ) {
+			beans_replace_action( $beans_id, null, $replaced_action['callback'] );
+		}
+
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $original_action ) {
+			// Check if it replaced the callback.
+			$new_action = _beans_get_action( $beans_id, 'added' );
+			$this->assertEquals( $original_action['hook'], $new_action['hook'] );
+			$this->assertEquals( $replaced_action['callback'], $new_action['callback'] );
+			$this->assertEquals( $original_action['priority'], $new_action['priority'] );
+			$this->assertEquals( $original_action['args'], $new_action['args'] );
+
+			// Check that the "replaced" action has been stored in Beans and WordPress.
+			$this->check_stored_in_beans( $beans_id, $replaced_action );
+			$this->check_registered_in_wp( $original_action['hook'], $new_action );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action() should return false when there's nothing to replace,
+	 * i.e. no arguments passed.
+	 */
+	public function test_should_return_false_when_nothing_to_replace() {
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action_config ) {
+			$this->assertFalse( beans_replace_action( $beans_id ) );
+
+			// Verify that it did not get stored in "replaced" or "modified".
+			global $_beans_registered_actions;
+			$this->assertArrayNotHasKey( $beans_id, $_beans_registered_actions['replaced'] );
+			$this->assertArrayNotHasKey( $beans_id, $_beans_registered_actions['modified'] );
+
+			// Check that the original action has not been replaced.
+			$this->assertSame( $action_config, _beans_get_action( $beans_id, 'added' ) );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action() should replace the registered action's hook.
+	 */
+	public function test_should_replace_the_action_hook() {
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action_config ) {
+			$original_action = _beans_get_action( $beans_id, 'added' );
+
+			// Make sure the callback is what we think before we get rolling.
+			$this->assertEquals( $action_config['hook'], $original_action['hook'] );
+
+			// Setup what will get stored in Beans.
+			$replaced_action = array(
+				'hook' => 'foo',
+			);
+
+			// Run the replace.
+			$this->assertTrue( beans_replace_action( $beans_id, $replaced_action['hook'] ) );
+
+			// Check if it replaced only the hook.
+			$new_action = _beans_get_action( $beans_id, 'added' );
+			$this->assertEquals( $replaced_action['hook'], $new_action['hook'] );
+			$this->assertEquals( $original_action['callback'], $new_action['callback'] );
+			$this->assertEquals( $original_action['priority'], $new_action['priority'] );
+			$this->assertEquals( $original_action['args'], $new_action['args'] );
+
+			// Check that the "replaced" action has been stored in Beans and WordPress.
+			$this->check_stored_in_beans( $beans_id, $replaced_action );
+			$this->check_registered_in_wp( $new_action['hook'], $new_action );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action() should replace the registered action's callback.
+	 */
+	public function test_should_replace_the_action_callback() {
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action_config ) {
+			$original_action = _beans_get_action( $beans_id, 'added' );
+
+			// Make sure the callback is what we think before we get rolling.
+			$this->assertEquals( $action_config['callback'], $original_action['callback'] );
+
+			// Setup what will get stored in Beans.
+			$replaced_action = array(
+				'callback' => 'foo',
+			);
+
+			// Run the replace.
+			$this->assertTrue( beans_replace_action( $beans_id, null, $replaced_action['callback'] ) );
+
+			// Check if it replaced only the callback.
+			$new_action = _beans_get_action( $beans_id, 'added' );
+			$this->assertEquals( $original_action['hook'], $new_action['hook'] );
+			$this->assertEquals( $replaced_action['callback'], $new_action['callback'] );
+			$this->assertEquals( $original_action['priority'], $new_action['priority'] );
+			$this->assertEquals( $original_action['args'], $new_action['args'] );
+
+			// Check that the "replaced" action has been stored in Beans and WordPress.
+			$this->check_stored_in_beans( $beans_id, $replaced_action );
+			$this->check_registered_in_wp( $original_action['hook'], $new_action );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action() should replace the registered action's priority level.
+	 */
+	public function test_should_replace_the_action_priority() {
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action_config ) {
+			$original_action = _beans_get_action( $beans_id, 'added' );
+
+			// Make sure the priority is what we think before we get rolling.
+			$this->assertEquals( $action_config['priority'], $original_action['priority'] );
+
+			// Setup what will get stored in Beans.
+			$replaced_action = array(
+				'priority' => 50,
+			);
+
+			// Run the replace.
+			$this->assertTrue( beans_replace_action( $beans_id, null, null, $replaced_action['priority'] ) );
+
+			// Check if it replaced only the callback.
+			$new_action = _beans_get_action( $beans_id, 'added' );
+			$this->assertEquals( $original_action['hook'], $new_action['hook'] );
+			$this->assertEquals( $original_action['callback'], $new_action['callback'] );
+			$this->assertEquals( $replaced_action['priority'], $new_action['priority'] );
+			$this->assertEquals( $original_action['args'], $new_action['args'] );
+
+			// Check that the "replaced" action has been stored in Beans and WordPress.
+			$this->check_stored_in_beans( $beans_id, $replaced_action );
+			$this->check_registered_in_wp( $original_action['hook'], $new_action );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action() should replace the registered action's number of arguments.
+	 */
+	public function test_should_replace_the_action_args() {
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action_config ) {
+			$original_action = _beans_get_action( $beans_id, 'added' );
+
+			// Make sure the args are what we think before we get rolling.
+			$this->assertEquals( $action_config['args'], $original_action['args'] );
+
+			// Setup what will get stored in Beans.
+			$replaced_action = array(
+				'args' => 5,
+			);
+
+			// Run the replace.
+			$this->assertTrue( beans_replace_action( $beans_id, null, null, null, $replaced_action['args'] ) );
+
+			// Check if it replaced only the callback.
+			$new_action = _beans_get_action( $beans_id, 'added' );
+			$this->assertEquals( $original_action['hook'], $new_action['hook'] );
+			$this->assertEquals( $original_action['callback'], $new_action['callback'] );
+			$this->assertEquals( $original_action['priority'], $new_action['priority'] );
+			$this->assertEquals( $replaced_action['args'], $new_action['args'] );
+
+			// Check that the "replaced" action has been stored in Beans and WordPress.
+			$this->check_stored_in_beans( $beans_id, $replaced_action );
+			$this->check_registered_in_wp( $original_action['hook'], $new_action );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action() should replace the original registered action.
+	 */
+	public function test_should_replace_the_action() {
+		// Setup what will get stored in Beans.
+		$replaced_action = array(
+			'hook'     => 'new_hook',
+			'callback' => 'new_callback',
+			'priority' => 99,
+			'args'     => 10,
+		);
+
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $original_action ) {
+			// Make sure the action is what we think before we get rolling.
+			$this->assertEquals( $original_action, _beans_get_action( $beans_id, 'added' ) );
+
+			// Run the replace.
+			$this->assertTrue( beans_replace_action(
+				$beans_id,
+				$replaced_action['hook'],
+				$replaced_action['callback'],
+				$replaced_action['priority'],
+				$replaced_action['args']
+			) );
+
+			// Check that the "replaced" action has been stored in Beans.
+			$this->assertSame( $replaced_action, _beans_get_action( $beans_id, 'added' ) );
+			$this->assertSame( $replaced_action, _beans_get_action( $beans_id, 'replaced' ) );
+			$this->assertSame( $replaced_action, _beans_get_action( $beans_id, 'modified' ) );
+
+			// Check that the original action was removed from WordPress.
+			$this->assertFalse( has_action( $original_action['hook'], $original_action['callback'] ) );
+
+			// Check that the new action is now registered in WordPress.
+			$this->check_registered_in_wp( $replaced_action['hook'], $replaced_action );
+		}
+	}
+}

--- a/tests/phpunit/integration/api/actions/beansReplaceActionArguments.php
+++ b/tests/phpunit/integration/api/actions/beansReplaceActionArguments.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Tests for beans_replace_action_arguments()
+ *
+ * @package Beans\Framework\Tests\Integration\API\Actions
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Integration\API\Actions;
+
+use Beans\Framework\Tests\Integration\API\Actions\Includes\Replace_Action_Test_Case;
+
+require_once __DIR__ . '/includes/class-replace-action-test-case.php';
+
+/**
+ * Class Tests_BeansReplaceActionArguments
+ *
+ * @package Beans\Framework\Tests\Integration\API\Actions
+ * @group   integration-tests
+ * @group   api
+ */
+class Tests_BeansReplaceActionArguments extends Replace_Action_Test_Case {
+
+	/**
+	 * Test beans_replace_action_arguments() should store the "replaced" action when the original action
+	 * has not yet been registered.
+	 *
+	 * Intent: We are testing to ensure Beans is "load order" agnostic.
+	 */
+	public function test_should_store_when_action_is_not_registered() {
+		$replaced_action = array(
+			'args' => 10,
+		);
+
+		// Store the "replaced" action.
+		foreach ( static::$test_ids as $beans_id ) {
+			// Test that the original action has not yet been added.
+			$this->assertFalse( _beans_get_action( $beans_id, 'added' ) );
+
+			// Now store away the "replace" args.
+			$this->assertFalse( beans_replace_action_arguments( $beans_id, $replaced_action['args'] ) );
+
+			// Check that it stored.
+			$this->assertEquals( $replaced_action, _beans_get_action( $beans_id, 'modified' ) );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action_arguments() should store the "replaced" action when the original action
+	 * has not yet been registered.  Once the original action is registered, then the arguments should be replaced.
+	 *
+	 * Intent: We are testing to ensure Beans is "load order" agnostic.
+	 */
+	public function test_should_store_and_then_replace_the_args() {
+		$replaced_action = array(
+			'args' => 10,
+		);
+
+		// Now replace the actions.
+		foreach ( static::$test_ids as $beans_id ) {
+			beans_replace_action_arguments( $beans_id, $replaced_action['args'] );
+		}
+
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $original_action ) {
+			// Check if it replaced the hook.
+			$new_action = _beans_get_action( $beans_id, 'added' );
+			$this->assertEquals( $original_action['hook'], $new_action['hook'] );
+			$this->assertEquals( $original_action['callback'], $new_action['callback'] );
+			$this->assertEquals( $original_action['priority'], $new_action['priority'] );
+			$this->assertEquals( $replaced_action['args'], $new_action['args'] );
+
+			// Check that the "replaced" action has been stored in Beans and WordPress.
+			$this->check_stored_in_beans( $beans_id, $replaced_action );
+			$this->check_registered_in_wp( $original_action['hook'], $new_action );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action_arguments() should return false when "args" is not passed.
+	 */
+	public function test_should_return_false_when_no_hook() {
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action_config ) {
+			$this->assertFalse( beans_replace_action_arguments( $beans_id, '' ) );
+
+			// Verify that it did not get stored in "replaced" or "modified".
+			global $_beans_registered_actions;
+			$this->assertArrayNotHasKey( $beans_id, $_beans_registered_actions['replaced'] );
+			$this->assertArrayNotHasKey( $beans_id, $_beans_registered_actions['modified'] );
+
+			// Check that the original action has not been replaced.
+			$this->assertSame( $action_config, _beans_get_action( $beans_id, 'added' ) );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action_arguments() should replace the registered action's args.
+	 */
+	public function test_should_replace_the_action_args() {
+		$replaced_action = array(
+			'args' => 14,
+		);
+
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action_config ) {
+			$original_action = _beans_get_action( $beans_id, 'added' );
+
+			// Make sure the args is what we think before we get rolling.
+			$this->assertEquals( $action_config['args'], $original_action['args'] );
+
+			// Run the replace.
+			$this->assertTrue( beans_replace_action_arguments( $beans_id, $replaced_action['args'] ) );
+
+			// Check if it replaced only the args.
+			$new_action = _beans_get_action( $beans_id, 'added' );
+			$this->assertEquals( $original_action['hook'], $new_action['hook'] );
+			$this->assertEquals( $original_action['callback'], $new_action['callback'] );
+			$this->assertEquals( $original_action['priority'], $new_action['priority'] );
+			$this->assertEquals( $replaced_action['args'], $new_action['args'] );
+
+			// Check that the "replaced" action has been stored in Beans and WordPress.
+			$this->check_stored_in_beans( $beans_id, $replaced_action );
+			$this->check_registered_in_wp( $new_action['hook'], $new_action );
+		}
+	}
+}

--- a/tests/phpunit/integration/api/actions/beansReplaceActionCallback.php
+++ b/tests/phpunit/integration/api/actions/beansReplaceActionCallback.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Tests for beans_replace_action_callback()
+ *
+ * @package Beans\Framework\Tests\Integration\API\Actions
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Integration\API\Actions;
+
+use Beans\Framework\Tests\Integration\API\Actions\Includes\Replace_Action_Test_Case;
+
+require_once __DIR__ . '/includes/class-replace-action-test-case.php';
+
+/**
+ * Class Tests_BeansReplaceActionCallback
+ *
+ * @package Beans\Framework\Tests\Integration\API\Actions
+ * @group   integration-tests
+ * @group   api
+ */
+class Tests_BeansReplaceActionCallback extends Replace_Action_Test_Case {
+
+	/**
+	 * Test beans_replace_action_callback() should store the "replaced" action when the original action
+	 * has not yet been registered.
+	 *
+	 * Intent: We are testing to ensure Beans is "load order" agnostic.
+	 */
+	public function test_should_store_when_action_is_not_registered() {
+		$replaced_action = array(
+			'callback' => 'my_new_callback',
+		);
+
+		foreach ( static::$test_ids as $beans_id ) {
+			// Test that the original action has not yet been added.
+			$this->assertFalse( _beans_get_action( $beans_id, 'added' ) );
+
+			// Now store away the "replace" callback.
+			$this->assertFalse( beans_replace_action_callback( $beans_id, $replaced_action['callback'] ) );
+
+			// Check that stored.
+			$this->assertEquals( $replaced_action, _beans_get_action( $beans_id, 'modified' ) );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action_callback() should store the "replaced" action when the original action
+	 * has not yet been registered.  Once the original action is registered, then the callback should be replaced.
+	 *
+	 * Intent: We are testing to ensure Beans is "load order" agnostic.
+	 */
+	public function test_should_store_and_then_replace_the_callback() {
+		$replaced_action = array(
+			'callback' => 'foo',
+		);
+
+		// Now replace the actions.
+		foreach ( static::$test_ids as $beans_id ) {
+			beans_replace_action_callback( $beans_id, $replaced_action['callback'] );
+		}
+
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $original_action ) {
+			// Check if it replaced the hook.
+			$new_action = _beans_get_action( $beans_id, 'added' );
+			$this->assertEquals( $original_action['hook'], $new_action['hook'] );
+			$this->assertEquals( $replaced_action['callback'], $new_action['callback'] );
+			$this->assertEquals( $original_action['priority'], $new_action['priority'] );
+			$this->assertEquals( $original_action['args'], $new_action['args'] );
+
+			// Check that the "replaced" action has been stored in Beans and WordPress.
+			$this->check_stored_in_beans( $beans_id, $replaced_action );
+			$this->check_registered_in_wp( $original_action['hook'], $new_action );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action_callback() should return false when no hook was passed.
+	 */
+	public function test_should_return_false_when_no_hook() {
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action_config ) {
+			$this->assertFalse( beans_replace_action_callback( $beans_id, '' ) );
+
+			// Verify that it did not get stored in "replaced" or "modified".
+			global $_beans_registered_actions;
+			$this->assertArrayNotHasKey( $beans_id, $_beans_registered_actions['replaced'] );
+			$this->assertArrayNotHasKey( $beans_id, $_beans_registered_actions['modified'] );
+
+			// Check that the original action has not been replaced.
+			$this->assertSame( $action_config, _beans_get_action( $beans_id, 'added' ) );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action_callback() should replace the registered action's callback.
+	 */
+	public function test_should_replace_the_action_callback() {
+		$replaced_action = array(
+			'callback' => 'beans_foo',
+		);
+
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action_config ) {
+			$original_action = _beans_get_action( $beans_id, 'added' );
+
+			// Make sure the callback is what we think before we get rolling.
+			$this->assertEquals( $action_config['callback'], $original_action['callback'] );
+
+			// Run the replace.
+			$this->assertTrue( beans_replace_action_callback( $beans_id, $replaced_action['callback'] ) );
+
+			// Check if it replaced only the callback.
+			$new_action = _beans_get_action( $beans_id, 'added' );
+			$this->assertEquals( $original_action['hook'], $new_action['hook'] );
+			$this->assertEquals( $replaced_action['callback'], $new_action['callback'] );
+			$this->assertEquals( $original_action['priority'], $new_action['priority'] );
+			$this->assertEquals( $original_action['args'], $new_action['args'] );
+
+			// Check that the "replaced" action has been stored in Beans and WordPress.
+			$this->check_stored_in_beans( $beans_id, $replaced_action );
+			$this->check_registered_in_wp( $new_action['hook'], $new_action );
+		}
+	}
+}

--- a/tests/phpunit/integration/api/actions/beansReplaceActionHook.php
+++ b/tests/phpunit/integration/api/actions/beansReplaceActionHook.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Tests for beans_replace_action_hook()
+ *
+ * @package Beans\Framework\Tests\Integration\API\Actions
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Integration\API\Actions;
+
+use Beans\Framework\Tests\Integration\API\Actions\Includes\Replace_Action_Test_Case;
+
+require_once __DIR__ . '/includes/class-replace-action-test-case.php';
+
+/**
+ * Class Tests_BeansReplaceActionHook
+ *
+ * @package Beans\Framework\Tests\Integration\API\Actions
+ * @group   integration-tests
+ * @group   api
+ */
+class Tests_BeansReplaceActionHook extends Replace_Action_Test_Case {
+
+	/**
+	 * Test beans_replace_action_hook() should store the "replaced" action when the original action
+	 * has not yet been registered.
+	 *
+	 * Intent: We are testing to ensure Beans is "load order" agnostic.
+	 */
+	public function test_should_store_when_action_is_not_registered() {
+		$replaced_action = array(
+			'hook' => 'my_new_hook',
+		);
+
+		foreach ( static::$test_ids as $beans_id ) {
+			// Test that the original action has not yet been added.
+			$this->assertFalse( _beans_get_action( $beans_id, 'added' ) );
+
+			// Now store away the "replace" hook.
+			$this->assertFalse( beans_replace_action_hook( $beans_id, $replaced_action['hook'] ) );
+
+			// Check that stored.
+			$this->assertEquals( $replaced_action, _beans_get_action( $beans_id, 'modified' ) );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action_hook() should store the "replaced" action when the original action
+	 * has not yet been registered.  Once the original action is registered, then the hook should be replaced.
+	 *
+	 * Intent: We are testing to ensure Beans is "load order" agnostic.
+	 */
+	public function test_should_store_and_then_replace_the_hook() {
+		$replaced_action = array(
+			'hook' => 'foo',
+		);
+
+		// Now replace the actions.
+		foreach ( static::$test_ids as $beans_id ) {
+			beans_replace_action_hook( $beans_id, $replaced_action['hook'] );
+		}
+
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $original_action ) {
+			// Check if it replaced the hook.
+			$new_action = _beans_get_action( $beans_id, 'added' );
+			$this->assertEquals( $replaced_action['hook'], $new_action['hook'] );
+			$this->assertEquals( $original_action['callback'], $new_action['callback'] );
+			$this->assertEquals( $original_action['priority'], $new_action['priority'] );
+			$this->assertEquals( $original_action['args'], $new_action['args'] );
+
+			// Check that the "replaced" action has been stored in Beans and WordPress.
+			$this->check_stored_in_beans( $beans_id, $replaced_action );
+			$this->assertFalse( has_action( $original_action['hook'], $original_action['callback'] ) );
+			$this->check_registered_in_wp( $replaced_action['hook'], $new_action );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action_hook() should return false when no hook was passed.
+	 */
+	public function test_should_return_false_when_no_hook() {
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action_config ) {
+			$this->assertFalse( beans_replace_action_hook( $beans_id, '' ) );
+
+			// Verify that it did not get stored in "replaced" or "modified".
+			global $_beans_registered_actions;
+			$this->assertArrayNotHasKey( $beans_id, $_beans_registered_actions['replaced'] );
+			$this->assertArrayNotHasKey( $beans_id, $_beans_registered_actions['modified'] );
+
+			// Check that the original action has not been replaced.
+			$this->assertSame( $action_config, _beans_get_action( $beans_id, 'added' ) );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action_hook() should replace the registered action's hook.
+	 */
+	public function test_should_replace_the_action_hook() {
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action_config ) {
+			$original_action = _beans_get_action( $beans_id, 'added' );
+
+			// Make sure the callback is what we think before we get rolling.
+			$this->assertEquals( $action_config['hook'], $original_action['hook'] );
+
+			// Setup what will get stored in Beans.
+			$replaced_action = array(
+				'hook' => 'beans_foo',
+			);
+
+			// Run the replace.
+			$this->assertTrue( beans_replace_action_hook( $beans_id, $replaced_action['hook'] ) );
+
+			// Check if it replaced only the hook.
+			$new_action = _beans_get_action( $beans_id, 'added' );
+			$this->assertEquals( $replaced_action['hook'], $new_action['hook'] );
+			$this->assertEquals( $original_action['callback'], $new_action['callback'] );
+			$this->assertEquals( $original_action['priority'], $new_action['priority'] );
+			$this->assertEquals( $original_action['args'], $new_action['args'] );
+
+			// Check that the "replaced" action has been stored in Beans and WordPress.
+			$this->check_stored_in_beans( $beans_id, $replaced_action );
+			$this->check_registered_in_wp( $new_action['hook'], $new_action );
+		}
+	}
+}

--- a/tests/phpunit/integration/api/actions/beansReplaceActionPriority.php
+++ b/tests/phpunit/integration/api/actions/beansReplaceActionPriority.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Tests for beans_replace_action_priority()
+ *
+ * @package Beans\Framework\Tests\Integration\API\Actions
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Integration\API\Actions;
+
+use Beans\Framework\Tests\Integration\API\Actions\Includes\Replace_Action_Test_Case;
+
+require_once __DIR__ . '/includes/class-replace-action-test-case.php';
+
+/**
+ * Class Tests_BeansReplaceActionPriority
+ *
+ * @package Beans\Framework\Tests\Integration\API\Actions
+ * @group   integration-tests
+ * @group   api
+ */
+class Tests_BeansReplaceActionPriority extends Replace_Action_Test_Case {
+
+	/**
+	 * Test beans_replace_action_priority() should store the "replaced" action when the original action
+	 * has not yet been registered.
+	 *
+	 * Intent: We are testing to ensure Beans is "load order" agnostic.
+	 */
+	public function test_should_store_when_action_is_not_registered() {
+		$replaced_action = array(
+			'priority' => 99,
+		);
+
+		foreach ( static::$test_ids as $beans_id ) {
+			// Test that the original action has not yet been added.
+			$this->assertFalse( _beans_get_action( $beans_id, 'added' ) );
+
+			// Now store away the "replace" priority.
+			$this->assertFalse( beans_replace_action_priority( $beans_id, $replaced_action['priority'] ) );
+
+			// Check that stored.
+			$this->assertEquals( $replaced_action, _beans_get_action( $beans_id, 'modified' ) );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action_priority() should store the "replaced" action when the original action
+	 * has not yet been registered.  Once the original action is registered, then the priority should be replaced.
+	 *
+	 * Intent: We are testing to ensure Beans is "load order" agnostic.
+	 */
+	public function test_should_store_and_then_replace_the_priority() {
+		$replaced_action = array(
+			'priority' => 10000,
+		);
+
+		// Now replace the actions.
+		foreach ( static::$test_ids as $beans_id ) {
+			beans_replace_action_priority( $beans_id, $replaced_action['priority'] );
+		}
+
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $original_action ) {
+			// Check if it replaced the hook.
+			$new_action = _beans_get_action( $beans_id, 'added' );
+			$this->assertEquals( $original_action['hook'], $new_action['hook'] );
+			$this->assertEquals( $original_action['callback'], $new_action['callback'] );
+			$this->assertEquals( $replaced_action['priority'], $new_action['priority'] );
+			$this->assertEquals( $original_action['args'], $new_action['args'] );
+
+			// Check that the "replaced" action has been stored in Beans and WordPress.
+			$this->check_stored_in_beans( $beans_id, $replaced_action );
+			$this->check_registered_in_wp( $original_action['hook'], $new_action );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action_priority() should return false when no priority is passed.
+	 */
+	public function test_should_return_false_when_no_hook() {
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action_config ) {
+			$this->assertFalse( beans_replace_action_priority( $beans_id, '' ) );
+
+			// Verify that it did not get stored in "replaced" or "modified".
+			global $_beans_registered_actions;
+			$this->assertArrayNotHasKey( $beans_id, $_beans_registered_actions['replaced'] );
+			$this->assertArrayNotHasKey( $beans_id, $_beans_registered_actions['modified'] );
+
+			// Check that the original action has not been replaced.
+			$this->assertSame( $action_config, _beans_get_action( $beans_id, 'added' ) );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action_priority() should replace the registered action's priority.
+	 */
+	public function test_should_replace_the_action_priority() {
+		$replaced_action = array(
+			'priority' => 999,
+		);
+
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action_config ) {
+			$original_action = _beans_get_action( $beans_id, 'added' );
+
+			// Make sure the priority is what we think before we get rolling.
+			$this->assertEquals( $action_config['priority'], $original_action['priority'] );
+
+			// Run the replace.
+			$this->assertTrue( beans_replace_action_priority( $beans_id, $replaced_action['priority'] ) );
+
+			// Check if it replaced only the priority.
+			$new_action = _beans_get_action( $beans_id, 'added' );
+			$this->assertEquals( $original_action['hook'], $new_action['hook'] );
+			$this->assertEquals( $original_action['callback'], $new_action['callback'] );
+			$this->assertEquals( $replaced_action['priority'], $new_action['priority'] );
+			$this->assertEquals( $original_action['args'], $new_action['args'] );
+
+			// Check that the "replaced" action has been stored in Beans and WordPress.
+			$this->check_stored_in_beans( $beans_id, $replaced_action );
+			$this->check_registered_in_wp( $new_action['hook'], $new_action );
+		}
+	}
+}

--- a/tests/phpunit/integration/api/actions/fixtures/test-actions.php
+++ b/tests/phpunit/integration/api/actions/fixtures/test-actions.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Array of test actions, which is used to test Beans Actions API against the original action configurations.
+ *
+ * @package Beans\Framework\Tests\Integration\API\Actions\Fixtures
+ *
+ * @since   1.5.0
+ */
+
+return array(
+	'beans_post_meta'          => array(
+		'hook'     => 'beans_post_header',
+		'callback' => 'beans_post_meta',
+		'priority' => 15,
+		'args'     => 1,
+	),
+	'beans_post_image'         => array(
+		'hook'     => 'beans_post_body',
+		'callback' => 'beans_post_image',
+		'priority' => 5,
+		'args'     => 1,
+	),
+	'beans_previous_post_link' => array(
+		'hook'     => 'previous_post_link',
+		'callback' => 'beans_previous_post_link',
+		'priority' => 10,
+		'args'     => 4,
+	),
+);

--- a/tests/phpunit/integration/api/actions/includes/class-actions-test-case.php
+++ b/tests/phpunit/integration/api/actions/includes/class-actions-test-case.php
@@ -19,10 +19,45 @@ use WP_UnitTestCase;
 abstract class Actions_Test_Case extends WP_UnitTestCase {
 
 	/**
+	 * When true, reset $_beans_registered_actions at tear down.
+	 *
+	 * @var bool
+	 */
+	protected $reset_beans_registry = true;
+
+	/**
+	 * An array of actions to test.
+	 *
+	 * @var array
+	 */
+	protected static $test_actions;
+
+	/**
+	 * An array of Beans' IDs for our test actions.
+	 *
+	 * @var array
+	 */
+	protected static $test_ids;
+
+	/**
+	 * Setup the test before we run the test setups.
+	 */
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
+		static::$test_actions = require dirname( __DIR__ ) . DIRECTORY_SEPARATOR . 'fixtures/test-actions.php';
+		static::$test_ids     = array_keys( static::$test_actions );
+	}
+
+	/**
 	 * Reset the test fixture.
 	 */
 	public function tearDown() {
 		parent::tearDown();
+
+		if ( false === $this->reset_beans_registry ) {
+			return;
+		}
 
 		global $_beans_registered_actions;
 		$_beans_registered_actions = array(
@@ -97,5 +132,14 @@ abstract class Actions_Test_Case extends WP_UnitTestCase {
 		$this->check_parameters_registered_in_wp( $action, false );
 
 		return $action;
+	}
+
+	/**
+	 * Create a post, load it, and force the "template redirect" to fire.
+	 */
+	protected function go_to_post() {
+		$post_id = self::factory()->post->create( array( 'post_title' => 'Hello Beans' ) );
+		$this->go_to( get_permalink( $post_id ) );
+		do_action( 'template_redirect' ); // @codingStandardsIgnoreLine
 	}
 }

--- a/tests/phpunit/integration/api/actions/includes/class-replace-action-test-case.php
+++ b/tests/phpunit/integration/api/actions/includes/class-replace-action-test-case.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Tests Case for Beans' Action API "replace action" integration tests.
+ *
+ * @package Beans\Framework\Tests\Integration\API\Actions\Includes
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Integration\API\Actions\Includes;
+
+use WP_UnitTestCase;
+
+/**
+ * Abstract Class Replace_Actions_Test_Case
+ *
+ * @package Beans\Framework\Tests\Integration\API\Actions\Includes
+ */
+abstract class Replace_Action_Test_Case extends Actions_Test_Case {
+
+	/**
+	 * Setup the test fixture.
+	 */
+	public function setUp() {
+		$this->reset_beans_registry = false;
+
+		parent::setUp();
+
+		// Just in case the original action is already registered, remove it.
+		$this->remove_original_action();
+	}
+
+	/**
+	 * Reset the test fixture.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		// Reset and restore.
+		foreach ( static::$test_actions as $beans_id => $action ) {
+			// Reset Beans.
+			_beans_unset_action( $beans_id, 'modified' );
+			_beans_unset_action( $beans_id, 'replaced' );
+			_beans_unset_action( $beans_id, 'added' );
+
+			// Restore the original action.
+			beans_add_smart_action( $action['hook'], $action['callback'], $action['priority'], $action['args'] );
+		}
+	}
+
+	/**
+	 * Store the original action and then remove it.  These steps allow us to setup an
+	 * initial test where the action is not registered.  Then when we're doing testing, we can
+	 * restore it.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @return void
+	 */
+	private function remove_original_action() {
+
+		foreach ( static::$test_actions as $beans_id => $action ) {
+			_beans_unset_action( $beans_id, 'added' );
+
+			if ( has_action( $action['hook'], $action['callback'] ) ) {
+				remove_action( $action['hook'], $action['callback'], $action['priority'], $action['args'] );
+			}
+		}
+	}
+
+	/**
+	 * Merge the action's configuration with the defaults.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param array $action The action to merge.
+	 *
+	 * @return array
+	 */
+	protected function merge_action_with_defaults( array $action ) {
+		return array_merge(
+			array(
+				'hook'     => null,
+				'callback' => null,
+				'priority' => null,
+				'args'     => null,
+			),
+			$action
+		);
+	}
+
+	/**
+	 * Check that the "replaced" action has been stored in Beans.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param string $beans_id        The Beans unique ID.
+	 * @param array  $replaced_action The "replaced" action's configuration.
+	 *
+	 * @return void
+	 */
+	protected function check_stored_in_beans( $beans_id, array $replaced_action ) {
+		$this->assertEquals( $replaced_action, _beans_get_action( $beans_id, 'replaced' ) );
+		$this->assertEquals( $replaced_action, _beans_get_action( $beans_id, 'modified' ) );
+	}
+
+	/**
+	 * Check that the "replaced" action has been stored in Beans.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param string $hook          The event's name (hook) that is registered in WordPress.
+	 * @param array  $new_action    The "new" action's configuration (after the replace).
+	 * @param bool   $remove_action When true, it removes the action automatically to clean up this test.
+	 *
+	 * @return void
+	 */
+	protected function check_registered_in_wp( $hook, array $new_action, $remove_action = true ) {
+		$this->assertTrue( has_action( $hook, $new_action['callback'] ) !== false );
+		$this->check_parameters_registered_in_wp( $new_action, $remove_action );
+	}
+
+	/**
+	 * Restore the original action after the replace.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param string $beans_id The Beans unique ID.
+	 *
+	 * @return void
+	 */
+	protected function restore_original( $beans_id ) {
+		$action = static::$test_actions[ $beans_id ];
+
+		_beans_unset_action( $beans_id, 'added' );
+
+		beans_add_smart_action( $action['hook'], $action['callback'], $action['priority'], $action['args'] );
+	}
+
+	/**
+	 * Create a post, load it, and force the "template redirect" to fire.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @return void
+	 */
+	protected function go_to_post() {
+		parent::go_to_post();
+
+		/**
+		 * Restore the actions. Why? The file loads once and initially adds the actions. But then we remove them
+		 * during our tests.
+		 */
+		foreach ( static::$test_ids as $beans_id ) {
+			$this->restore_original( $beans_id );
+		}
+	}
+}

--- a/tests/phpunit/unit/api/actions/beansReplaceAction.php
+++ b/tests/phpunit/unit/api/actions/beansReplaceAction.php
@@ -1,0 +1,272 @@
+<?php
+/**
+ * Tests for beans_replace_action()
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Unit\API\Actions;
+
+use Beans\Framework\Tests\Unit\API\Actions\Includes\Replace_Action_Test_Case;
+
+require_once __DIR__ . '/includes/class-replace-action-test-case.php';
+
+/**
+ * Class Tests_BeansReplaceAction
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ * @group   unit-tests
+ * @group   api
+ */
+class Tests_BeansReplaceAction extends Replace_Action_Test_Case {
+
+	/**
+	 * Test beans_replace_action() should store the "replaced" action when the original action
+	 * has not yet been registered.
+	 *
+	 * Intent: We are testing to ensure Beans is "load order" agnostic.
+	 */
+	public function test_should_store_when_action_is_not_registered() {
+		$replaced_action = array(
+			'callback' => 'my_new_callback',
+		);
+
+		foreach ( static::$test_ids as $beans_id ) {
+			// Test that the original action has not yet been added.
+			$this->assertFalse( _beans_get_action( $beans_id, 'added' ) );
+
+			// Now store away the "replace" hook.
+			$this->assertFalse( beans_replace_action( $beans_id, null, $replaced_action['callback'] ) );
+
+			// Check that stored.
+			$this->assertEquals( $replaced_action, _beans_get_action( $beans_id, 'modified' ) );
+			$this->assertEquals( $replaced_action, _beans_get_action( $beans_id, 'added' ) );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action() should store the "replaced" action when the original action
+	 * has not yet been registered.  Once the original action is registered, then it should be replaced.
+	 *
+	 * Intent: We are testing to ensure Beans is "load order" agnostic.
+	 */
+	public function test_should_store_and_then_replace_action() {
+		$replaced_action = array(
+			'callback' => 'my_new_callback',
+		);
+
+		// Now replace the actions.
+		foreach ( static::$test_ids as $beans_id ) {
+			beans_replace_action( $beans_id, null, $replaced_action['callback'] );
+		}
+
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $original_action ) {
+			// Check if it replaced the callback.
+			$new_action = _beans_get_action( $beans_id, 'added' );
+			$this->assertEquals( $original_action['hook'], $new_action['hook'] );
+			$this->assertEquals( $replaced_action['callback'], $new_action['callback'] );
+			$this->assertEquals( $original_action['priority'], $new_action['priority'] );
+			$this->assertEquals( $original_action['args'], $new_action['args'] );
+
+			// Check that the "replaced" action has been stored in Beans and WordPress.
+			$this->check_stored_in_beans( $beans_id, $replaced_action );
+			$this->check_registered_in_wp( $original_action['hook'], $new_action );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action() should return false when there's nothing to replace,
+	 * i.e. no arguments passed.
+	 */
+	public function test_should_return_false_when_nothing_to_replace() {
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action_config ) {
+			$this->assertFalse( beans_replace_action( $beans_id ) );
+
+			// Verify that it did not get stored in "replaced" or "modified".
+			global $_beans_registered_actions;
+			$this->assertArrayNotHasKey( $beans_id, $_beans_registered_actions['replaced'] );
+			$this->assertArrayNotHasKey( $beans_id, $_beans_registered_actions['modified'] );
+
+			// Check that the original action has not been replaced.
+			$this->assertSame( $action_config, _beans_get_action( $beans_id, 'added' ) );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action() should replace the registered action's hook.
+	 */
+	public function test_should_replace_the_action_hook() {
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action_config ) {
+			$original_action = _beans_get_action( $beans_id, 'added' );
+
+			// Make sure the callback is what we think before we get rolling.
+			$this->assertEquals( $action_config['hook'], $original_action['hook'] );
+
+			// Setup what will get stored in Beans.
+			$replaced_action = array(
+				'hook' => 'foo',
+			);
+
+			// Run the replace.
+			$this->assertTrue( beans_replace_action( $beans_id, $replaced_action['hook'] ) );
+
+			// Check if it replaced only the hook.
+			$new_action = _beans_get_action( $beans_id, 'added' );
+			$this->assertEquals( $replaced_action['hook'], $new_action['hook'] );
+			$this->assertEquals( $original_action['callback'], $new_action['callback'] );
+			$this->assertEquals( $original_action['priority'], $new_action['priority'] );
+			$this->assertEquals( $original_action['args'], $new_action['args'] );
+
+			// Check that the "replaced" action has been stored in Beans and WordPress.
+			$this->check_stored_in_beans( $beans_id, $replaced_action );
+			$this->check_registered_in_wp( $new_action['hook'], $new_action );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action() should replace the registered action's callback.
+	 */
+	public function test_should_replace_the_action_callback() {
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action_config ) {
+			$original_action = _beans_get_action( $beans_id, 'added' );
+
+			// Make sure the callback is what we think before we get rolling.
+			$this->assertEquals( $action_config['callback'], $original_action['callback'] );
+
+			// Setup what will get stored in Beans.
+			$replaced_action = array(
+				'callback' => 'foo',
+			);
+
+			// Run the replace.
+			$this->assertTrue( beans_replace_action( $beans_id, null, $replaced_action['callback'] ) );
+
+			// Check if it replaced only the callback.
+			$new_action = _beans_get_action( $beans_id, 'added' );
+			$this->assertEquals( $original_action['hook'], $new_action['hook'] );
+			$this->assertEquals( $replaced_action['callback'], $new_action['callback'] );
+			$this->assertEquals( $original_action['priority'], $new_action['priority'] );
+			$this->assertEquals( $original_action['args'], $new_action['args'] );
+
+			// Check that the "replaced" action has been stored in Beans and WordPress.
+			$this->check_stored_in_beans( $beans_id, $replaced_action );
+			$this->check_registered_in_wp( $original_action['hook'], $new_action );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action() should replace the registered action's priority level.
+	 */
+	public function test_should_replace_the_action_priority() {
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action_config ) {
+			$original_action = _beans_get_action( $beans_id, 'added' );
+
+			// Make sure the priority is what we think before we get rolling.
+			$this->assertEquals( $action_config['priority'], $original_action['priority'] );
+
+			// Setup what will get stored in Beans.
+			$replaced_action = array(
+				'priority' => 50,
+			);
+
+			// Run the replace.
+			$this->assertTrue( beans_replace_action( $beans_id, null, null, $replaced_action['priority'] ) );
+
+			// Check if it replaced only the callback.
+			$new_action = _beans_get_action( $beans_id, 'added' );
+			$this->assertEquals( $original_action['hook'], $new_action['hook'] );
+			$this->assertEquals( $original_action['callback'], $new_action['callback'] );
+			$this->assertEquals( $replaced_action['priority'], $new_action['priority'] );
+			$this->assertEquals( $original_action['args'], $new_action['args'] );
+
+			// Check that the "replaced" action has been stored in Beans and WordPress.
+			$this->check_stored_in_beans( $beans_id, $replaced_action );
+			$this->check_registered_in_wp( $original_action['hook'], $new_action );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action() should replace the registered action's number of arguments.
+	 */
+	public function test_should_replace_the_action_args() {
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action_config ) {
+			$original_action = _beans_get_action( $beans_id, 'added' );
+
+			// Make sure the args are what we think before we get rolling.
+			$this->assertEquals( $action_config['args'], $original_action['args'] );
+
+			// Setup what will get stored in Beans.
+			$replaced_action = array(
+				'args' => 5,
+			);
+
+			// Run the replace.
+			$this->assertTrue( beans_replace_action( $beans_id, null, null, null, $replaced_action['args'] ) );
+
+			// Check if it replaced only the callback.
+			$new_action = _beans_get_action( $beans_id, 'added' );
+			$this->assertEquals( $original_action['hook'], $new_action['hook'] );
+			$this->assertEquals( $original_action['callback'], $new_action['callback'] );
+			$this->assertEquals( $original_action['priority'], $new_action['priority'] );
+			$this->assertEquals( $replaced_action['args'], $new_action['args'] );
+
+			// Check that the "replaced" action has been stored in Beans and WordPress.
+			$this->check_stored_in_beans( $beans_id, $replaced_action );
+			$this->check_registered_in_wp( $original_action['hook'], $new_action );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action() should replace the original registered action.
+	 */
+	public function test_should_replace_the_action() {
+		// Setup what will get stored in Beans.
+		$replaced_action = array(
+			'hook'     => 'new_hook',
+			'callback' => 'new_callback',
+			'priority' => 99,
+			'args'     => 10,
+		);
+
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $original_action ) {
+			// Make sure the action is what we think before we get rolling.
+			$this->assertEquals( $original_action, _beans_get_action( $beans_id, 'added' ) );
+
+			// Run the replace.
+			$this->assertTrue( beans_replace_action(
+				$beans_id,
+				$replaced_action['hook'],
+				$replaced_action['callback'],
+				$replaced_action['priority'],
+				$replaced_action['args']
+			) );
+
+			// Check that the "replaced" action has been stored in Beans.
+			$this->assertSame( $replaced_action, _beans_get_action( $beans_id, 'added' ) );
+			$this->assertSame( $replaced_action, _beans_get_action( $beans_id, 'replaced' ) );
+			$this->assertSame( $replaced_action, _beans_get_action( $beans_id, 'modified' ) );
+
+			// Check that the original action was removed from WordPress.
+			$this->assertFalse( has_action( $original_action['hook'], $original_action['callback'] ) );
+
+			// Check that the new action is now registered in WordPress.
+			$this->check_registered_in_wp( $replaced_action['hook'], $replaced_action );
+		}
+	}
+}

--- a/tests/phpunit/unit/api/actions/beansReplaceActionArguments.php
+++ b/tests/phpunit/unit/api/actions/beansReplaceActionArguments.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Tests for beans_replace_action_arguments()
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Unit\API\Actions;
+
+use Beans\Framework\Tests\Unit\API\Actions\Includes\Replace_Action_Test_Case;
+
+require_once __DIR__ . '/includes/class-replace-action-test-case.php';
+
+/**
+ * Class Tests_BeansReplaceActionArguments
+ *
+ * @package Beans\Framework\Tests\Integration\API\Actions
+ * @group   unit-tests
+ * @group   api
+ */
+class Tests_BeansReplaceActionArguments extends Replace_Action_Test_Case {
+
+	/**
+	 * Test beans_replace_action_arguments() should store the "replaced" action when the original action
+	 * has not yet been registered.
+	 *
+	 * Intent: We are testing to ensure Beans is "load order" agnostic.
+	 */
+	public function test_should_store_when_action_is_not_registered() {
+		$replaced_action = array(
+			'args' => 10,
+		);
+
+		// Store the "replaced" action.
+		foreach ( array_keys( static::$test_actions ) as $beans_id ) {
+			// Test that the original action has not yet been added.
+			$this->assertFalse( _beans_get_action( $beans_id, 'added' ) );
+
+			// Now store away the "replace" args.
+			$this->assertFalse( beans_replace_action_arguments( $beans_id, $replaced_action['args'] ) );
+
+			// Check that it stored.
+			$this->assertEquals( $replaced_action, _beans_get_action( $beans_id, 'modified' ) );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action_arguments() should store the "replaced" hook when the original action
+	 * has not yet been registered.  Once the original action is registered, then the hook should be replaced.
+	 *
+	 * Intent: We are testing to ensure Beans is "load order" agnostic.
+	 */
+	public function test_should_store_and_then_replace_the_args() {
+		$replaced_action = array(
+			'args' => 10,
+		);
+
+		// Now replace the actions.
+		foreach ( static::$test_ids as $beans_id ) {
+			beans_replace_action_arguments( $beans_id, $replaced_action['args'] );
+		}
+
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $original_action ) {
+			// Check if it replaced the hook.
+			$new_action = _beans_get_action( $beans_id, 'added' );
+			$this->assertEquals( $original_action['hook'], $new_action['hook'] );
+			$this->assertEquals( $original_action['callback'], $new_action['callback'] );
+			$this->assertEquals( $original_action['priority'], $new_action['priority'] );
+			$this->assertEquals( $replaced_action['args'], $new_action['args'] );
+
+			// Check that the "replaced" action has been stored in Beans and WordPress.
+			$this->check_stored_in_beans( $beans_id, $replaced_action );
+			$this->check_registered_in_wp( $original_action['hook'], $new_action );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action_arguments() should return false when no args is passed.
+	 */
+	public function test_should_return_false_when_no_hook() {
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action_config ) {
+			$this->assertFalse( beans_replace_action_arguments( $beans_id, '' ) );
+
+			// Verify that it did not get stored in "replaced" or "modified".
+			global $_beans_registered_actions;
+			$this->assertArrayNotHasKey( $beans_id, $_beans_registered_actions['replaced'] );
+			$this->assertArrayNotHasKey( $beans_id, $_beans_registered_actions['modified'] );
+
+			// Check that the original action has not been replaced.
+			$this->assertSame( $action_config, _beans_get_action( $beans_id, 'added' ) );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action_arguments() should replace the registered action's args.
+	 */
+	public function test_should_replace_the_action_args() {
+		$replaced_action = array(
+			'args' => 14,
+		);
+
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action_config ) {
+			$original_action = _beans_get_action( $beans_id, 'added' );
+
+			// Make sure the args is what we think before we get rolling.
+			$this->assertEquals( $action_config['args'], $original_action['args'] );
+
+			// Run the replace.
+			$this->assertTrue( beans_replace_action_arguments( $beans_id, $replaced_action['args'] ) );
+
+			// Check if it replaced only the args.
+			$new_action = _beans_get_action( $beans_id, 'added' );
+			$this->assertEquals( $original_action['hook'], $new_action['hook'] );
+			$this->assertEquals( $original_action['callback'], $new_action['callback'] );
+			$this->assertEquals( $original_action['priority'], $new_action['priority'] );
+			$this->assertEquals( $replaced_action['args'], $new_action['args'] );
+
+			// Check that the "replaced" action has been stored in Beans and WordPress.
+			$this->check_stored_in_beans( $beans_id, $replaced_action );
+			$this->check_registered_in_wp( $new_action['hook'], $new_action );
+		}
+	}
+}

--- a/tests/phpunit/unit/api/actions/beansReplaceActionCallback.php
+++ b/tests/phpunit/unit/api/actions/beansReplaceActionCallback.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Tests for beans_replace_action_callback()
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Unit\API\Actions;
+
+use Beans\Framework\Tests\Unit\API\Actions\Includes\Replace_Action_Test_Case;
+
+require_once __DIR__ . '/includes/class-replace-action-test-case.php';
+
+/**
+ * Class Tests_BeansReplaceActionCallback
+ *
+ * @package Beans\Framework\Tests\Integration\API\Actions
+ * @group   unit-tests
+ * @group   api
+ */
+class Tests_BeansReplaceActionCallback extends Replace_Action_Test_Case {
+
+	/**
+	 * Test beans_replace_action_callback() should store the "replaced" action when the original action
+	 * has not yet been registered.
+	 *
+	 * Intent: We are testing to ensure Beans is "load order" agnostic.
+	 */
+	public function test_should_store_when_action_is_not_registered() {
+		$replaced_action = array(
+			'callback' => 'my_new_callback',
+		);
+
+		foreach ( array_keys( static::$test_actions ) as $beans_id ) {
+			// Test that the original action has not yet been added.
+			$this->assertFalse( _beans_get_action( $beans_id, 'added' ) );
+
+			// Now store away the "replace" callback.
+			$this->assertFalse( beans_replace_action_callback( $beans_id, $replaced_action['callback'] ) );
+
+			// Check that stored.
+			$this->assertEquals( $replaced_action, _beans_get_action( $beans_id, 'modified' ) );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action_callback() should store the "replaced" hook when the original action
+	 * has not yet been registered.  Once the original action is registered, then the hook should be replaced.
+	 *
+	 * Intent: We are testing to ensure Beans is "load order" agnostic.
+	 */
+	public function test_should_store_and_then_replace_the_callback() {
+		$replaced_action = array(
+			'callback' => 'foo',
+		);
+
+		// Now replace the actions.
+		foreach ( static::$test_ids as $beans_id ) {
+			beans_replace_action_callback( $beans_id, $replaced_action['callback'] );
+		}
+
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $original_action ) {
+			// Check if it replaced the hook.
+			$new_action = _beans_get_action( $beans_id, 'added' );
+			$this->assertEquals( $original_action['hook'], $new_action['hook'] );
+			$this->assertEquals( $replaced_action['callback'], $new_action['callback'] );
+			$this->assertEquals( $original_action['priority'], $new_action['priority'] );
+			$this->assertEquals( $original_action['args'], $new_action['args'] );
+
+			// Check that the "replaced" action has been stored in Beans and WordPress.
+			$this->check_stored_in_beans( $beans_id, $replaced_action );
+			$this->check_registered_in_wp( $original_action['hook'], $new_action );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action_callback() should return false when no hook was passed.
+	 */
+	public function test_should_return_false_when_no_hook() {
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action_config ) {
+			$this->assertFalse( beans_replace_action_callback( $beans_id, '' ) );
+
+			// Verify that it did not get stored in "replaced" or "modified".
+			global $_beans_registered_actions;
+			$this->assertArrayNotHasKey( $beans_id, $_beans_registered_actions['replaced'] );
+			$this->assertArrayNotHasKey( $beans_id, $_beans_registered_actions['modified'] );
+
+			// Check that the original action has not been replaced.
+			$this->assertSame( $action_config, _beans_get_action( $beans_id, 'added' ) );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action_callback() should replace the registered action's callback.
+	 */
+	public function test_should_replace_the_action_callback() {
+		$replaced_action = array(
+			'callback' => 'beans_foo',
+		);
+
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action_config ) {
+			$original_action = _beans_get_action( $beans_id, 'added' );
+
+			// Make sure the callback is what we think before we get rolling.
+			$this->assertEquals( $action_config['callback'], $original_action['callback'] );
+
+			// Run the replace.
+			$this->assertTrue( beans_replace_action_callback( $beans_id, $replaced_action['callback'] ) );
+
+			// Check if it replaced only the callback.
+			$new_action = _beans_get_action( $beans_id, 'added' );
+			$this->assertEquals( $original_action['hook'], $new_action['hook'] );
+			$this->assertEquals( $replaced_action['callback'], $new_action['callback'] );
+			$this->assertEquals( $original_action['priority'], $new_action['priority'] );
+			$this->assertEquals( $original_action['args'], $new_action['args'] );
+
+			// Check that the "replaced" action has been stored in Beans and WordPress.
+			$this->check_stored_in_beans( $beans_id, $replaced_action );
+			$this->check_registered_in_wp( $new_action['hook'], $new_action );
+		}
+	}
+}

--- a/tests/phpunit/unit/api/actions/beansReplaceActionHook.php
+++ b/tests/phpunit/unit/api/actions/beansReplaceActionHook.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * Tests for beans_replace_action_hook()
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Unit\API\Actions;
+
+use Beans\Framework\Tests\Unit\API\Actions\Includes\Replace_Action_Test_Case;
+
+require_once __DIR__ . '/includes/class-replace-action-test-case.php';
+
+/**
+ * Class Tests_BeansReplaceActionHook
+ *
+ * @package Beans\Framework\Tests\Integration\API\Actions
+ * @group   unit-tests
+ * @group   api
+ */
+class Tests_BeansReplaceActionHook extends Replace_Action_Test_Case {
+
+	/**
+	 * Test beans_replace_action_hook() should store the "replaced" action when the original action
+	 * has not yet been registered.
+	 *
+	 * Intent: We are testing to ensure Beans is "load order" agnostic.
+	 */
+	public function test_should_store_when_action_is_not_registered() {
+		$replaced_action = array(
+			'hook' => 'my_new_hook',
+		);
+
+		foreach ( array_keys( static::$test_actions ) as $beans_id ) {
+			// Test that the original action has not yet been added.
+			$this->assertFalse( _beans_get_action( $beans_id, 'added' ) );
+
+			// Now store away the "replace" hook.
+			$this->assertFalse( beans_replace_action_hook( $beans_id, $replaced_action['hook'] ) );
+
+			// Check that stored.
+			$this->assertEquals( $replaced_action, _beans_get_action( $beans_id, 'modified' ) );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action_hook() should store the "replaced" hook when the original action
+	 * has not yet been registered.  Once the original action is registered, then the hook should be replaced.
+	 *
+	 * Intent: We are testing to ensure Beans is "load order" agnostic.
+	 */
+	public function test_should_store_and_then_replace_the_hook() {
+		$replaced_action = array(
+			'hook' => 'foo',
+		);
+
+		// Now replace the actions.
+		foreach ( static::$test_ids as $beans_id ) {
+			beans_replace_action_hook( $beans_id, $replaced_action['hook'] );
+		}
+
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $original_action ) {
+			// Check if it replaced the hook.
+			$new_action = _beans_get_action( $beans_id, 'added' );
+			$this->assertEquals( $replaced_action['hook'], $new_action['hook'] );
+			$this->assertEquals( $original_action['callback'], $new_action['callback'] );
+			$this->assertEquals( $original_action['priority'], $new_action['priority'] );
+			$this->assertEquals( $original_action['args'], $new_action['args'] );
+
+			// Check that the "replaced" action has been stored in Beans and WordPress.
+			$this->check_stored_in_beans( $beans_id, $replaced_action );
+			$this->assertFalse( has_action( $original_action['hook'], $original_action['callback'] ) );
+			$this->check_registered_in_wp( $replaced_action['hook'], $new_action );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action_hook() should return false when no hook was passed.
+	 */
+	public function test_should_return_false_when_no_hook() {
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action_config ) {
+			$this->assertFalse( beans_replace_action_hook( $beans_id, '' ) );
+
+			// Verify that it did not get stored in "replaced" or "modified".
+			global $_beans_registered_actions;
+			$this->assertArrayNotHasKey( $beans_id, $_beans_registered_actions['replaced'] );
+			$this->assertArrayNotHasKey( $beans_id, $_beans_registered_actions['modified'] );
+
+			// Check that the original action has not been replaced.
+			$this->assertSame( $action_config, _beans_get_action( $beans_id, 'added' ) );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action_hook() should replace the registered action's hook.
+	 */
+	public function test_should_replace_the_action_hook() {
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action_config ) {
+			$original_action = _beans_get_action( $beans_id, 'added' );
+
+			// Make sure the callback is what we think before we get rolling.
+			$this->assertEquals( $action_config['hook'], $original_action['hook'] );
+
+			// Setup what will get stored in Beans.
+			$replaced_action = array(
+				'hook' => 'beans_foo',
+			);
+
+			// Run the replace.
+			$this->assertTrue( beans_replace_action_hook( $beans_id, $replaced_action['hook'] ) );
+
+			// Check if it replaced only the hook.
+			$new_action = _beans_get_action( $beans_id, 'added' );
+			$this->assertEquals( $replaced_action['hook'], $new_action['hook'] );
+			$this->assertEquals( $original_action['callback'], $new_action['callback'] );
+			$this->assertEquals( $original_action['priority'], $new_action['priority'] );
+			$this->assertEquals( $original_action['args'], $new_action['args'] );
+
+			// Check that the "replaced" action has been stored in Beans and WordPress.
+			$this->check_stored_in_beans( $beans_id, $replaced_action );
+			$this->check_registered_in_wp( $new_action['hook'], $new_action );
+		}
+	}
+}

--- a/tests/phpunit/unit/api/actions/beansReplaceActionPriority.php
+++ b/tests/phpunit/unit/api/actions/beansReplaceActionPriority.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Tests for beans_replace_action_priority()
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Unit\API\Actions;
+
+use Beans\Framework\Tests\Unit\API\Actions\Includes\Replace_Action_Test_Case;
+
+require_once __DIR__ . '/includes/class-replace-action-test-case.php';
+
+/**
+ * Class Tests_BeansReplaceActionPriority
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ * @group   unit-tests
+ * @group   api
+ */
+class Tests_BeansReplaceActionPriority extends Replace_Action_Test_Case {
+
+	/**
+	 * Test beans_replace_action_priority() should store the "replaced" action when the original action
+	 * has not yet been registered.
+	 *
+	 * Intent: We are testing to ensure Beans is "load order" agnostic.
+	 */
+	public function test_should_store_when_action_is_not_registered() {
+		$replaced_action = array(
+			'priority' => 99,
+		);
+
+		foreach ( array_keys( static::$test_actions ) as $beans_id ) {
+			// Test that the original action has not yet been added.
+			$this->assertFalse( _beans_get_action( $beans_id, 'added' ) );
+
+			// Now store away the "replace" priority.
+			$this->assertFalse( beans_replace_action_priority( $beans_id, $replaced_action['priority'] ) );
+
+			// Check that stored.
+			$this->assertEquals( $replaced_action, _beans_get_action( $beans_id, 'modified' ) );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action_priority() should store the "replaced" hook when the original action
+	 * has not yet been registered.  Once the original action is registered, then the hook should be replaced.
+	 *
+	 * Intent: We are testing to ensure Beans is "load order" agnostic.
+	 */
+	public function test_should_store_and_then_replace_the_priority() {
+		$replaced_action = array(
+			'priority' => 10000,
+		);
+
+		// Now replace the actions.
+		foreach ( static::$test_ids as $beans_id ) {
+			beans_replace_action_priority( $beans_id, $replaced_action['priority'] );
+		}
+
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $original_action ) {
+			// Check if it replaced the hook.
+			$new_action = _beans_get_action( $beans_id, 'added' );
+			$this->assertEquals( $original_action['hook'], $new_action['hook'] );
+			$this->assertEquals( $original_action['callback'], $new_action['callback'] );
+			$this->assertEquals( $replaced_action['priority'], $new_action['priority'] );
+			$this->assertEquals( $original_action['args'], $new_action['args'] );
+
+			// Check that the "replaced" action has been stored in Beans and WordPress.
+			$this->check_stored_in_beans( $beans_id, $replaced_action );
+			$this->check_registered_in_wp( $original_action['hook'], $new_action );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action_priority() should return false when no priority is passed.
+	 */
+	public function test_should_return_false_when_no_hook() {
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action_config ) {
+			$this->assertFalse( beans_replace_action_priority( $beans_id, '' ) );
+
+			// Verify that it did not get stored in "replaced" or "modified".
+			global $_beans_registered_actions;
+			$this->assertArrayNotHasKey( $beans_id, $_beans_registered_actions['replaced'] );
+			$this->assertArrayNotHasKey( $beans_id, $_beans_registered_actions['modified'] );
+
+			// Check that the original action has not been replaced.
+			$this->assertSame( $action_config, _beans_get_action( $beans_id, 'added' ) );
+		}
+	}
+
+	/**
+	 * Test beans_replace_action_priority() should replace the registered action's priority.
+	 */
+	public function test_should_replace_the_action_priority() {
+		$replaced_action = array(
+			'priority' => 999,
+		);
+
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action_config ) {
+			$original_action = _beans_get_action( $beans_id, 'added' );
+
+			// Make sure the priority is what we think before we get rolling.
+			$this->assertEquals( $action_config['priority'], $original_action['priority'] );
+
+			// Run the replace.
+			$this->assertTrue( beans_replace_action_priority( $beans_id, $replaced_action['priority'] ) );
+
+			// Check if it replaced only the priority.
+			$new_action = _beans_get_action( $beans_id, 'added' );
+			$this->assertEquals( $original_action['hook'], $new_action['hook'] );
+			$this->assertEquals( $original_action['callback'], $new_action['callback'] );
+			$this->assertEquals( $replaced_action['priority'], $new_action['priority'] );
+			$this->assertEquals( $original_action['args'], $new_action['args'] );
+
+			// Check that the "replaced" action has been stored in Beans and WordPress.
+			$this->check_stored_in_beans( $beans_id, $replaced_action );
+			$this->check_registered_in_wp( $new_action['hook'], $new_action );
+		}
+	}
+}

--- a/tests/phpunit/unit/api/actions/fixtures/test-actions.php
+++ b/tests/phpunit/unit/api/actions/fixtures/test-actions.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Array of test actions, which is used to test Beans Actions API against the original action configurations.
+ *
+ * @package Beans\Framework\Tests\Integration\API\Actions\Fixtures
+ *
+ * @since   1.5.0
+ */
+
+return array(
+	'beans_post_meta'          => array(
+		'hook'     => 'beans_post_header',
+		'callback' => 'beans_post_meta',
+		'priority' => 15,
+		'args'     => 1,
+	),
+	'beans_post_image'         => array(
+		'hook'     => 'beans_post_body',
+		'callback' => 'beans_post_image',
+		'priority' => 5,
+		'args'     => 1,
+	),
+	'beans_previous_post_link' => array(
+		'hook'     => 'previous_post_link',
+		'callback' => 'beans_previous_post_link',
+		'priority' => 10,
+		'args'     => 4,
+	),
+);

--- a/tests/phpunit/unit/api/actions/includes/class-replace-action-test-case.php
+++ b/tests/phpunit/unit/api/actions/includes/class-replace-action-test-case.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Tests Case for Beans' Action API "replace" action unit tests.
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions\Includes
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Unit\API\Actions\Includes;
+
+use Beans\Framework\Tests\Unit\Test_Case;
+use Brain\Monkey;
+
+/**
+ * Abstract Class Replace_Action_Test_Case
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions\Includes
+ */
+abstract class Replace_Action_Test_Case extends Actions_Test_Case {
+
+	/**
+	 * Check that the "replaced" action has been stored in Beans.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param string $beans_id        The Beans unique ID.
+	 * @param array  $replaced_action The "replaced" action's configuration.
+	 *
+	 * @return void
+	 */
+	protected function check_stored_in_beans( $beans_id, array $replaced_action ) {
+		$this->assertEquals( $replaced_action, _beans_get_action( $beans_id, 'replaced' ) );
+		$this->assertEquals( $replaced_action, _beans_get_action( $beans_id, 'modified' ) );
+	}
+
+	/**
+	 * Check that the "replaced" action has been stored in Beans.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param string $hook          The event's name (hook) that is registered in WordPress.
+	 * @param array  $new_action    The "new" action's configuration (after the replace).
+	 * @param bool   $remove_action When true, it removes the action automatically to clean up this test.
+	 *
+	 * @return void
+	 */
+	protected function check_registered_in_wp( $hook, array $new_action, $remove_action = true ) {
+		$this->assertTrue( has_action( $hook, $new_action['callback'] ) !== false );
+		$this->check_parameters_registered_in_wp( $new_action, $remove_action );
+	}
+}


### PR DESCRIPTION
The changes below affect the following functions:

- `beans_replace_action()`
- `beans_replace_action_hook()`
- `beans_replace_action_callback()`
- `beans_replace_action_priority()`
- `beans_replace_action_arguments()`

1. Made WPCS compliant.
2. Added integration and unit tests.
3. Used real Beans actions for test fixtures.
4. Fixed #101.
5. Improved documentation.