### PR TITLE
Improved beans_get tests.

### DIFF
--- a/tests/phpunit/unit/api/utilities/beansGet.php
+++ b/tests/phpunit/unit/api/utilities/beansGet.php
@@ -30,35 +30,90 @@ class Tests_BeansGet extends Test_Case {
 	}
 
 	/**
-	 * Test beans_get() should return the default value.
+	 * Test beans_get() should find the needle when array is given.
 	 */
-	public function test_should_return_default() {
-		$this->assertEquals( 10, beans_get( 'foo', 'bar', 10 ) );
-		$this->assertNull( beans_get( 'foo', array( 'oof' => 'found me' ) ) );
-		$this->assertNull( beans_get( 'foo', array( 10, 'bar', 'baz' ) ) );
-		$this->assertFalse( beans_get( 'foo', (object) array( 'bar', 'baz' ), false ) );
+	public function test_should_find_needle_when_array_given() {
+		$haystack = array(
+			'post_type'       => 'foo',
+			'number_of_posts' => 5,
+		);
+
+		$this->assertSame( $haystack['number_of_posts'], beans_get( 'number_of_posts', $haystack ) );
+		$this->assertSame( 'foo', beans_get( 'post_type', $haystack ) );
 	}
 
 	/**
-	 * Test beans_get() should find the needle.
+	 * Test beans_get() should return default value when array is given.
 	 */
-	public function test_should_find_needle() {
+	public function test_should_return_default_when_array_given() {
+		$haystack = array(
+			'post_type'       => 'foo',
+			'number_of_posts' => 5,
+		);
+
+		$this->assertSame( 'published', beans_get( 'post_status', $haystack, 'published' ) );
+		$this->assertFalse( beans_get( 'post_status', $haystack, false ) );
+		$this->assertNull( beans_get( 'post_status', $haystack ) );
+	}
+
+	/**
+	 * Test beans_get() should find the needle when object is given.
+	 */
+	public function test_should_find_needle_when_object_given() {
+		$haystack = (object) array(
+			'post_type'       => 'foo',
+			'number_of_posts' => 5,
+		);
+
+		$this->assertSame( $haystack->number_of_posts, beans_get( 'number_of_posts', $haystack ) );
+		$this->assertSame( 'foo', beans_get( 'post_type', $haystack ) );
+	}
+
+	/**
+	 * Test beans_get() should return default value when object is given.
+	 */
+	public function test_should_return_default_when_object_given() {
+		$haystack = (object) array(
+			'post_type'       => 'foo',
+			'number_of_posts' => 5,
+		);
+
+		$this->assertSame( 'published', beans_get( 'post_status', $haystack, 'published' ) );
+		$this->assertFalse( beans_get( 'post_status', $haystack, false ) );
+		$this->assertNull( beans_get( 'post_status', $haystack ) );
+	}
+
+	/**
+	 * Test beans_get() should return default value when a literal (hard coded) value is given.
+	 */
+	public function test_should_return_default_when_literal_given() {
+		$this->assertNull( beans_get( 'foo', 'bar' ) );
+		$this->assertSame( 'foo', beans_get( 'foo', 10, 'foo' ) );
+		$this->assertFalse( beans_get( 10, 'Testing is fun!', false ) );
+	}
+
+	/**
+	 * Test beans_get() should find the needle when the array's index is given.
+	 */
+	public function test_should_find_needle_when_index_given() {
 		$this->assertEquals( 'bar', beans_get( 0, 'bar', 10 ) );
 
 		$data = array(
-			'foo' => 'found me',
-		);
-		$this->assertEquals( 'found me', beans_get( 'foo', $data, 10 ) );
-		$this->assertEquals( 'found me', beans_get( 'foo', (object) $data, 10 ) );
-
-		$data = array(
-			'baz' => 'zab',
-			'rab' => 'bar',
 			'red',
+			'white',
+			'foo' => 'baz',
+			'green',
 		);
 		$this->assertEquals( 'red', beans_get( 0, $data ) );
-		$this->assertEquals( 'zab', beans_get( 'baz', $data ) );
-		$this->assertEquals( 'red', beans_get( 0, (object) $data ) );
-		$this->assertEquals( 'zab', beans_get( 'baz', (object) $data ) );
+		$this->assertEquals( 'white', beans_get( 1, $data ) );
+		$this->assertEquals( 'green', beans_get( 2, $data ) );
+	}
+
+	/**
+	 * Test beans_get() should return the value from the $_GET superglobal.
+	 */
+	public function test_should_get_value_from_get_superglobal() {
+		$_GET['beans'] = 'Testing is fun!';
+		$this->assertSame( 'Testing is fun!', beans_get( 'beans' ) );
 	}
 }

--- a/tests/phpunit/unit/api/utilities/beansGet.php
+++ b/tests/phpunit/unit/api/utilities/beansGet.php
@@ -30,7 +30,7 @@ class Tests_BeansGet extends Test_Case {
 	}
 
 	/**
-	 * Test beans_get() should find the needle when array is given.
+	 * Test beans_get() should find the needle when an array is given.
 	 */
 	public function test_should_find_needle_when_array_given() {
 		$haystack = array(
@@ -43,7 +43,7 @@ class Tests_BeansGet extends Test_Case {
 	}
 
 	/**
-	 * Test beans_get() should return default value when array is given.
+	 * Test beans_get() should return default value when an array is given.
 	 */
 	public function test_should_return_default_when_array_given() {
 		$haystack = array(
@@ -57,7 +57,7 @@ class Tests_BeansGet extends Test_Case {
 	}
 
 	/**
-	 * Test beans_get() should find the needle when object is given.
+	 * Test beans_get() should find the needle when an object is given.
 	 */
 	public function test_should_find_needle_when_object_given() {
 		$haystack = (object) array(
@@ -70,7 +70,7 @@ class Tests_BeansGet extends Test_Case {
 	}
 
 	/**
-	 * Test beans_get() should return default value when object is given.
+	 * Test beans_get() should return default value when an object is given.
 	 */
 	public function test_should_return_default_when_object_given() {
 		$haystack = (object) array(


### PR DESCRIPTION
The original unit tests for `beans_get()` was light and incomplete.  This PR breaks up the tests for array and object haystacks as well as covers additional scenarios, such as `$_GET` and indexed arrays.