### PR TITLE
Made WPCS compliant. Added tests.

### DIFF
--- a/lib/api/actions/functions.php
+++ b/lib/api/actions/functions.php
@@ -322,24 +322,35 @@ function beans_replace_action_arguments( $id, $args ) {
  * This function removes an action registered using {@see beans_add_action()} or
  * {@see beans_add_smart_action()}. The original action can be re-added using {@see beans_reset_action()}.
  *
+ * This function is "load order" agnostic, meaning that you can remove an action before it's added.
+ *
  * @since 1.0.0
+ * @since 1.5.0 When no current action, sets "removed" to default configuration.
  *
- * @param string $id The action ID.
+ * @param string $id The action's Beans ID, a unique ID tracked within Beans for this action.
  *
- * @return bool Will always return true.
+ * @return bool
  */
 function beans_remove_action( $id ) {
+	$action = _beans_get_current_action( $id );
 
-	// Remove.
-	if ( $action = _beans_get_current_action( $id ) ) {
+	// If the action is not registered yet, set it to a default configuration.
+	if ( empty( $action ) ) {
+		$action = array(
+			'hook'     => null,
+			'callback' => null,
+			'priority' => null,
+			'args'     => null,
+		);
+	}
+
+	// When there is a current action, remove it.
+	if ( _beans_is_action_valid( $action ) ) {
 		remove_action( $action['hook'], $action['callback'], $action['priority'], $action['args'] );
 	}
 
-	// Register as removed.
-	_beans_set_action( $id, $action, 'removed' );
-
-	return true;
-
+	// Store as "removed".
+	return _beans_set_action( $id, $action, 'removed' );
 }
 
 /**

--- a/tests/phpunit/integration/api/actions/beansRemoveAction.php
+++ b/tests/phpunit/integration/api/actions/beansRemoveAction.php
@@ -41,13 +41,13 @@ class Tests_BeansRemoveAction extends Actions_Test_Case {
 			$this->assertFalse( _beans_get_action( $beans_id, 'added' ) );
 			$this->assertFalse( _beans_get_current_action( $beans_id ) );
 
-			// Now do the remove and test that it returns on empty action.
+			// Remove the action. Test that an empty action is returned.
 			$this->assertSame( $empty_action, beans_remove_action( $beans_id ) );
 
-			// Check that the "empty" action was stored as "removed".
+			// Check that the "empty" action is registered as "removed".
 			$this->assertSame( $empty_action, _beans_get_action( $beans_id, 'removed' ) );
 
-			// Check that the action is not registered in WordPress.
+			// Check that the original action is not registered in WordPress.
 			$this->assertFalse( has_action( $action['hook'], $action['callback'] ) );
 		}
 	}
@@ -69,7 +69,7 @@ class Tests_BeansRemoveAction extends Actions_Test_Case {
 		$this->go_to_post();
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
-			// Check if the action is stored as "added".
+			// Check that the action is registered as "added".
 			$this->assertSame( $action, _beans_get_action( $beans_id, 'added' ) );
 
 			// Check that the action is not registered in WordPress.
@@ -90,13 +90,13 @@ class Tests_BeansRemoveAction extends Actions_Test_Case {
 			// Check that the action is registered with WordPress.
 			$this->assertTrue( has_action( $action['hook'], $action['callback'] ) !== false );
 
-			// Do the remove.
+			// Remove it.
 			$this->assertSame( $action, beans_remove_action( $beans_id ) );
 
-			// Check what is stored in "removed".
+			// Check that the action is registered as "removed".
 			$this->assertSame( $action, _beans_get_action( $beans_id, 'removed' ) );
 
-			// Check that is no longer registered with WordPress, i.e. that `remove_action` did run.
+			// Check that the action is no longer registered with WordPress.
 			$this->assertFalse( has_action( $action['hook'], $action['callback'] ) );
 		}
 	}

--- a/tests/phpunit/integration/api/actions/beansRemoveAction.php
+++ b/tests/phpunit/integration/api/actions/beansRemoveAction.php
@@ -60,7 +60,7 @@ class Tests_BeansRemoveAction extends Actions_Test_Case {
 	 */
 	public function test_should_store_and_then_replace_action() {
 
-		// Replace the actions.
+		// Remove the actions.
 		foreach ( static::$test_actions as $beans_id => $action ) {
 			beans_remove_action( $beans_id );
 		}

--- a/tests/phpunit/integration/api/actions/beansRemoveAction.php
+++ b/tests/phpunit/integration/api/actions/beansRemoveAction.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Tests for beans_remove_action()
+ *
+ * @package Beans\Framework\Tests\Integration\API\Actions
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Integration\API\Actions;
+
+use Beans\Framework\Tests\Integration\API\Actions\Includes\Actions_Test_Case;
+
+require_once __DIR__ . '/includes/class-actions-test-case.php';
+
+/**
+ * Class Tests_BeansRemoveAction
+ *
+ * @package Beans\Framework\Tests\Integration\API\Actions
+ * @group   integration-tests
+ * @group   api
+ */
+class Tests_BeansRemoveAction extends Actions_Test_Case {
+
+	/**
+	 * Test beans_remove_action() should store the "removed" action when the original action
+	 * has not yet been registered.
+	 *
+	 * Intent: We are testing to ensure Beans is "load order" agnostic.
+	 */
+	public function test_should_store_when_action_is_not_registered() {
+		$empty_action = array(
+			'hook'     => null,
+			'callback' => null,
+			'priority' => null,
+			'args'     => null,
+		);
+
+		foreach ( static::$test_actions as $beans_id => $action ) {
+			// Test that the original action has not yet been added.
+			$this->assertFalse( _beans_get_action( $beans_id, 'added' ) );
+			$this->assertFalse( _beans_get_current_action( $beans_id ) );
+
+			// Now do the remove and test that it returns on empty action.
+			$this->assertSame( $empty_action, beans_remove_action( $beans_id ) );
+
+			// Check that stored.
+			$this->assertSame( $empty_action, _beans_get_action( $beans_id, 'removed' ) );
+
+			// Check that it is not registered in WordPress.
+			$this->assertFalse( has_action( $action['hook'], $action['callback'] ) );
+		}
+	}
+
+	/**
+	 * Test beans_remove_action() should store the "removed" action when the original action
+	 * has not yet been registered.  Once the original action is registered, then it should be removed.
+	 *
+	 * Intent: We are testing to ensure Beans is "load order" agnostic.
+	 */
+	public function test_should_store_and_then_replace_action() {
+
+		// Replace the actions.
+		foreach ( static::$test_actions as $beans_id => $action ) {
+			beans_remove_action( $beans_id );
+		}
+
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action ) {
+			// Check if it the action is stored as "added".
+			$this->assertSame( $action, _beans_get_action( $beans_id, 'added' ) );
+
+			// Check that it is not registered in WordPress.
+			$this->assertFalse( has_action( $action['hook'], $action['callback'] ) );
+		}
+	}
+
+	/**
+	 * Test beans_remove_action() should remove a registered action.
+	 */
+	public function test_should_remove_a_registered_action() {
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action ) {
+			// Check that the action is registered with Beans.
+			$this->assertSame( $action, _beans_get_action( $beans_id, 'added' ) );
+
+			// Check that the action is registered with WordPress.
+			$this->assertTrue( has_action( $action['hook'], $action['callback'] ) !== false );
+
+			// Do the remove.
+			$this->assertSame( $action, beans_remove_action( $beans_id ) );
+
+			// Check what is stored in "removed".
+			$this->assertSame( $action, _beans_get_action( $beans_id, 'removed' ) );
+
+			// Check that is no longer registered with WordPress, i.e. that `remove_action` did run.
+			$this->assertFalse( has_action( $action['hook'], $action['callback'] ) );
+		}
+	}
+}

--- a/tests/phpunit/integration/api/actions/beansRemoveAction.php
+++ b/tests/phpunit/integration/api/actions/beansRemoveAction.php
@@ -24,7 +24,7 @@ class Tests_BeansRemoveAction extends Actions_Test_Case {
 
 	/**
 	 * Test beans_remove_action() should store the "removed" action when the original action
-	 * has not yet been registered.
+	 * is not registered.
 	 *
 	 * Intent: We are testing to ensure Beans is "load order" agnostic.
 	 */
@@ -53,18 +53,19 @@ class Tests_BeansRemoveAction extends Actions_Test_Case {
 	}
 
 	/**
-	 * Test beans_remove_action() should store the "removed" action when the original action
-	 * has not yet been registered.  Once the original action is registered, then it should be removed.
+	 * Test beans_remove_action() should store the "removed" action before the original action is "added".
+	 * Once the original action is registered, then it should be removed.
 	 *
 	 * Intent: We are testing to ensure Beans is "load order" agnostic.
 	 */
-	public function test_should_store_and_then_replace_action() {
+	public function test_should_store_and_then_remove_action() {
 
 		// Remove the actions.
 		foreach ( static::$test_actions as $beans_id => $action ) {
 			beans_remove_action( $beans_id );
 		}
 
+		// Load the post, which runs beans_add_action for each of our test actions.
 		$this->go_to_post();
 
 		foreach ( static::$test_actions as $beans_id => $action ) {

--- a/tests/phpunit/integration/api/actions/beansReplaceAction.php
+++ b/tests/phpunit/integration/api/actions/beansReplaceAction.php
@@ -183,7 +183,7 @@ class Tests_BeansReplaceAction extends Replace_Action_Test_Case {
 			// Run the replace.
 			$this->assertTrue( beans_replace_action( $beans_id, null, null, $replaced_action['priority'] ) );
 
-			// Check if it replaced only the callback.
+			// Check if it replaced only the priority.
 			$new_action = _beans_get_action( $beans_id, 'added' );
 			$this->assertEquals( $original_action['hook'], $new_action['hook'] );
 			$this->assertEquals( $original_action['callback'], $new_action['callback'] );
@@ -216,7 +216,7 @@ class Tests_BeansReplaceAction extends Replace_Action_Test_Case {
 			// Run the replace.
 			$this->assertTrue( beans_replace_action( $beans_id, null, null, null, $replaced_action['args'] ) );
 
-			// Check if it replaced only the callback.
+			// Check if it replaced only the args.
 			$new_action = _beans_get_action( $beans_id, 'added' );
 			$this->assertEquals( $original_action['hook'], $new_action['hook'] );
 			$this->assertEquals( $original_action['callback'], $new_action['callback'] );

--- a/tests/phpunit/integration/api/actions/beansReplaceAction.php
+++ b/tests/phpunit/integration/api/actions/beansReplaceAction.php
@@ -40,7 +40,7 @@ class Tests_BeansReplaceAction extends Replace_Action_Test_Case {
 			// Now store away the "replace" hook.
 			$this->assertFalse( beans_replace_action( $beans_id, null, $replaced_action['callback'] ) );
 
-			// Check that stored.
+			// Check that it was stored as "modified".
 			$this->assertEquals( $replaced_action, _beans_get_action( $beans_id, 'modified' ) );
 		}
 	}

--- a/tests/phpunit/integration/api/actions/beansReplaceAction.php
+++ b/tests/phpunit/integration/api/actions/beansReplaceAction.php
@@ -109,7 +109,7 @@ class Tests_BeansReplaceAction extends Replace_Action_Test_Case {
 			// Make sure the callback is what we think before we get rolling.
 			$this->assertEquals( $action_config['hook'], $original_action['hook'] );
 
-			// Setup what will get stored in Beans.
+			// Set up what will get stored in Beans.
 			$replaced_action = array(
 				'hook' => 'foo',
 			);
@@ -142,7 +142,7 @@ class Tests_BeansReplaceAction extends Replace_Action_Test_Case {
 			// Make sure the callback is what we think before we get rolling.
 			$this->assertEquals( $action_config['callback'], $original_action['callback'] );
 
-			// Setup what will get stored in Beans.
+			// Set up what will get stored in Beans.
 			$replaced_action = array(
 				'callback' => 'foo',
 			);
@@ -175,7 +175,7 @@ class Tests_BeansReplaceAction extends Replace_Action_Test_Case {
 			// Make sure the priority is what we think before we get rolling.
 			$this->assertEquals( $action_config['priority'], $original_action['priority'] );
 
-			// Setup what will get stored in Beans.
+			// Set up what will get stored in Beans.
 			$replaced_action = array(
 				'priority' => 50,
 			);
@@ -208,7 +208,7 @@ class Tests_BeansReplaceAction extends Replace_Action_Test_Case {
 			// Make sure the args are what we think before we get rolling.
 			$this->assertEquals( $action_config['args'], $original_action['args'] );
 
-			// Setup what will get stored in Beans.
+			// Set up what will get stored in Beans.
 			$replaced_action = array(
 				'args' => 5,
 			);
@@ -233,7 +233,7 @@ class Tests_BeansReplaceAction extends Replace_Action_Test_Case {
 	 * Test beans_replace_action() should replace the original registered action.
 	 */
 	public function test_should_replace_the_action() {
-		// Setup what will get stored in Beans.
+		// Set up what will get stored in Beans.
 		$replaced_action = array(
 			'hook'     => 'new_hook',
 			'callback' => 'new_callback',

--- a/tests/phpunit/integration/api/actions/beansReplaceActionArguments.php
+++ b/tests/phpunit/integration/api/actions/beansReplaceActionArguments.php
@@ -65,7 +65,7 @@ class Tests_BeansReplaceActionArguments extends Replace_Action_Test_Case {
 		$this->go_to_post();
 
 		foreach ( static::$test_actions as $beans_id => $original_action ) {
-			// Check if it replaced the hook.
+			// Check if it replaced the args.
 			$new_action = _beans_get_action( $beans_id, 'added' );
 			$this->assertEquals( $original_action['hook'], $new_action['hook'] );
 			$this->assertEquals( $original_action['callback'], $new_action['callback'] );
@@ -81,7 +81,7 @@ class Tests_BeansReplaceActionArguments extends Replace_Action_Test_Case {
 	/**
 	 * Test beans_replace_action_arguments() should return false when "args" is not passed.
 	 */
-	public function test_should_return_false_when_no_hook() {
+	public function test_should_return_false_when_no_args() {
 		$this->go_to_post();
 
 		foreach ( static::$test_actions as $beans_id => $action_config ) {

--- a/tests/phpunit/integration/api/actions/beansReplaceActionArguments.php
+++ b/tests/phpunit/integration/api/actions/beansReplaceActionArguments.php
@@ -41,7 +41,7 @@ class Tests_BeansReplaceActionArguments extends Replace_Action_Test_Case {
 			// Now store away the "replace" args.
 			$this->assertFalse( beans_replace_action_arguments( $beans_id, $replaced_action['args'] ) );
 
-			// Check that it stored.
+			// Check that it was stored as "modified".
 			$this->assertEquals( $replaced_action, _beans_get_action( $beans_id, 'modified' ) );
 		}
 	}

--- a/tests/phpunit/integration/api/actions/beansReplaceActionCallback.php
+++ b/tests/phpunit/integration/api/actions/beansReplaceActionCallback.php
@@ -40,7 +40,7 @@ class Tests_BeansReplaceActionCallback extends Replace_Action_Test_Case {
 			// Now store away the "replace" callback.
 			$this->assertFalse( beans_replace_action_callback( $beans_id, $replaced_action['callback'] ) );
 
-			// Check that stored.
+			// Check that it was stored as "modified".
 			$this->assertEquals( $replaced_action, _beans_get_action( $beans_id, 'modified' ) );
 		}
 	}

--- a/tests/phpunit/integration/api/actions/beansReplaceActionHook.php
+++ b/tests/phpunit/integration/api/actions/beansReplaceActionHook.php
@@ -40,7 +40,7 @@ class Tests_BeansReplaceActionHook extends Replace_Action_Test_Case {
 			// Now store away the "replace" hook.
 			$this->assertFalse( beans_replace_action_hook( $beans_id, $replaced_action['hook'] ) );
 
-			// Check that stored.
+			// Check that it was stored as "modified".
 			$this->assertEquals( $replaced_action, _beans_get_action( $beans_id, 'modified' ) );
 		}
 	}

--- a/tests/phpunit/integration/api/actions/beansReplaceActionHook.php
+++ b/tests/phpunit/integration/api/actions/beansReplaceActionHook.php
@@ -109,7 +109,7 @@ class Tests_BeansReplaceActionHook extends Replace_Action_Test_Case {
 			// Make sure the callback is what we think before we get rolling.
 			$this->assertEquals( $action_config['hook'], $original_action['hook'] );
 
-			// Setup what will get stored in Beans.
+			// Set up what will get stored in Beans.
 			$replaced_action = array(
 				'hook' => 'beans_foo',
 			);

--- a/tests/phpunit/integration/api/actions/beansReplaceActionPriority.php
+++ b/tests/phpunit/integration/api/actions/beansReplaceActionPriority.php
@@ -40,7 +40,7 @@ class Tests_BeansReplaceActionPriority extends Replace_Action_Test_Case {
 			// Now store away the "replace" priority.
 			$this->assertFalse( beans_replace_action_priority( $beans_id, $replaced_action['priority'] ) );
 
-			// Check that stored.
+			// Check that it was stored as "modified".
 			$this->assertEquals( $replaced_action, _beans_get_action( $beans_id, 'modified' ) );
 		}
 	}

--- a/tests/phpunit/integration/api/actions/beansResetAction.php
+++ b/tests/phpunit/integration/api/actions/beansResetAction.php
@@ -23,80 +23,491 @@ require_once __DIR__ . '/includes/class-actions-test-case.php';
 class Tests_BeansResetAction extends Actions_Test_Case {
 
 	/**
-	 * Test beans_remove_action() should store the "removed" action when the original action
-	 * has not yet been registered.
-	 *
-	 * Intent: We are testing to ensure Beans is "load order" agnostic.
+	 * Test beans_reset_action() should return false when the action is not registered.
 	 */
-	public function test_should_store_when_action_is_not_registered() {
-		$empty_action = array(
-			'hook'     => null,
-			'callback' => null,
-			'priority' => null,
-			'args'     => null,
+	public function test_should_return_false_when_no_action() {
+
+		foreach ( static::$test_actions as $beans_id => $action ) {
+			$this->assertFalse( beans_reset_action( $beans_id ) );
+		}
+	}
+
+	/**
+	 * Test beans_reset_action() should reset the original action after it was "removed" via beans_remove_action().
+	 */
+	public function test_should_reset_after_remove() {
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action ) {
+			// Check that the action is registered before we start.
+			$this->assertSame( $action, _beans_get_action( $beans_id, 'added' ) );
+			$this->assertTrue( has_action( $action['hook'], $action['callback'] ) !== false );
+
+			// Now remove it.
+			beans_remove_action( $beans_id );
+
+			// Check that it did get removed.
+			$this->assertSame( $action, _beans_get_action( $beans_id, 'removed' ) );
+			$this->assertFalse( has_action( $action['hook'], $action['callback'] ) );
+
+			// Let's reset the action.
+			$this->assertSame( $action, beans_reset_action( $beans_id ) );
+
+			// Check that it was reset.
+			$this->assertFalse( _beans_get_action( $beans_id, 'removed' ) );
+			$this->check_the_action( $beans_id, $action );
+		}
+	}
+
+	/**
+	 * Test beans_reset_action() should reset the original action's hook after it was "modified".
+	 */
+	public function test_should_reset_after_modifying_the_hook() {
+		$modified_action = array(
+			'hook' => 'foo',
+		);
+
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action ) {
+			// Check that the action is registered before we start.
+			$this->assertSame( $action, _beans_get_action( $beans_id, 'added' ) );
+			$this->assertTrue( has_action( $action['hook'], $action['callback'] ) !== false );
+
+			// Now modify the hook.
+			beans_modify_action_hook( $beans_id, $modified_action['hook'] );
+
+			// Check that the hook was modified.
+			$this->assertSame( $modified_action, _beans_get_action( $beans_id, 'modified' ) );
+			$this->assertFalse( has_action( $action['hook'], $action['callback'] ) );
+			$this->assertTrue( has_action( $modified_action['hook'], $action['callback'] ) !== false );
+
+			// Let's reset the action.
+			$this->assertSame( $action, beans_reset_action( $beans_id ) );
+
+			// Check that it was reset.
+			$this->assertFalse( _beans_get_action( $beans_id, 'modified' ) );
+			$this->check_the_action( $beans_id, $action );
+		}
+	}
+
+	/**
+	 * Test beans_reset_action() should reset the original action's callback after it was "modified".
+	 */
+	public function test_should_reset_after_modifying_the_callback() {
+		global $wp_filter;
+
+		$modified_action = array(
+			'callback' => 'my_callback',
+		);
+
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action ) {
+			// Test the original callback.
+			$this->assertTrue( has_action( $action['hook'], $action['callback'] ) !== false );
+
+			// Grab what's registered in WordPress.
+			$action_in_wp = $wp_filter[ $action['hook'] ]->callbacks[ $action['priority'] ];
+
+			// Now modify the callback.
+			beans_modify_action_callback( $beans_id, $modified_action['callback'] );
+
+			// Check that it did get modified.
+			$this->assertSame( $modified_action, _beans_get_action( $beans_id, 'modified' ) );
+			$this->assertEquals( $action['callback'], $action_in_wp[ $action['callback'] ]['function'] );
+
+			// Let's reset the action.
+			$this->assertSame( $action, beans_reset_action( $beans_id ) );
+
+			// Check that it was reset.
+			$this->assertFalse( _beans_get_action( $beans_id, 'modified' ) );
+			$this->check_the_action( $beans_id, $action );
+		}
+	}
+
+	/**
+	 * Test beans_reset_action() should reset the original action's priority after it was "modified".
+	 */
+	public function test_should_reset_after_modifying_the_priority() {
+		global $wp_filter;
+
+		$modified_action = array(
+			'priority' => 9999,
+		);
+
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action ) {
+			// Test the original priority.
+			$this->assertEquals(
+				$action['callback'],
+				$wp_filter[ $action['hook'] ]->callbacks[ $action['priority'] ][ $action['callback'] ]['function']
+			);
+
+			// Now modify the priority.
+			beans_modify_action_priority( $beans_id, $modified_action['priority'] );
+
+			// Check that the priority was modified.
+			$this->assertSame( $modified_action, _beans_get_action( $beans_id, 'modified' ) );
+			$this->assertEquals(
+				$action['callback'],
+				$wp_filter[ $action['hook'] ]->callbacks[ $modified_action['priority'] ][ $action['callback'] ]['function']
+			);
+
+			// Let's reset the action.
+			$this->assertSame( $action, beans_reset_action( $beans_id ) );
+
+			// Check that it was reset.
+			$this->assertFalse( _beans_get_action( $beans_id, 'modified' ) );
+			$this->check_the_action( $beans_id, $action );
+		}
+	}
+
+	/**
+	 * Test beans_reset_action() should reset the original action's args after it was "modified".
+	 */
+	public function test_should_reset_after_modifying_the_args() {
+		global $wp_filter;
+
+		$modified_action = array(
+			'args' => 14,
+		);
+
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action ) {
+			// Test the original number of arguments.
+			$this->assertEquals(
+				$action['args'],
+				$wp_filter[ $action['hook'] ]->callbacks[ $action['priority'] ][ $action['callback'] ]['accepted_args']
+			);
+
+			// Now modify the number of arguments.
+			beans_modify_action_arguments( $beans_id, $modified_action['args'] );
+
+			// Check that the number of arguments was modified.
+			$this->assertSame( $modified_action, _beans_get_action( $beans_id, 'modified' ) );
+			$this->assertEquals(
+				$modified_action['args'],
+				$wp_filter[ $action['hook'] ]->callbacks[ $action['priority'] ][ $action['callback'] ]['accepted_args']
+			);
+
+			// Let's reset the action.
+			$this->assertSame( $action, beans_reset_action( $beans_id ) );
+
+			// Check that it was reset.
+			$this->assertFalse( _beans_get_action( $beans_id, 'modified' ) );
+			$this->check_the_action( $beans_id, $action );
+		}
+	}
+
+	/**
+	 * Test beans_reset_action() should reset the original action's callback and args after they were "modified".
+	 */
+	public function test_should_reset_after_modifying_callback_and_args() {
+		global $wp_filter;
+
+		$this->go_to_post();
+
+		$modified_action = array(
+			'callback' => 'my_callback',
+			'args'     => 14,
 		);
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
-			// Test that the original action has not yet been added.
-			$this->assertFalse( _beans_get_action( $beans_id, 'added' ) );
-			$this->assertFalse( _beans_get_current_action( $beans_id ) );
+			// Test the action before we start.
+			$this->check_the_action( $beans_id, $action );
 
-			// Now do the remove and test that it returns on empty action.
-			$this->assertSame( $empty_action, beans_remove_action( $beans_id ) );
+			// Modify the action.
+			beans_modify_action( $beans_id, null, $modified_action['callback'], null, $modified_action['args'] );
 
-			// Check that stored.
-			$this->assertSame( $empty_action, _beans_get_action( $beans_id, 'removed' ) );
-
-			// Check that it is not registered in WordPress.
+			// Check that it did get modified.
+			$this->assertSame( $modified_action, _beans_get_action( $beans_id, 'modified' ) );
 			$this->assertFalse( has_action( $action['hook'], $action['callback'] ) );
+			$this->assertTrue( has_action( $action['hook'], $modified_action['callback'] ) !== false );
+			$this->assertEquals(
+				array(
+					'function'      => $modified_action['callback'],
+					'accepted_args' => $modified_action['args'],
+				),
+				$wp_filter[ $action['hook'] ]->callbacks[ $action['priority'] ][ $modified_action['callback'] ]
+			);
+
+			// Let's reset the action.
+			$this->assertSame( $action, beans_reset_action( $beans_id ) );
+
+			// Check that it was reset.
+			$this->assertFalse( _beans_get_action( $beans_id, 'modified' ) );
+			$this->check_the_action( $beans_id, $action );
 		}
 	}
 
 	/**
-	 * Test beans_remove_action() should store the "removed" action when the original action
-	 * has not yet been registered.  Once the original action is registered, then it should be removed.
+	 * Test beans_reset_action() should reset the original action's priority and args after they were "modified".
+	 */
+	public function test_should_reset_after_modifying_priority_and_args() {
+		global $wp_filter;
+
+		$this->go_to_post();
+
+		$modified_action = array(
+			'priority' => 79,
+			'args'     => 14,
+		);
+
+		foreach ( static::$test_actions as $beans_id => $action ) {
+			// Test the action before we start.
+			$this->check_the_action( $beans_id, $action );
+
+			// Now modify the action.
+			beans_modify_action( $beans_id, null, null, $modified_action['priority'], $modified_action['args'] );
+
+			// Check that it did get modified.
+			$this->assertSame( $modified_action, _beans_get_action( $beans_id, 'modified' ) );
+			$this->assertEquals(
+				array(
+					'function'      => $action['callback'],
+					'accepted_args' => $modified_action['args'],
+				),
+				$wp_filter[ $action['hook'] ]->callbacks[ $modified_action['priority'] ][ $action['callback'] ]
+			);
+
+			// Let's reset the action.
+			$this->assertSame( $action, beans_reset_action( $beans_id ) );
+
+			// Check that it was reset.
+			$this->assertFalse( _beans_get_action( $beans_id, 'modified' ) );
+			$this->check_the_action( $beans_id, $action );
+		}
+	}
+
+	/**
+	 * Test beans_reset_action() should reset the original action's callback and priority after they were "modified".
+	 */
+	public function test_should_reset_after_modifying_callback_and_priority() {
+		global $wp_filter;
+
+		$this->go_to_post();
+
+		$modified_action = array(
+			'callback' => 'foo',
+			'priority' => 39,
+		);
+
+		foreach ( static::$test_actions as $beans_id => $action ) {
+			// Test the action before we start.
+			$this->check_the_action( $beans_id, $action );
+
+			// Now modify the action.
+			beans_modify_action( $beans_id, null, $modified_action['callback'], $modified_action['priority'] );
+
+			// Check that it did get modified.
+			$this->assertSame( $modified_action, _beans_get_action( $beans_id, 'modified' ) );
+			$this->assertEquals(
+				array(
+					'function'      => $modified_action['callback'],
+					'accepted_args' => $action['args'],
+				),
+				$wp_filter[ $action['hook'] ]->callbacks[ $modified_action['priority'] ][ $modified_action['callback'] ]
+			);
+
+			// Let's reset the action.
+			$this->assertSame( $action, beans_reset_action( $beans_id ) );
+
+			// Check that it was reset.
+			$this->assertFalse( _beans_get_action( $beans_id, 'modified' ) );
+			$this->check_the_action( $beans_id, $action );
+		}
+	}
+
+	/**
+	 * Test beans_reset_action() should reset the original action's callback, priority, and args after they were
+	 * "modified".
+	 */
+	public function test_should_reset_after_modifying_all_but_hook() {
+		global $wp_filter;
+
+		$this->go_to_post();
+
+		$modified_action = array(
+			'callback' => 'foo',
+			'priority' => 39,
+			'args'     => 24,
+		);
+
+		foreach ( static::$test_actions as $beans_id => $action ) {
+			// Test the action before we start.
+			$this->check_the_action( $beans_id, $action );
+
+			// Now modify the action.
+			beans_modify_action( $beans_id, null, $modified_action['callback'], $modified_action['priority'], $modified_action['args'] );
+
+			// Check that it did get modified.
+			$this->assertSame( $modified_action, _beans_get_action( $beans_id, 'modified' ) );
+			$this->assertEquals(
+				array(
+					'function'      => $modified_action['callback'],
+					'accepted_args' => $modified_action['args'],
+				),
+				$wp_filter[ $action['hook'] ]->callbacks[ $modified_action['priority'] ][ $modified_action['callback'] ]
+			);
+
+			// Let's reset the action.
+			$this->assertSame( $action, beans_reset_action( $beans_id ) );
+
+			// Check that it was reset.
+			$this->assertFalse( _beans_get_action( $beans_id, 'modified' ) );
+			$this->check_the_action( $beans_id, $action );
+		}
+	}
+
+	/**
+	 * Test beans_reset_action() should not reset after replacing the action's hook.
 	 *
-	 * Intent: We are testing to ensure Beans is "load order" agnostic.
+	 * Why? "Replace" overwrites and is not resettable.
 	 */
-	public function test_should_store_and_then_replace_action() {
-
-		// Replace the actions.
-		foreach ( static::$test_actions as $beans_id => $action ) {
-			beans_remove_action( $beans_id );
-		}
+	public function test_should_not_reset_after_replacing_hook() {
+		$hook = 'foo';
 
 		$this->go_to_post();
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
-			// Check if the action is stored as "added".
-			$this->assertSame( $action, _beans_get_action( $beans_id, 'added' ) );
-
-			// Check that the action is not registered in WordPress.
-			$this->assertFalse( has_action( $action['hook'], $action['callback'] ) );
-		}
-	}
-
-	/**
-	 * Test beans_remove_action() should remove a registered action.
-	 */
-	public function test_should_remove_a_registered_action() {
-		$this->go_to_post();
-
-		foreach ( static::$test_actions as $beans_id => $action ) {
-			// Check that the action is registered with Beans.
-			$this->assertSame( $action, _beans_get_action( $beans_id, 'added' ) );
-
-			// Check that the action is registered with WordPress.
+			// Test the action before we start.
 			$this->assertTrue( has_action( $action['hook'], $action['callback'] ) !== false );
 
-			// Do the remove.
-			$this->assertSame( $action, beans_remove_action( $beans_id ) );
+			// Run the replace.
+			beans_replace_action_hook( $beans_id, $hook );
 
-			// Check what is stored in "removed".
-			$this->assertSame( $action, _beans_get_action( $beans_id, 'removed' ) );
+			// Let's try to reset the action.
+			$this->assertSame( $hook, beans_reset_action( $beans_id )['hook'] );
 
-			// Check that is no longer registered with WordPress, i.e. that `remove_action` did run.
+			// Check that it was not reset.
 			$this->assertFalse( has_action( $action['hook'], $action['callback'] ) );
+			$this->assertTrue( has_action( $hook, $action['callback'] ) !== false );
 		}
+	}
+
+	/**
+	 * Test beans_reset_action() should not reset after replacing the action's callback.
+	 *
+	 * Why? "Replace" overwrites and is not resettable.
+	 */
+	public function test_should_not_reset_after_replacing_callback() {
+		$callback = 'foo_cb';
+
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action ) {
+			// Test the action before we start.
+			$this->assertTrue( has_action( $action['hook'], $action['callback'] ) !== false );
+
+			// Run the replace.
+			beans_replace_action_callback( $beans_id, $callback );
+
+			// Let's try to reset the action.
+			$this->assertSame( $callback, beans_reset_action( $beans_id )['callback'] );
+
+			// Check that it was not reset.
+			$this->assertFalse( has_action( $action['hook'], $action['callback'] ) );
+			$this->assertTrue( has_action( $action['hook'], $callback ) !== false );
+		}
+	}
+
+	/**
+	 * Test beans_reset_action() should not reset after replacing the action's priority.
+	 *
+	 * Why? "Replace" overwrites and is not resettable.
+	 */
+	public function test_should_not_reset_after_replacing_priority() {
+		global $wp_filter;
+
+		$priority = 17;
+
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action ) {
+			// Test the action before we start.
+			$this->assertEquals(
+				array(
+					'function'      => $action['callback'],
+					'accepted_args' => $action['args'],
+				),
+				$wp_filter[ $action['hook'] ]->callbacks[ $action['priority'] ][ $action['callback'] ]
+			);
+
+			// Run the replace.
+			beans_replace_action_priority( $beans_id, $priority );
+
+			// Let's try to reset the action.
+			$this->assertSame( $priority, beans_reset_action( $beans_id )['priority'] );
+
+			// Check that it was not reset.
+			$this->assertEquals(
+				array(
+					'function'      => $action['callback'],
+					'accepted_args' => $action['args'],
+				),
+				$wp_filter[ $action['hook'] ]->callbacks[ $priority ][ $action['callback'] ]
+			);
+		}
+	}
+
+	/**
+	 * Test beans_reset_action() should not reset after replacing the action's args.
+	 *
+	 * Why? "Replace" overwrites and is not resettable.
+	 */
+	public function test_should_not_reset_after_replacing_args() {
+		global $wp_filter;
+
+		$args = 29;
+
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action ) {
+			// Test the action before we start.
+			$this->assertEquals(
+				$action['args'],
+				$wp_filter[ $action['hook'] ]->callbacks[ $action['priority'] ][ $action['callback'] ]['accepted_args']
+			);
+
+			// Run the replace.
+			beans_replace_action_arguments( $beans_id, $args );
+
+			// Let's try to reset the action.
+			$this->assertSame( $args, beans_reset_action( $beans_id )['args'] );
+
+			// Check that it was not reset.
+			$this->assertEquals(
+				$args,
+				$wp_filter[ $action['hook'] ]->callbacks[ $action['priority'] ][ $action['callback'] ]['accepted_args']
+			);
+		}
+	}
+
+	/**
+	 * Check that the action was reset.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param string $beans_id The action's Beans ID, a unique ID tracked within Beans for this action.
+	 * @param array  $action   The action to check.
+	 *
+	 * @return void
+	 */
+	protected function check_the_action( $beans_id, array $action ) {
+		global $wp_filter;
+
+		$this->assertSame( $action, _beans_get_action( $beans_id, 'added' ) );
+		$this->assertTrue( has_action( $action['hook'], $action['callback'] ) !== false );
+
+		$this->assertEquals(
+			array(
+				'function'      => $action['callback'],
+				'accepted_args' => $action['args'],
+			),
+			$wp_filter[ $action['hook'] ]->callbacks[ $action['priority'] ][ $action['callback'] ]
+		);
 	}
 }

--- a/tests/phpunit/integration/api/actions/beansResetAction.php
+++ b/tests/phpunit/integration/api/actions/beansResetAction.php
@@ -39,21 +39,21 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 		$this->go_to_post();
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
-			// Check that the action is registered before we start.
+			// Before we start, check that the action is registered.
 			$this->assertSame( $action, _beans_get_action( $beans_id, 'added' ) );
 			$this->assertTrue( has_action( $action['hook'], $action['callback'] ) !== false );
 
-			// Now remove it.
+			// Remove it.
 			beans_remove_action( $beans_id );
 
-			// Check that it did get removed.
+			// Check that the action did get removed.
 			$this->assertSame( $action, _beans_get_action( $beans_id, 'removed' ) );
 			$this->assertFalse( has_action( $action['hook'], $action['callback'] ) );
 
 			// Let's reset the action.
 			$this->assertSame( $action, beans_reset_action( $beans_id ) );
 
-			// Check that it was reset.
+			// Check that the action was reset.
 			$this->assertFalse( _beans_get_action( $beans_id, 'removed' ) );
 			$this->check_the_action( $beans_id, $action );
 		}
@@ -70,7 +70,7 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 		$this->go_to_post();
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
-			// Check that the action is registered before we start.
+			// Before we start, check that the action is registered.
 			$this->assertSame( $action, _beans_get_action( $beans_id, 'added' ) );
 			$this->assertTrue( has_action( $action['hook'], $action['callback'] ) !== false );
 
@@ -85,7 +85,7 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 			// Let's reset the action.
 			$this->assertSame( $action, beans_reset_action( $beans_id ) );
 
-			// Check that it was reset.
+			// Check that the action was reset.
 			$this->assertFalse( _beans_get_action( $beans_id, 'modified' ) );
 			$this->check_the_action( $beans_id, $action );
 		}
@@ -104,23 +104,23 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 		$this->go_to_post();
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
-			// Test the original callback.
+			// Before we start, check that the action is registered.
 			$this->assertTrue( has_action( $action['hook'], $action['callback'] ) !== false );
 
 			// Grab what's registered in WordPress.
 			$action_in_wp = $wp_filter[ $action['hook'] ]->callbacks[ $action['priority'] ];
 
-			// Now modify the callback.
+			// Modify the callback.
 			beans_modify_action_callback( $beans_id, $modified_action['callback'] );
 
-			// Check that it did get modified.
+			// Check that the action's callback was modified.
 			$this->assertSame( $modified_action, _beans_get_action( $beans_id, 'modified' ) );
 			$this->assertEquals( $action['callback'], $action_in_wp[ $action['callback'] ]['function'] );
 
 			// Let's reset the action.
 			$this->assertSame( $action, beans_reset_action( $beans_id ) );
 
-			// Check that it was reset.
+			// Check that the action was reset.
 			$this->assertFalse( _beans_get_action( $beans_id, 'modified' ) );
 			$this->check_the_action( $beans_id, $action );
 		}
@@ -139,13 +139,13 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 		$this->go_to_post();
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
-			// Test the original priority.
+			// Before we start, do a hard check to ensure the original priority is registered.
 			$this->assertEquals(
 				$action['callback'],
 				$wp_filter[ $action['hook'] ]->callbacks[ $action['priority'] ][ $action['callback'] ]['function']
 			);
 
-			// Now modify the priority.
+			// Modify the priority.
 			beans_modify_action_priority( $beans_id, $modified_action['priority'] );
 
 			// Check that the priority was modified.
@@ -158,7 +158,7 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 			// Let's reset the action.
 			$this->assertSame( $action, beans_reset_action( $beans_id ) );
 
-			// Check that it was reset.
+			// Check that the action was reset.
 			$this->assertFalse( _beans_get_action( $beans_id, 'modified' ) );
 			$this->check_the_action( $beans_id, $action );
 		}
@@ -177,13 +177,13 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 		$this->go_to_post();
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
-			// Test the original number of arguments.
+			// Before we start, do a hard check to ensure the original number of args is registered.
 			$this->assertEquals(
 				$action['args'],
 				$wp_filter[ $action['hook'] ]->callbacks[ $action['priority'] ][ $action['callback'] ]['accepted_args']
 			);
 
-			// Now modify the number of arguments.
+			// Modify the number of arguments.
 			beans_modify_action_arguments( $beans_id, $modified_action['args'] );
 
 			// Check that the number of arguments was modified.
@@ -196,7 +196,7 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 			// Let's reset the action.
 			$this->assertSame( $action, beans_reset_action( $beans_id ) );
 
-			// Check that it was reset.
+			// Check that the action was reset.
 			$this->assertFalse( _beans_get_action( $beans_id, 'modified' ) );
 			$this->check_the_action( $beans_id, $action );
 		}
@@ -216,13 +216,13 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 		);
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
-			// Test the action before we start.
+			// Before we start, check that the action is registered.
 			$this->check_the_action( $beans_id, $action );
 
 			// Modify the action.
 			beans_modify_action( $beans_id, null, $modified_action['callback'], null, $modified_action['args'] );
 
-			// Check that it did get modified.
+			// Check that the action was modified.
 			$this->assertSame( $modified_action, _beans_get_action( $beans_id, 'modified' ) );
 			$this->assertFalse( has_action( $action['hook'], $action['callback'] ) );
 			$this->assertTrue( has_action( $action['hook'], $modified_action['callback'] ) !== false );
@@ -237,7 +237,7 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 			// Let's reset the action.
 			$this->assertSame( $action, beans_reset_action( $beans_id ) );
 
-			// Check that it was reset.
+			// Check that the action was reset.
 			$this->assertFalse( _beans_get_action( $beans_id, 'modified' ) );
 			$this->check_the_action( $beans_id, $action );
 		}
@@ -257,13 +257,13 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 		);
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
-			// Test the action before we start.
+			// Before we start, check that the action is registered.
 			$this->check_the_action( $beans_id, $action );
 
-			// Now modify the action.
+			// Modify the action.
 			beans_modify_action( $beans_id, null, null, $modified_action['priority'], $modified_action['args'] );
 
-			// Check that it did get modified.
+			// Check that the action was modified.
 			$this->assertSame( $modified_action, _beans_get_action( $beans_id, 'modified' ) );
 			$this->assertEquals(
 				array(
@@ -276,7 +276,7 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 			// Let's reset the action.
 			$this->assertSame( $action, beans_reset_action( $beans_id ) );
 
-			// Check that it was reset.
+			// Check that the action was reset.
 			$this->assertFalse( _beans_get_action( $beans_id, 'modified' ) );
 			$this->check_the_action( $beans_id, $action );
 		}
@@ -296,13 +296,13 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 		);
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
-			// Test the action before we start.
+			// Before we start, check that the action is registered.
 			$this->check_the_action( $beans_id, $action );
 
-			// Now modify the action.
+			// Modify the action.
 			beans_modify_action( $beans_id, null, $modified_action['callback'], $modified_action['priority'] );
 
-			// Check that it did get modified.
+			// Check that the action was modified.
 			$this->assertSame( $modified_action, _beans_get_action( $beans_id, 'modified' ) );
 			$this->assertEquals(
 				array(
@@ -315,7 +315,7 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 			// Let's reset the action.
 			$this->assertSame( $action, beans_reset_action( $beans_id ) );
 
-			// Check that it was reset.
+			// Check that the action was reset.
 			$this->assertFalse( _beans_get_action( $beans_id, 'modified' ) );
 			$this->check_the_action( $beans_id, $action );
 		}
@@ -337,13 +337,13 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 		);
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
-			// Test the action before we start.
+			// Before we start, check that the action is registered.
 			$this->check_the_action( $beans_id, $action );
 
-			// Now modify the action.
+			// Modify the action.
 			beans_modify_action( $beans_id, null, $modified_action['callback'], $modified_action['priority'], $modified_action['args'] );
 
-			// Check that it did get modified.
+			// Check that the action was modified.
 			$this->assertSame( $modified_action, _beans_get_action( $beans_id, 'modified' ) );
 			$this->assertEquals(
 				array(
@@ -356,7 +356,7 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 			// Let's reset the action.
 			$this->assertSame( $action, beans_reset_action( $beans_id ) );
 
-			// Check that it was reset.
+			// Check that the action was reset.
 			$this->assertFalse( _beans_get_action( $beans_id, 'modified' ) );
 			$this->check_the_action( $beans_id, $action );
 		}
@@ -373,7 +373,7 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 		$this->go_to_post();
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
-			// Test the action before we start.
+			// Before we start, check that the action is registered.
 			$this->assertTrue( has_action( $action['hook'], $action['callback'] ) !== false );
 
 			// Run the replace.
@@ -382,7 +382,7 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 			// Let's try to reset the action.
 			$this->assertSame( $hook, beans_reset_action( $beans_id )['hook'] );
 
-			// Check that it was not reset.
+			// Check that the action was not reset.
 			$this->assertFalse( has_action( $action['hook'], $action['callback'] ) );
 			$this->assertTrue( has_action( $hook, $action['callback'] ) !== false );
 		}
@@ -399,7 +399,7 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 		$this->go_to_post();
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
-			// Test the action before we start.
+			// Before we start, check that the action is registered.
 			$this->assertTrue( has_action( $action['hook'], $action['callback'] ) !== false );
 
 			// Run the replace.
@@ -408,7 +408,7 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 			// Let's try to reset the action.
 			$this->assertSame( $callback, beans_reset_action( $beans_id )['callback'] );
 
-			// Check that it was not reset.
+			// Check that the action was not reset.
 			$this->assertFalse( has_action( $action['hook'], $action['callback'] ) );
 			$this->assertTrue( has_action( $action['hook'], $callback ) !== false );
 		}
@@ -427,7 +427,7 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 		$this->go_to_post();
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
-			// Test the action before we start.
+			// Before we start, do a hard check to ensure the original priority is registered.
 			$this->assertEquals(
 				array(
 					'function'      => $action['callback'],
@@ -442,7 +442,7 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 			// Let's try to reset the action.
 			$this->assertSame( $priority, beans_reset_action( $beans_id )['priority'] );
 
-			// Check that it was not reset.
+			// Check that the action was not reset.
 			$this->assertEquals(
 				array(
 					'function'      => $action['callback'],
@@ -466,7 +466,7 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 		$this->go_to_post();
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
-			// Test the action before we start.
+			// Before we start, do a hard check to ensure the original number of args is registered.
 			$this->assertEquals(
 				$action['args'],
 				$wp_filter[ $action['hook'] ]->callbacks[ $action['priority'] ][ $action['callback'] ]['accepted_args']
@@ -478,7 +478,7 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 			// Let's try to reset the action.
 			$this->assertSame( $args, beans_reset_action( $beans_id )['args'] );
 
-			// Check that it was not reset.
+			// Check that the action was not reset.
 			$this->assertEquals(
 				$args,
 				$wp_filter[ $action['hook'] ]->callbacks[ $action['priority'] ][ $action['callback'] ]['accepted_args']

--- a/tests/phpunit/integration/api/actions/beansResetAction.php
+++ b/tests/phpunit/integration/api/actions/beansResetAction.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests for beans_remove_action()
+ * Tests for beans_reset_action()
  *
  * @package Beans\Framework\Tests\Integration\API\Actions
  *
@@ -14,13 +14,13 @@ use Beans\Framework\Tests\Integration\API\Actions\Includes\Actions_Test_Case;
 require_once __DIR__ . '/includes/class-actions-test-case.php';
 
 /**
- * Class Tests_BeansRemoveAction
+ * Class Tests_BeansResetAction
  *
  * @package Beans\Framework\Tests\Integration\API\Actions
  * @group   integration-tests
  * @group   api
  */
-class Tests_BeansRemoveAction extends Actions_Test_Case {
+class Tests_BeansResetAction extends Actions_Test_Case {
 
 	/**
 	 * Test beans_remove_action() should store the "removed" action when the original action
@@ -44,10 +44,10 @@ class Tests_BeansRemoveAction extends Actions_Test_Case {
 			// Now do the remove and test that it returns on empty action.
 			$this->assertSame( $empty_action, beans_remove_action( $beans_id ) );
 
-			// Check that the "empty" action was stored as "removed".
+			// Check that stored.
 			$this->assertSame( $empty_action, _beans_get_action( $beans_id, 'removed' ) );
 
-			// Check that the action is not registered in WordPress.
+			// Check that it is not registered in WordPress.
 			$this->assertFalse( has_action( $action['hook'], $action['callback'] ) );
 		}
 	}

--- a/tests/phpunit/integration/api/actions/includes/class-actions-test-case.php
+++ b/tests/phpunit/integration/api/actions/includes/class-actions-test-case.php
@@ -69,6 +69,23 @@ abstract class Actions_Test_Case extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Restore the original action.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param string $beans_id The Beans unique ID.
+	 *
+	 * @return void
+	 */
+	protected function restore_original( $beans_id ) {
+		$action = static::$test_actions[ $beans_id ];
+
+		_beans_unset_action( $beans_id, 'added' );
+
+		beans_add_action( $beans_id, $action['hook'], $action['callback'], $action['priority'], $action['args'] );
+	}
+
+	/**
 	 * Check that it is not registered first.
 	 *
 	 * @since 1.5.0
@@ -135,9 +152,22 @@ abstract class Actions_Test_Case extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Create a post, load it, and force the "template redirect" to fire.
+	 * Simulate going to the post and loading in the template and fragments.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @return void
 	 */
 	protected function go_to_post() {
+
+		/**
+		 * Restore the actions. Why? The file loads once and initially adds the actions. But then we remove them
+		 * during our tests.
+		 */
+		foreach ( static::$test_ids as $beans_id ) {
+			$this->restore_original( $beans_id );
+		}
+
 		$post_id = self::factory()->post->create( array( 'post_title' => 'Hello Beans' ) );
 		$this->go_to( get_permalink( $post_id ) );
 		do_action( 'template_redirect' ); // @codingStandardsIgnoreLine

--- a/tests/phpunit/integration/api/actions/includes/class-actions-test-case.php
+++ b/tests/phpunit/integration/api/actions/includes/class-actions-test-case.php
@@ -40,13 +40,36 @@ abstract class Actions_Test_Case extends WP_UnitTestCase {
 	protected static $test_ids;
 
 	/**
-	 * Setup the test before we run the test setups.
+	 * Set up the test before we run the test setups.
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
 
 		static::$test_actions = require dirname( __DIR__ ) . DIRECTORY_SEPARATOR . 'fixtures/test-actions.php';
 		static::$test_ids     = array_keys( static::$test_actions );
+	}
+
+	/**
+	 * Tear down the test before we exit this class.
+	 */
+	public static function tearDownAfterClass() {
+		parent::tearDownAfterClass();
+
+		global $_beans_registered_actions;
+		$_beans_registered_actions = array(
+			'added'    => array(),
+			'modified' => array(),
+			'removed'  => array(),
+			'replaced' => array(),
+		);
+
+		// Remove the test actions.
+		foreach ( static::$test_actions as $beans_id => $action ) {
+			remove_action( $action['hook'], $action['callback'], $action['priority'] );
+		}
+
+		static::$test_actions = null;
+		static::$test_ids     = null;
 	}
 
 	/**

--- a/tests/phpunit/integration/api/actions/includes/class-replace-action-test-case.php
+++ b/tests/phpunit/integration/api/actions/includes/class-replace-action-test-case.php
@@ -19,7 +19,7 @@ use WP_UnitTestCase;
 abstract class Replace_Action_Test_Case extends Actions_Test_Case {
 
 	/**
-	 * Setup the test fixture.
+	 * Set up the test fixture.
 	 */
 	public function setUp() {
 		$this->reset_beans_registry = false;
@@ -49,7 +49,7 @@ abstract class Replace_Action_Test_Case extends Actions_Test_Case {
 	}
 
 	/**
-	 * Store the original action and then remove it.  These steps allow us to setup an
+	 * Store the original action and then remove it.  These steps allow us to set up an
 	 * initial test where the action is not registered.  Then when we're doing testing, we can
 	 * restore it.
 	 *
@@ -105,7 +105,7 @@ abstract class Replace_Action_Test_Case extends Actions_Test_Case {
 	}
 
 	/**
-	 * Check that the "replaced" action has been stored in Beans.
+	 * Check that the "replaced" action has been registered in WordPress.
 	 *
 	 * @since 1.5.0
 	 *

--- a/tests/phpunit/integration/api/actions/includes/class-replace-action-test-case.php
+++ b/tests/phpunit/integration/api/actions/includes/class-replace-action-test-case.php
@@ -119,40 +119,4 @@ abstract class Replace_Action_Test_Case extends Actions_Test_Case {
 		$this->assertTrue( has_action( $hook, $new_action['callback'] ) !== false );
 		$this->check_parameters_registered_in_wp( $new_action, $remove_action );
 	}
-
-	/**
-	 * Restore the original action after the replace.
-	 *
-	 * @since 1.5.0
-	 *
-	 * @param string $beans_id The Beans unique ID.
-	 *
-	 * @return void
-	 */
-	protected function restore_original( $beans_id ) {
-		$action = static::$test_actions[ $beans_id ];
-
-		_beans_unset_action( $beans_id, 'added' );
-
-		beans_add_smart_action( $action['hook'], $action['callback'], $action['priority'], $action['args'] );
-	}
-
-	/**
-	 * Create a post, load it, and force the "template redirect" to fire.
-	 *
-	 * @since 1.5.0
-	 *
-	 * @return void
-	 */
-	protected function go_to_post() {
-		parent::go_to_post();
-
-		/**
-		 * Restore the actions. Why? The file loads once and initially adds the actions. But then we remove them
-		 * during our tests.
-		 */
-		foreach ( static::$test_ids as $beans_id ) {
-			$this->restore_original( $beans_id );
-		}
-	}
 }

--- a/tests/phpunit/unit/api/actions/beansRemoveAction.php
+++ b/tests/phpunit/unit/api/actions/beansRemoveAction.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Tests for beans_remove_action()
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Unit\API\Actions;
+
+use Beans\Framework\Tests\Unit\API\Actions\Includes\Replace_Action_Test_Case;
+
+require_once __DIR__ . '/includes/class-replace-action-test-case.php';
+
+/**
+ * Class Tests_BeansRemoveAction
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ * @group   unit-tests
+ * @group   api
+ */
+class Tests_BeansRemoveAction extends Replace_Action_Test_Case {
+
+	/**
+	 * Test beans_remove_action() should store the "removed" action when the original action
+	 * has not yet been registered.
+	 *
+	 * Intent: We are testing to ensure Beans is "load order" agnostic.
+	 */
+	public function test_should_store_when_action_is_not_registered() {
+		$empty_action = array(
+			'hook'     => null,
+			'callback' => null,
+			'priority' => null,
+			'args'     => null,
+		);
+
+		foreach ( static::$test_actions as $beans_id => $action ) {
+			// Test that the original action has not yet been added.
+			$this->assertFalse( _beans_get_action( $beans_id, 'added' ) );
+			$this->assertFalse( _beans_get_current_action( $beans_id ) );
+
+			// Now do the remove and test that it returns on empty action.
+			$this->assertSame( $empty_action, beans_remove_action( $beans_id ) );
+
+			// Check that stored.
+			$this->assertSame( $empty_action, _beans_get_action( $beans_id, 'removed' ) );
+
+			// Check that it is not registered in WordPress.
+			$this->assertFalse( has_action( $action['hook'], $action['callback'] ) );
+		}
+	}
+
+	/**
+	 * Test beans_remove_action() should store the "removed" action when the original action
+	 * has not yet been registered.  Once the original action is registered, then it should be removed.
+	 *
+	 * Intent: We are testing to ensure Beans is "load order" agnostic.
+	 */
+	public function test_should_store_and_then_replace_action() {
+
+		// Replace the actions.
+		foreach ( static::$test_actions as $beans_id => $action ) {
+			beans_remove_action( $beans_id );
+		}
+
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action ) {
+			// Check if it the action is stored as "added".
+			$this->assertSame( $action, _beans_get_action( $beans_id, 'added' ) );
+
+			// Check that it is not registered in WordPress.
+			$this->assertFalse( has_action( $action['hook'], $action['callback'] ) );
+		}
+	}
+
+	/**
+	 * Test beans_remove_action() should remove a registered action.
+	 */
+	public function test_should_remove_a_registered_action() {
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action ) {
+			// Check that the action is registered with Beans.
+			$this->assertSame( $action, _beans_get_action( $beans_id, 'added' ) );
+
+			// Check that the action is registered with WordPress.
+			$this->assertTrue( has_action( $action['hook'], $action['callback'] ) !== false );
+
+			// Do the remove.
+			$this->assertSame( $action, beans_remove_action( $beans_id ) );
+
+			// Check what is stored in "removed".
+			$this->assertSame( $action, _beans_get_action( $beans_id, 'removed' ) );
+
+			// Check that is no longer registered with WordPress, i.e. that `remove_action` did run.
+			$this->assertFalse( has_action( $action['hook'], $action['callback'] ) );
+		}
+	}
+}

--- a/tests/phpunit/unit/api/actions/beansRemoveAction.php
+++ b/tests/phpunit/unit/api/actions/beansRemoveAction.php
@@ -23,8 +23,7 @@ require_once __DIR__ . '/includes/class-replace-action-test-case.php';
 class Tests_BeansRemoveAction extends Replace_Action_Test_Case {
 
 	/**
-	 * Test beans_remove_action() should store the "removed" action when the original action
-	 * has not yet been registered.
+	 * Test beans_remove_action() should store the "removed" action before the original action is "added".
 	 *
 	 * Intent: We are testing to ensure Beans is "load order" agnostic.
 	 */
@@ -53,18 +52,19 @@ class Tests_BeansRemoveAction extends Replace_Action_Test_Case {
 	}
 
 	/**
-	 * Test beans_remove_action() should store the "removed" action when the original action
-	 * has not yet been registered.  Once the original action is registered, then it should be removed.
+	 * Test beans_remove_action() should store the "removed" action before the original action is "added".
+	 * Once the original action is registered, then it should be removed.
 	 *
 	 * Intent: We are testing to ensure Beans is "load order" agnostic.
 	 */
-	public function test_should_store_and_then_replace_action() {
+	public function test_should_store_and_then_remove_action() {
 
 		// Remove the actions.
 		foreach ( static::$test_actions as $beans_id => $action ) {
 			beans_remove_action( $beans_id );
 		}
 
+		// Load the post, which runs beans_add_action for each of our test actions.
 		$this->go_to_post();
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
@@ -77,9 +77,9 @@ class Tests_BeansRemoveAction extends Replace_Action_Test_Case {
 	}
 
 	/**
-	 * Test beans_remove_action() should remove a registered action.
+	 * Test beans_remove_action() should remove the registered action.
 	 */
-	public function test_should_remove_a_registered_action() {
+	public function test_should_remove_registered_action() {
 		$this->go_to_post();
 
 		foreach ( static::$test_actions as $beans_id => $action ) {

--- a/tests/phpunit/unit/api/actions/beansRemoveAction.php
+++ b/tests/phpunit/unit/api/actions/beansRemoveAction.php
@@ -60,7 +60,7 @@ class Tests_BeansRemoveAction extends Replace_Action_Test_Case {
 	 */
 	public function test_should_store_and_then_replace_action() {
 
-		// Replace the actions.
+		// Remove the actions.
 		foreach ( static::$test_actions as $beans_id => $action ) {
 			beans_remove_action( $beans_id );
 		}

--- a/tests/phpunit/unit/api/actions/beansRemoveAction.php
+++ b/tests/phpunit/unit/api/actions/beansRemoveAction.php
@@ -40,13 +40,13 @@ class Tests_BeansRemoveAction extends Replace_Action_Test_Case {
 			$this->assertFalse( _beans_get_action( $beans_id, 'added' ) );
 			$this->assertFalse( _beans_get_current_action( $beans_id ) );
 
-			// Now do the remove and test that it returns on empty action.
+			// Remove the action. Test that an empty action is returned.
 			$this->assertSame( $empty_action, beans_remove_action( $beans_id ) );
 
-			// Check that stored.
+			// Check that the "empty" action is registered as "removed".
 			$this->assertSame( $empty_action, _beans_get_action( $beans_id, 'removed' ) );
 
-			// Check that it is not registered in WordPress.
+			// Check that the original action is not registered in WordPress.
 			$this->assertFalse( has_action( $action['hook'], $action['callback'] ) );
 		}
 	}
@@ -68,10 +68,10 @@ class Tests_BeansRemoveAction extends Replace_Action_Test_Case {
 		$this->go_to_post();
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
-			// Check if it the action is stored as "added".
+			// Check that the action is registered as "added".
 			$this->assertSame( $action, _beans_get_action( $beans_id, 'added' ) );
 
-			// Check that it is not registered in WordPress.
+			// Check that the action is not registered in WordPress.
 			$this->assertFalse( has_action( $action['hook'], $action['callback'] ) );
 		}
 	}
@@ -89,13 +89,13 @@ class Tests_BeansRemoveAction extends Replace_Action_Test_Case {
 			// Check that the action is registered with WordPress.
 			$this->assertTrue( has_action( $action['hook'], $action['callback'] ) !== false );
 
-			// Do the remove.
+			// Remove it.
 			$this->assertSame( $action, beans_remove_action( $beans_id ) );
 
-			// Check what is stored in "removed".
+			// Check that the action is registered as "removed".
 			$this->assertSame( $action, _beans_get_action( $beans_id, 'removed' ) );
 
-			// Check that is no longer registered with WordPress, i.e. that `remove_action` did run.
+			// Check that the action is no longer registered with WordPress.
 			$this->assertFalse( has_action( $action['hook'], $action['callback'] ) );
 		}
 	}

--- a/tests/phpunit/unit/api/actions/beansReplaceAction.php
+++ b/tests/phpunit/unit/api/actions/beansReplaceAction.php
@@ -184,7 +184,7 @@ class Tests_BeansReplaceAction extends Replace_Action_Test_Case {
 			// Run the replace.
 			$this->assertTrue( beans_replace_action( $beans_id, null, null, $replaced_action['priority'] ) );
 
-			// Check if it replaced only the callback.
+			// Check if it replaced only the priority.
 			$new_action = _beans_get_action( $beans_id, 'added' );
 			$this->assertEquals( $original_action['hook'], $new_action['hook'] );
 			$this->assertEquals( $original_action['callback'], $new_action['callback'] );
@@ -217,7 +217,7 @@ class Tests_BeansReplaceAction extends Replace_Action_Test_Case {
 			// Run the replace.
 			$this->assertTrue( beans_replace_action( $beans_id, null, null, null, $replaced_action['args'] ) );
 
-			// Check if it replaced only the callback.
+			// Check if it replaced only the args.
 			$new_action = _beans_get_action( $beans_id, 'added' );
 			$this->assertEquals( $original_action['hook'], $new_action['hook'] );
 			$this->assertEquals( $original_action['callback'], $new_action['callback'] );

--- a/tests/phpunit/unit/api/actions/beansReplaceAction.php
+++ b/tests/phpunit/unit/api/actions/beansReplaceAction.php
@@ -40,7 +40,7 @@ class Tests_BeansReplaceAction extends Replace_Action_Test_Case {
 			// Now store away the "replace" hook.
 			$this->assertFalse( beans_replace_action( $beans_id, null, $replaced_action['callback'] ) );
 
-			// Check that stored.
+			// Check that it was stored as "modified" and "added".
 			$this->assertEquals( $replaced_action, _beans_get_action( $beans_id, 'modified' ) );
 			$this->assertEquals( $replaced_action, _beans_get_action( $beans_id, 'added' ) );
 		}

--- a/tests/phpunit/unit/api/actions/beansReplaceAction.php
+++ b/tests/phpunit/unit/api/actions/beansReplaceAction.php
@@ -110,7 +110,7 @@ class Tests_BeansReplaceAction extends Replace_Action_Test_Case {
 			// Make sure the callback is what we think before we get rolling.
 			$this->assertEquals( $action_config['hook'], $original_action['hook'] );
 
-			// Setup what will get stored in Beans.
+			// Set up what will get stored in Beans.
 			$replaced_action = array(
 				'hook' => 'foo',
 			);
@@ -143,7 +143,7 @@ class Tests_BeansReplaceAction extends Replace_Action_Test_Case {
 			// Make sure the callback is what we think before we get rolling.
 			$this->assertEquals( $action_config['callback'], $original_action['callback'] );
 
-			// Setup what will get stored in Beans.
+			// Set up what will get stored in Beans.
 			$replaced_action = array(
 				'callback' => 'foo',
 			);
@@ -176,7 +176,7 @@ class Tests_BeansReplaceAction extends Replace_Action_Test_Case {
 			// Make sure the priority is what we think before we get rolling.
 			$this->assertEquals( $action_config['priority'], $original_action['priority'] );
 
-			// Setup what will get stored in Beans.
+			// Set up what will get stored in Beans.
 			$replaced_action = array(
 				'priority' => 50,
 			);
@@ -209,7 +209,7 @@ class Tests_BeansReplaceAction extends Replace_Action_Test_Case {
 			// Make sure the args are what we think before we get rolling.
 			$this->assertEquals( $action_config['args'], $original_action['args'] );
 
-			// Setup what will get stored in Beans.
+			// Set up what will get stored in Beans.
 			$replaced_action = array(
 				'args' => 5,
 			);
@@ -234,7 +234,7 @@ class Tests_BeansReplaceAction extends Replace_Action_Test_Case {
 	 * Test beans_replace_action() should replace the original registered action.
 	 */
 	public function test_should_replace_the_action() {
-		// Setup what will get stored in Beans.
+		// Set up what will get stored in Beans.
 		$replaced_action = array(
 			'hook'     => 'new_hook',
 			'callback' => 'new_callback',

--- a/tests/phpunit/unit/api/actions/beansReplaceActionArguments.php
+++ b/tests/phpunit/unit/api/actions/beansReplaceActionArguments.php
@@ -41,7 +41,7 @@ class Tests_BeansReplaceActionArguments extends Replace_Action_Test_Case {
 			// Now store away the "replace" args.
 			$this->assertFalse( beans_replace_action_arguments( $beans_id, $replaced_action['args'] ) );
 
-			// Check that it stored.
+			// Check that it was stored as "modified".
 			$this->assertEquals( $replaced_action, _beans_get_action( $beans_id, 'modified' ) );
 		}
 	}

--- a/tests/phpunit/unit/api/actions/beansReplaceActionArguments.php
+++ b/tests/phpunit/unit/api/actions/beansReplaceActionArguments.php
@@ -65,7 +65,7 @@ class Tests_BeansReplaceActionArguments extends Replace_Action_Test_Case {
 		$this->go_to_post();
 
 		foreach ( static::$test_actions as $beans_id => $original_action ) {
-			// Check if it replaced the hook.
+			// Check if it replaced the args.
 			$new_action = _beans_get_action( $beans_id, 'added' );
 			$this->assertEquals( $original_action['hook'], $new_action['hook'] );
 			$this->assertEquals( $original_action['callback'], $new_action['callback'] );
@@ -81,7 +81,7 @@ class Tests_BeansReplaceActionArguments extends Replace_Action_Test_Case {
 	/**
 	 * Test beans_replace_action_arguments() should return false when no args is passed.
 	 */
-	public function test_should_return_false_when_no_hook() {
+	public function test_should_return_false_when_no_args() {
 		$this->go_to_post();
 
 		foreach ( static::$test_actions as $beans_id => $action_config ) {

--- a/tests/phpunit/unit/api/actions/beansReplaceActionArguments.php
+++ b/tests/phpunit/unit/api/actions/beansReplaceActionArguments.php
@@ -47,8 +47,8 @@ class Tests_BeansReplaceActionArguments extends Replace_Action_Test_Case {
 	}
 
 	/**
-	 * Test beans_replace_action_arguments() should store the "replaced" hook when the original action
-	 * has not yet been registered.  Once the original action is registered, then the hook should be replaced.
+	 * Test beans_replace_action_arguments() should store the "replaced" args when the original action
+	 * has not yet been registered.  Once the original action is registered, then the args should be replaced.
 	 *
 	 * Intent: We are testing to ensure Beans is "load order" agnostic.
 	 */

--- a/tests/phpunit/unit/api/actions/beansReplaceActionCallback.php
+++ b/tests/phpunit/unit/api/actions/beansReplaceActionCallback.php
@@ -40,7 +40,7 @@ class Tests_BeansReplaceActionCallback extends Replace_Action_Test_Case {
 			// Now store away the "replace" callback.
 			$this->assertFalse( beans_replace_action_callback( $beans_id, $replaced_action['callback'] ) );
 
-			// Check that stored.
+			// Check that it was stored as "modified".
 			$this->assertEquals( $replaced_action, _beans_get_action( $beans_id, 'modified' ) );
 		}
 	}

--- a/tests/phpunit/unit/api/actions/beansReplaceActionCallback.php
+++ b/tests/phpunit/unit/api/actions/beansReplaceActionCallback.php
@@ -46,8 +46,8 @@ class Tests_BeansReplaceActionCallback extends Replace_Action_Test_Case {
 	}
 
 	/**
-	 * Test beans_replace_action_callback() should store the "replaced" hook when the original action
-	 * has not yet been registered.  Once the original action is registered, then the hook should be replaced.
+	 * Test beans_replace_action_callback() should store the "replaced" callback when the original action
+	 * has not yet been registered.  Once the original action is registered, then the callback should be replaced.
 	 *
 	 * Intent: We are testing to ensure Beans is "load order" agnostic.
 	 */
@@ -64,7 +64,7 @@ class Tests_BeansReplaceActionCallback extends Replace_Action_Test_Case {
 		$this->go_to_post();
 
 		foreach ( static::$test_actions as $beans_id => $original_action ) {
-			// Check if it replaced the hook.
+			// Check if it replaced the callback.
 			$new_action = _beans_get_action( $beans_id, 'added' );
 			$this->assertEquals( $original_action['hook'], $new_action['hook'] );
 			$this->assertEquals( $replaced_action['callback'], $new_action['callback'] );
@@ -78,9 +78,9 @@ class Tests_BeansReplaceActionCallback extends Replace_Action_Test_Case {
 	}
 
 	/**
-	 * Test beans_replace_action_callback() should return false when no hook was passed.
+	 * Test beans_replace_action_callback() should return false when no callback was passed.
 	 */
-	public function test_should_return_false_when_no_hook() {
+	public function test_should_return_false_when_no_callback() {
 		$this->go_to_post();
 
 		foreach ( static::$test_actions as $beans_id => $action_config ) {

--- a/tests/phpunit/unit/api/actions/beansReplaceActionHook.php
+++ b/tests/phpunit/unit/api/actions/beansReplaceActionHook.php
@@ -40,7 +40,7 @@ class Tests_BeansReplaceActionHook extends Replace_Action_Test_Case {
 			// Now store away the "replace" hook.
 			$this->assertFalse( beans_replace_action_hook( $beans_id, $replaced_action['hook'] ) );
 
-			// Check that stored.
+			// Check that it was stored as "modified".
 			$this->assertEquals( $replaced_action, _beans_get_action( $beans_id, 'modified' ) );
 		}
 	}

--- a/tests/phpunit/unit/api/actions/beansReplaceActionHook.php
+++ b/tests/phpunit/unit/api/actions/beansReplaceActionHook.php
@@ -109,7 +109,7 @@ class Tests_BeansReplaceActionHook extends Replace_Action_Test_Case {
 			// Make sure the callback is what we think before we get rolling.
 			$this->assertEquals( $action_config['hook'], $original_action['hook'] );
 
-			// Setup what will get stored in Beans.
+			// Set up what will get stored in Beans.
 			$replaced_action = array(
 				'hook' => 'beans_foo',
 			);

--- a/tests/phpunit/unit/api/actions/beansReplaceActionPriority.php
+++ b/tests/phpunit/unit/api/actions/beansReplaceActionPriority.php
@@ -46,8 +46,8 @@ class Tests_BeansReplaceActionPriority extends Replace_Action_Test_Case {
 	}
 
 	/**
-	 * Test beans_replace_action_priority() should store the "replaced" hook when the original action
-	 * has not yet been registered.  Once the original action is registered, then the hook should be replaced.
+	 * Test beans_replace_action_priority() should store the "replaced" priority when the original action
+	 * has not yet been registered.  Once the original action is registered, then the priority should be replaced.
 	 *
 	 * Intent: We are testing to ensure Beans is "load order" agnostic.
 	 */
@@ -64,7 +64,7 @@ class Tests_BeansReplaceActionPriority extends Replace_Action_Test_Case {
 		$this->go_to_post();
 
 		foreach ( static::$test_actions as $beans_id => $original_action ) {
-			// Check if it replaced the hook.
+			// Check if it replaced the priority.
 			$new_action = _beans_get_action( $beans_id, 'added' );
 			$this->assertEquals( $original_action['hook'], $new_action['hook'] );
 			$this->assertEquals( $original_action['callback'], $new_action['callback'] );
@@ -80,7 +80,7 @@ class Tests_BeansReplaceActionPriority extends Replace_Action_Test_Case {
 	/**
 	 * Test beans_replace_action_priority() should return false when no priority is passed.
 	 */
-	public function test_should_return_false_when_no_hook() {
+	public function test_should_return_false_when_no_priority() {
 		$this->go_to_post();
 
 		foreach ( static::$test_actions as $beans_id => $action_config ) {

--- a/tests/phpunit/unit/api/actions/beansReplaceActionPriority.php
+++ b/tests/phpunit/unit/api/actions/beansReplaceActionPriority.php
@@ -40,7 +40,7 @@ class Tests_BeansReplaceActionPriority extends Replace_Action_Test_Case {
 			// Now store away the "replace" priority.
 			$this->assertFalse( beans_replace_action_priority( $beans_id, $replaced_action['priority'] ) );
 
-			// Check that stored.
+			// Check that it was stored as "modified".
 			$this->assertEquals( $replaced_action, _beans_get_action( $beans_id, 'modified' ) );
 		}
 	}

--- a/tests/phpunit/unit/api/actions/beansResetAction.php
+++ b/tests/phpunit/unit/api/actions/beansResetAction.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * Tests for beans_reset_action()
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Unit\API\Actions;
+
+use Beans\Framework\Tests\Unit\API\Actions\Includes\Actions_Test_Case;
+use Brain\Monkey;
+
+require_once __DIR__ . '/includes/class-actions-test-case.php';
+
+/**
+ * Class Tests_BeansResetAction
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ * @group   unit-tests
+ * @group   api
+ */
+class Tests_BeansResetAction extends Actions_Test_Case {
+
+	/**
+	 * Test beans_reset_action() should return false when the action is not registered.
+	 */
+	public function test_should_return_false_when_no_action() {
+
+		foreach ( static::$test_actions as $beans_id => $action ) {
+			$this->assertFalse( beans_reset_action( $beans_id ) );
+		}
+	}
+
+	/**
+	 * Test beans_reset_action() should reset the original action after it was "removed" via beans_remove_action().
+	 */
+	public function test_should_reset_after_remove() {
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action ) {
+			// Check that the action is registered before we start.
+			$this->assertSame( $action, _beans_get_action( $beans_id, 'added' ) );
+			$this->assertTrue( has_action( $action['hook'], $action['callback'] ) !== false );
+
+			// Now remove it.
+			beans_remove_action( $beans_id );
+
+			// Check that it did get removed.
+			$this->assertSame( $action, _beans_get_action( $beans_id, 'removed' ) );
+			$this->assertFalse( has_action( $action['hook'], $action['callback'] ) );
+
+			// Let's reset the action.
+			$this->assertSame( $action, beans_reset_action( $beans_id ) );
+
+			// Check that it was reset.
+			$this->assertFalse( _beans_get_action( $beans_id, 'removed' ) );
+			$this->check_the_action( $beans_id, $action );
+		}
+	}
+
+	/**
+	 * Test beans_reset_action() should reset the original action's hook after it was "modified".
+	 */
+	public function test_should_reset_after_modifying_the_hook() {
+		$modified_action = array(
+			'hook' => 'foo',
+		);
+
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action ) {
+			// Check that the action is registered before we start.
+			$this->assertSame( $action, _beans_get_action( $beans_id, 'added' ) );
+			$this->assertTrue( has_action( $action['hook'], $action['callback'] ) !== false );
+
+			// Now modify the hook.
+			beans_modify_action_hook( $beans_id, $modified_action['hook'] );
+
+			// Check that the hook was modified.
+			$this->assertSame( $modified_action, _beans_get_action( $beans_id, 'modified' ) );
+			$this->assertFalse( has_action( $action['hook'], $action['callback'] ) );
+			$this->assertTrue( has_action( $modified_action['hook'], $action['callback'] ) !== false );
+
+			// Let's reset the action.
+			$this->assertSame( $action, beans_reset_action( $beans_id ) );
+
+			// Check that it was reset.
+			$this->assertFalse( _beans_get_action( $beans_id, 'modified' ) );
+			$this->check_the_action( $beans_id, $action );
+		}
+	}
+
+	/**
+	 * Test beans_reset_action() should reset the original action's callback after it was "modified".
+	 */
+	public function test_should_reset_after_modifying_the_callback() {
+		$modified_action = array(
+			'callback' => 'my_callback',
+		);
+
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action ) {
+			// Test the original callback.
+			$this->assertTrue( has_action( $action['hook'], $action['callback'] ) !== false );
+
+			// Now modify the callback.
+			beans_modify_action_callback( $beans_id, $modified_action['callback'] );
+
+			// Check that it did get modified.
+			$this->assertSame( $modified_action, _beans_get_action( $beans_id, 'modified' ) );
+
+			// Let's reset the action.
+			$this->assertSame( $action, beans_reset_action( $beans_id ) );
+
+			// Check that it was reset.
+			$this->assertFalse( _beans_get_action( $beans_id, 'modified' ) );
+			$this->check_the_action( $beans_id, $action );
+		}
+	}
+
+	/**
+	 * Test beans_reset_action() should not reset after replacing the action's hook.
+	 *
+	 * Why? "Replace" overwrites and is not resettable.
+	 */
+	public function test_should_not_reset_after_replacing_hook() {
+		$hook = 'foo';
+
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action ) {
+			// Test the action before we start.
+			$this->assertTrue( has_action( $action['hook'], $action['callback'] ) !== false );
+
+			// Run the replace.
+			beans_replace_action_hook( $beans_id, $hook );
+
+			// Let's try to reset the action.
+			$this->assertSame( $hook, beans_reset_action( $beans_id )['hook'] );
+
+			// Check that it was not reset.
+			$this->assertFalse( has_action( $action['hook'], $action['callback'] ) );
+			$this->assertTrue( has_action( $hook, $action['callback'] ) !== false );
+		}
+	}
+
+	/**
+	 * Test beans_reset_action() should not reset after replacing the action's callback.
+	 *
+	 * Why? "Replace" overwrites and is not resettable.
+	 */
+	public function test_should_not_reset_after_replacing_callback() {
+		$callback = 'foo_cb';
+
+		$this->go_to_post();
+
+		foreach ( static::$test_actions as $beans_id => $action ) {
+			// Test the action before we start.
+			$this->assertTrue( has_action( $action['hook'], $action['callback'] ) !== false );
+
+			// Run the replace.
+			beans_replace_action_callback( $beans_id, $callback );
+
+			// Let's try to reset the action.
+			$this->assertSame( $callback, beans_reset_action( $beans_id )['callback'] );
+
+			// Check that it was not reset.
+			$this->assertFalse( has_action( $action['hook'], $action['callback'] ) );
+			$this->assertTrue( has_action( $action['hook'], $callback ) !== false );
+		}
+	}
+
+	/**
+	 * Check that the action was reset.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param string $beans_id The action's Beans ID, a unique ID tracked within Beans for this action.
+	 * @param array  $action   The action to check.
+	 *
+	 * @return void
+	 */
+	protected function check_the_action( $beans_id, array $action ) {
+		$this->assertSame( $action, _beans_get_action( $beans_id, 'added' ) );
+		$this->assertTrue( has_action( $action['hook'], $action['callback'] ) !== false );
+
+		$container = Monkey\Container::instance();
+		$this->assertTrue(
+			$container->hookStorage()->isHookAdded(
+				Monkey\Hook\HookStorage::ACTIONS,
+				$action['hook'],
+				$action['callback']
+			)
+		);
+	}
+}

--- a/tests/phpunit/unit/api/actions/beansResetAction.php
+++ b/tests/phpunit/unit/api/actions/beansResetAction.php
@@ -311,7 +311,7 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 					$this->assertSame( $modified_action['args'], $args );
 				} );
 
-			// Modify the action's callback and priority.
+			// Modify the action.
 			beans_modify_action( $beans_id, null, $modified_action['callback'], $modified_action['priority'], $modified_action['args'] );
 
 			// Check that the action was modified in Beans.

--- a/tests/phpunit/unit/api/actions/beansResetAction.php
+++ b/tests/phpunit/unit/api/actions/beansResetAction.php
@@ -34,7 +34,7 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 	}
 
 	/**
-	 * Test beans_reset_action() should reset the original action after it was "removed" via beans_remove_action().
+	 * Test beans_reset_action() should reset the original action after it was "removed".
 	 */
 	public function test_should_reset_after_remove() {
 		$this->go_to_post();

--- a/tests/phpunit/unit/api/actions/beansResetAction.php
+++ b/tests/phpunit/unit/api/actions/beansResetAction.php
@@ -40,21 +40,21 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 		$this->go_to_post();
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
-			// Check that the action is registered before we start.
+			// Before we start, check that the action is registered.
 			$this->assertSame( $action, _beans_get_action( $beans_id, 'added' ) );
 			$this->assertTrue( has_action( $action['hook'], $action['callback'] ) !== false );
 
-			// Now remove it.
+			// Remove the action.
 			beans_remove_action( $beans_id );
 
-			// Check that it did get removed.
+			// Check that the action was removed.
 			$this->assertSame( $action, _beans_get_action( $beans_id, 'removed' ) );
 			$this->assertFalse( has_action( $action['hook'], $action['callback'] ) );
 
 			// Let's reset the action.
 			$this->assertSame( $action, beans_reset_action( $beans_id ) );
 
-			// Check that it was reset.
+			// Check that the action was reset.
 			$this->assertFalse( _beans_get_action( $beans_id, 'removed' ) );
 			$this->check_the_action( $beans_id, $action );
 		}
@@ -71,11 +71,11 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 		$this->go_to_post();
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
-			// Check that the action is registered before we start.
+			// Before we start, check that the action is registered.
 			$this->assertSame( $action, _beans_get_action( $beans_id, 'added' ) );
 			$this->assertTrue( has_action( $action['hook'], $action['callback'] ) !== false );
 
-			// Now modify the hook.
+			// Modify the hook.
 			beans_modify_action_hook( $beans_id, $modified_action['hook'] );
 
 			// Check that the hook was modified.
@@ -86,7 +86,7 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 			// Let's reset the action.
 			$this->assertSame( $action, beans_reset_action( $beans_id ) );
 
-			// Check that it was reset.
+			// Check that the action was reset.
 			$this->assertFalse( _beans_get_action( $beans_id, 'modified' ) );
 			$this->check_the_action( $beans_id, $action );
 		}
@@ -103,19 +103,19 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 		$this->go_to_post();
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
-			// Test the original callback.
+			// Before we start, check that the action is registered.
 			$this->assertTrue( has_action( $action['hook'], $action['callback'] ) !== false );
 
-			// Now modify the callback.
+			// Modify the callback.
 			beans_modify_action_callback( $beans_id, $modified_action['callback'] );
 
-			// Check that it did get modified.
+			// Check that the action's callback was modified.
 			$this->assertSame( $modified_action, _beans_get_action( $beans_id, 'modified' ) );
 
 			// Let's reset the action.
 			$this->assertSame( $action, beans_reset_action( $beans_id ) );
 
-			// Check that it was reset.
+			// Check that the action was reset.
 			$this->assertFalse( _beans_get_action( $beans_id, 'modified' ) );
 			$this->check_the_action( $beans_id, $action );
 		}
@@ -132,7 +132,7 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 		$this->go_to_post();
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
-			// Test the action before we start.
+			// Before we start, check that the action is registered.
 			$this->assertTrue( has_action( $action['hook'], $action['callback'] ) !== false );
 
 			// Run the replace.
@@ -141,7 +141,7 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 			// Let's try to reset the action.
 			$this->assertSame( $hook, beans_reset_action( $beans_id )['hook'] );
 
-			// Check that it was not reset.
+			// Check that the action was not reset.
 			$this->assertFalse( has_action( $action['hook'], $action['callback'] ) );
 			$this->assertTrue( has_action( $hook, $action['callback'] ) !== false );
 		}
@@ -158,7 +158,7 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 		$this->go_to_post();
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
-			// Test the action before we start.
+			// Before we start, check that the action is registered.
 			$this->assertTrue( has_action( $action['hook'], $action['callback'] ) !== false );
 
 			// Run the replace.
@@ -167,7 +167,7 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 			// Let's try to reset the action.
 			$this->assertSame( $callback, beans_reset_action( $beans_id )['callback'] );
 
-			// Check that it was not reset.
+			// Check that the action was not reset.
 			$this->assertFalse( has_action( $action['hook'], $action['callback'] ) );
 			$this->assertTrue( has_action( $action['hook'], $callback ) !== false );
 		}

--- a/tests/phpunit/unit/api/actions/beansResetAction.php
+++ b/tests/phpunit/unit/api/actions/beansResetAction.php
@@ -37,26 +37,20 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 	 * Test beans_reset_action() should reset the original action after it was "removed".
 	 */
 	public function test_should_reset_after_remove() {
-		$this->go_to_post();
+		$this->go_to_post( true );
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
-			// Before we start, check that the action is registered.
-			$this->assertSame( $action, _beans_get_action( $beans_id, 'added' ) );
-			$this->assertTrue( has_action( $action['hook'], $action['callback'] ) !== false );
-
 			// Remove the action.
 			beans_remove_action( $beans_id );
 
-			// Check that the action was removed.
-			$this->assertSame( $action, _beans_get_action( $beans_id, 'removed' ) );
+			// Check that the action was removed in WordPress.
 			$this->assertFalse( has_action( $action['hook'], $action['callback'] ) );
 
-			// Let's reset the action.
-			$this->assertSame( $action, beans_reset_action( $beans_id ) );
+			// Check that the action was "removed" in Beans.
+			$this->assertSame( $action, _beans_get_action( $beans_id, 'removed' ) );
 
-			// Check that the action was reset.
-			$this->assertFalse( _beans_get_action( $beans_id, 'removed' ) );
-			$this->check_the_action( $beans_id, $action );
+			// Reset and then check in WordPress and Beans.
+			$this->reset_and_check( $beans_id, $action, true );
 		}
 	}
 
@@ -68,27 +62,27 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 			'hook' => 'foo',
 		);
 
-		$this->go_to_post();
+		$this->go_to_post( true );
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
-			// Before we start, check that the action is registered.
-			$this->assertSame( $action, _beans_get_action( $beans_id, 'added' ) );
-			$this->assertTrue( has_action( $action['hook'], $action['callback'] ) !== false );
+			// Set up the WordPress simulator before we modify the action.
+			Monkey\Actions\expectAdded( $modified_action['hook'] )
+				->once()
+				->whenHappen( function( $callback, $priority, $args ) use ( $action ) {
+					// Check that the parameters remain unchanged in WordPress.
+					$this->assertSame( $action['callback'], $callback );
+					$this->assertSame( $action['priority'], $priority );
+					$this->assertSame( $action['args'], $args );
+				} );
 
-			// Modify the hook.
+			// Modify the action's hook.
 			beans_modify_action_hook( $beans_id, $modified_action['hook'] );
 
-			// Check that the hook was modified.
+			// Check that the action was modified in Beans.
 			$this->assertSame( $modified_action, _beans_get_action( $beans_id, 'modified' ) );
-			$this->assertFalse( has_action( $action['hook'], $action['callback'] ) );
-			$this->assertTrue( has_action( $modified_action['hook'], $action['callback'] ) !== false );
 
-			// Let's reset the action.
-			$this->assertSame( $action, beans_reset_action( $beans_id ) );
-
-			// Check that the action was reset.
-			$this->assertFalse( _beans_get_action( $beans_id, 'modified' ) );
-			$this->check_the_action( $beans_id, $action );
+			// Reset and then check in WordPress and Beans.
+			$this->reset_and_check( $beans_id, $action );
 		}
 	}
 
@@ -100,24 +94,231 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 			'callback' => 'my_callback',
 		);
 
-		$this->go_to_post();
+		$this->go_to_post( true );
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
-			// Before we start, check that the action is registered.
-			$this->assertTrue( has_action( $action['hook'], $action['callback'] ) !== false );
+			// Set up the WordPress simulator before we modify the action.
+			Monkey\Actions\expectAdded( $action['hook'] )
+				->once()
+				->whenHappen( function( $callback, $priority, $args ) use ( $action, $modified_action ) {
+					// Check that the callback was modified in WordPress.
+					$this->assertSame( $modified_action['callback'], $callback );
+					// Check that the other parameters remain unchanged.
+					$this->assertSame( $action['priority'], $priority );
+					$this->assertSame( $action['args'], $args );
+				} );
 
-			// Modify the callback.
+			// Modify the action's callback.
 			beans_modify_action_callback( $beans_id, $modified_action['callback'] );
 
-			// Check that the action's callback was modified.
+			// Check that the action was modified in Beans.
 			$this->assertSame( $modified_action, _beans_get_action( $beans_id, 'modified' ) );
 
-			// Let's reset the action.
-			$this->assertSame( $action, beans_reset_action( $beans_id ) );
+			// Reset and then check in WordPress and Beans.
+			$this->reset_and_check( $beans_id, $action );
+		}
+	}
 
-			// Check that the action was reset.
-			$this->assertFalse( _beans_get_action( $beans_id, 'modified' ) );
-			$this->check_the_action( $beans_id, $action );
+	/**
+	 * Test beans_reset_action() should reset the original action's priority after it was "modified".
+	 */
+	public function test_should_reset_after_modifying_the_priority() {
+		$modified_action = array(
+			'priority' => 9999,
+		);
+
+		$this->go_to_post( true );
+
+		foreach ( static::$test_actions as $beans_id => $action ) {
+			// Set up the WordPress simulator before we modify the action.
+			Monkey\Actions\expectAdded( $action['hook'] )
+				->once()
+				->whenHappen( function( $callback, $priority, $args ) use ( $action, $modified_action ) {
+					// Check that the priority was modified in WordPress.
+					$this->assertSame( $modified_action['priority'], $priority );
+					// Check that the other parameters remain unchanged.
+					$this->assertSame( $action['callback'], $callback );
+					$this->assertSame( $action['args'], $args );
+				} );
+
+			// Modify the action's priority.
+			beans_modify_action_priority( $beans_id, $modified_action['priority'] );
+
+			// Check that the action was modified in Beans.
+			$this->assertSame( $modified_action, _beans_get_action( $beans_id, 'modified' ) );
+
+			// Reset and then check in WordPress and Beans.
+			$this->reset_and_check( $beans_id, $action );
+		}
+	}
+
+	/**
+	 * Test beans_reset_action() should reset the original action's args after it was "modified".
+	 */
+	public function test_should_reset_after_modifying_the_args() {
+		$modified_action = array(
+			'args' => 14,
+		);
+
+		$this->go_to_post( true );
+
+		foreach ( static::$test_actions as $beans_id => $action ) {
+			// Set up the WordPress simulator before we modify the action.
+			Monkey\Actions\expectAdded( $action['hook'] )
+				->once()
+				->whenHappen( function( $callback, $priority, $args ) use ( $action, $modified_action ) {
+					// Check that the args was modified in WordPress.
+					$this->assertSame( $modified_action['args'], $args );
+					// Check that the other parameters remain unchanged.
+					$this->assertSame( $action['callback'], $callback );
+					$this->assertSame( $action['priority'], $priority );
+				} );
+
+			// Modify the action's args.
+			beans_modify_action_arguments( $beans_id, $modified_action['args'] );
+
+			// Check that the action was modified in Beans.
+			$this->assertSame( $modified_action, _beans_get_action( $beans_id, 'modified' ) );
+
+			// Reset and then check in WordPress and Beans.
+			$this->reset_and_check( $beans_id, $action );
+		}
+	}
+
+	/**
+	 * Test beans_reset_action() should reset the original action's callback and args after they were "modified".
+	 */
+	public function test_should_reset_after_modifying_callback_and_args() {
+		$modified_action = array(
+			'callback' => 'my_callback',
+			'args'     => 14,
+		);
+
+		$this->go_to_post( true );
+
+		foreach ( static::$test_actions as $beans_id => $action ) {
+			// Set up the WordPress simulator before we modify the action.
+			Monkey\Actions\expectAdded( $action['hook'] )
+				->once()
+				->whenHappen( function( $callback, $priority, $args ) use ( $action, $modified_action ) {
+					// Check that the callback and args were modified in WordPress.
+					$this->assertSame( $modified_action['callback'], $callback );
+					$this->assertSame( $modified_action['args'], $args );
+					// Check that the priority remains unchanged.
+					$this->assertSame( $action['priority'], $priority );
+				} );
+
+			// Modify the action's callback and args.
+			beans_modify_action( $beans_id, null, $modified_action['callback'], null, $modified_action['args'] );
+
+			// Check that the action was modified in Beans.
+			$this->assertSame( $modified_action, _beans_get_action( $beans_id, 'modified' ) );
+
+			// Reset and then check in WordPress and Beans.
+			$this->reset_and_check( $beans_id, $action );
+		}
+	}
+
+	/**
+	 * Test beans_reset_action() should reset the original action's priority and args after they were "modified".
+	 */
+	public function test_should_reset_after_modifying_priority_and_args() {
+		$modified_action = array(
+			'priority' => 79,
+			'args'     => 14,
+		);
+
+		$this->go_to_post( true );
+
+		foreach ( static::$test_actions as $beans_id => $action ) {
+			// Set up the WordPress simulator before we modify the action.
+			Monkey\Actions\expectAdded( $action['hook'] )
+				->once()
+				->whenHappen( function( $callback, $priority, $args ) use ( $action, $modified_action ) {
+					// Check that the priority and args were modified in WordPress.
+					$this->assertSame( $modified_action['priority'], $priority );
+					$this->assertSame( $modified_action['args'], $args );
+					// Check that the callback remains unchanged.
+					$this->assertSame( $action['callback'], $callback );
+				} );
+
+			// Modify the action's priority and args.
+			beans_modify_action( $beans_id, null, null, $modified_action['priority'], $modified_action['args'] );
+
+			// Check that the action was modified in Beans.
+			$this->assertSame( $modified_action, _beans_get_action( $beans_id, 'modified' ) );
+
+			// Reset and then check in WordPress and Beans.
+			$this->reset_and_check( $beans_id, $action );
+		}
+	}
+
+	/**
+	 * Test beans_reset_action() should reset the original action's callback and priority after they were "modified".
+	 */
+	public function test_should_reset_after_modifying_callback_and_priority() {
+		$modified_action = array(
+			'callback' => 'foo',
+			'priority' => 39,
+		);
+
+		$this->go_to_post( true );
+
+		foreach ( static::$test_actions as $beans_id => $action ) {
+			// Set up the WordPress simulator before we modify the action.
+			Monkey\Actions\expectAdded( $action['hook'] )
+				->once()
+				->whenHappen( function( $callback, $priority, $args ) use ( $action, $modified_action ) {
+					// Check that the callback and priority were modified in WordPress.
+					$this->assertSame( $modified_action['callback'], $callback );
+					$this->assertSame( $modified_action['priority'], $priority );
+					// Check that the args remains unchanged.
+					$this->assertSame( $action['args'], $args );
+				} );
+
+			// Modify the action's callback and priority.
+			beans_modify_action( $beans_id, null, $modified_action['callback'], $modified_action['priority'] );
+
+			// Check that the action was modified in Beans.
+			$this->assertSame( $modified_action, _beans_get_action( $beans_id, 'modified' ) );
+
+			// Reset and then check in WordPress and Beans.
+			$this->reset_and_check( $beans_id, $action );
+		}
+	}
+
+	/**
+	 * Test beans_reset_action() should reset the original action's callback, priority, and args after they were
+	 * "modified".
+	 */
+	public function test_should_reset_after_modifying_all_but_hook() {
+		$modified_action = array(
+			'callback' => 'foo',
+			'priority' => 39,
+			'args'     => 24,
+		);
+
+		$this->go_to_post( true );
+
+		foreach ( static::$test_actions as $beans_id => $action ) {
+			// Set up the WordPress simulator before we modify the action.
+			Monkey\Actions\expectAdded( $action['hook'] )
+				->once()
+				->whenHappen( function( $callback, $priority, $args ) use ( $action, $modified_action ) {
+					// Check that all of the parameters were modified in WordPress.
+					$this->assertSame( $modified_action['callback'], $callback );
+					$this->assertSame( $modified_action['priority'], $priority );
+					$this->assertSame( $modified_action['args'], $args );
+				} );
+
+			// Modify the action's callback and priority.
+			beans_modify_action( $beans_id, null, $modified_action['callback'], $modified_action['priority'], $modified_action['args'] );
+
+			// Check that the action was modified in Beans.
+			$this->assertSame( $modified_action, _beans_get_action( $beans_id, 'modified' ) );
+
+			// Reset and then check in WordPress and Beans.
+			$this->reset_and_check( $beans_id, $action );
 		}
 	}
 
@@ -174,26 +375,40 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 	}
 
 	/**
-	 * Check that the action was reset.
+	 * Reset the action.
+	 *
+	 * 1. Set up the WordPress simulator before we reset the action.
+	 * 2. Then reset the action.
+	 * 3. Check that the action was reset in WordPress.
+	 * 4. Check that the action was reset in Beans.
 	 *
 	 * @since 1.5.0
 	 *
-	 * @param string $beans_id The action's Beans ID, a unique ID tracked within Beans for this action.
-	 * @param array  $action   The action to check.
+	 * @param string $beans_id        Beans' action ID.
+	 * @param array  $original_action Action's original configuration.
+	 * @param bool   $after_remove    Set to true when resetting after a remove.
 	 *
 	 * @return void
+	 * @throws Monkey\Expectation\Exception\NotAllowedMethod Throws when callback is invalid.
 	 */
-	protected function check_the_action( $beans_id, array $action ) {
-		$this->assertSame( $action, _beans_get_action( $beans_id, 'added' ) );
-		$this->assertTrue( has_action( $action['hook'], $action['callback'] ) !== false );
+	protected function reset_and_check( $beans_id, $original_action, $after_remove = false ) {
+		Monkey\Actions\expectAdded( $original_action['hook'] )
+			->once()
+			->whenHappen( function( $callback, $priority, $args ) use ( $original_action ) {
+				$this->assertSame( $original_action['args'], $args );
+				$this->assertSame( $original_action['callback'], $callback );
+				$this->assertSame( $original_action['priority'], $priority );
+			} );
 
-		$container = Monkey\Container::instance();
-		$this->assertTrue(
-			$container->hookStorage()->isHookAdded(
-				Monkey\Hook\HookStorage::ACTIONS,
-				$action['hook'],
-				$action['callback']
-			)
-		);
+		$this->assertSame( $original_action, beans_reset_action( $beans_id ) );
+
+		if ( $after_remove ) {
+			$this->assertFalse( _beans_get_action( $beans_id, 'removed' ) );
+		} else {
+			$this->assertFalse( _beans_get_action( $beans_id, 'modified' ) );
+		}
+
+		$this->assertSame( $original_action, _beans_get_action( $beans_id, 'added' ) );
+		$this->assertTrue( has_action( $original_action['hook'], $original_action['callback'] ) !== false );
 	}
 }

--- a/tests/phpunit/unit/api/actions/includes/class-actions-test-case.php
+++ b/tests/phpunit/unit/api/actions/includes/class-actions-test-case.php
@@ -114,6 +114,10 @@ abstract class Actions_Test_Case extends Test_Case {
 
 	/**
 	 * Simulate going to the post and loading in the template and fragments.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @return void
 	 */
 	protected function go_to_post() {
 

--- a/tests/phpunit/unit/api/actions/includes/class-actions-test-case.php
+++ b/tests/phpunit/unit/api/actions/includes/class-actions-test-case.php
@@ -140,12 +140,29 @@ abstract class Actions_Test_Case extends Test_Case {
 	 *
 	 * @since 1.5.0
 	 *
+	 * @param bool $expect_added Optional. When true, runs tests to ensure it's been added.
+	 *
 	 * @return void
+	 * @throws Monkey\Expectation\Exception\NotAllowedMethod Thrown from Monkey.
 	 */
-	protected function go_to_post() {
+	protected function go_to_post( $expect_added = false ) {
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
+			if ( $expect_added ) {
+				Monkey\Actions\expectAdded( $action['hook'] )
+					->once()
+					->whenHappen( function( $callback, $priority, $args ) use ( $action ) {
+						$this->assertSame( $action['callback'], $callback );
+						$this->assertSame( $action['priority'], $priority );
+						$this->assertSame( $action['args'], $args );
+					} );
+			}
+
 			beans_add_action( $beans_id, $action['hook'], $action['callback'], $action['priority'], $action['args'] );
+
+			if ( $expect_added ) {
+				$this->assertTrue( has_action( $action['hook'], $action['callback'] ) !== false );
+			}
 		}
 	}
 

--- a/tests/phpunit/unit/api/actions/includes/class-actions-test-case.php
+++ b/tests/phpunit/unit/api/actions/includes/class-actions-test-case.php
@@ -34,7 +34,7 @@ abstract class Actions_Test_Case extends Test_Case {
 	protected static $test_ids;
 
 	/**
-	 * Setup the test before we run the test setups.
+	 * Set up the test before we run the test setups.
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
@@ -44,6 +44,29 @@ abstract class Actions_Test_Case extends Test_Case {
 
 		require_once BEANS_TESTS_LIB_DIR . 'api/actions/functions.php';
 		require_once BEANS_TESTS_LIB_DIR . 'api/utilities/functions.php';
+	}
+
+	/**
+	 * Tear down the test before we exit this class.
+	 */
+	public static function tearDownAfterClass() {
+		parent::tearDownAfterClass();
+
+		global $_beans_registered_actions;
+		$_beans_registered_actions = array(
+			'added'    => array(),
+			'modified' => array(),
+			'removed'  => array(),
+			'replaced' => array(),
+		);
+
+		// Remove the test actions.
+		foreach ( static::$test_actions as $beans_id => $action ) {
+			remove_action( $action['hook'], $action['callback'], $action['priority'] );
+		}
+
+		static::$test_actions = null;
+		static::$test_ids     = null;
 	}
 
 	/**

--- a/tests/phpunit/unit/api/actions/includes/class-replace-action-test-case.php
+++ b/tests/phpunit/unit/api/actions/includes/class-replace-action-test-case.php
@@ -9,9 +9,6 @@
 
 namespace Beans\Framework\Tests\Unit\API\Actions\Includes;
 
-use Beans\Framework\Tests\Unit\Test_Case;
-use Brain\Monkey;
-
 /**
  * Abstract Class Replace_Action_Test_Case
  *


### PR DESCRIPTION
Functions: `beans_remove_action` and `beans_reset_action`.

1. Made WPCS compliant.
2. Added integration tests.
3. Added unit tests.
4. Improved documentation.
5. Improved both functions.