### PR TITLE
Upgrade PHPCS/WPCS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,13 +41,15 @@
     "roave/security-advisories": "dev-master"
   },
   "require-dev": {
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3",
-    "sirbrillig/phpcs-variable-analysis": "^2.0",
-    "wimg/php-compatibility": "^8.0",
-    "wp-coding-standards/wpcs": "^0.14.0",
-    "phpunit/phpunit": "~4.8 || ~5.7.9",
-    "brain/monkey": "^2.0",
+    "php": "^5.6|^7",
+    "brain/monkey": "^2.2",
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
     "mikey179/vfsStream": "^1.6",
+    "phpunit/phpunit": "~4.8 || ~5.7.9",
+    "sirbrillig/phpcs-variable-analysis": "^2.0",
+    "squizlabs/php_codesniffer": "^3.3",
+    "wimg/php-compatibility": "^8.0",
+    "wp-coding-standards/wpcs": "^0.14.1",
     "xwp/wp-dev-lib": "^1.0.1"
   },
   "config": {

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
     "brain/monkey": "^2.2",
     "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
     "mikey179/vfsStream": "^1.6",
-    "phpunit/phpunit": "~4.8 || ~5.7.9",
+    "phpunit/phpunit": "~5.7.9",
     "sirbrillig/phpcs-variable-analysis": "^2.0",
     "squizlabs/php_codesniffer": "^3.2",
     "wimg/php-compatibility": "^8.0",

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
     "mikey179/vfsStream": "^1.6",
     "phpunit/phpunit": "~4.8 || ~5.7.9",
     "sirbrillig/phpcs-variable-analysis": "^2.0",
-    "squizlabs/php_codesniffer": "^3.3",
+    "squizlabs/php_codesniffer": "^3.2",
     "wimg/php-compatibility": "^8.0",
     "wp-coding-standards/wpcs": "^0.14.1",
     "xwp/wp-dev-lib": "^1.0.1"

--- a/lib/api/actions/class-beans-anonymous-action.php
+++ b/lib/api/actions/class-beans-anonymous-action.php
@@ -51,6 +51,6 @@ final class _Beans_Anonymous_Actions {
 	 * @return void
 	 */
 	public function callback() {
-		echo call_user_func_array( $this->callback[0], $this->callback[1] ); // @codingStandardsIgnoreLine - WordPress.XSS.EscapeOutput.OutputNotEscaped - reason: the callback should escape the output.
+		echo call_user_func_array( $this->callback[0], $this->callback[1] ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- The callback should escape the output.
 	}
 }

--- a/lib/api/compiler/class-page-compiler.php
+++ b/lib/api/compiler/class-page-compiler.php
@@ -186,7 +186,7 @@ final class _Beans_Page_Compiler {
 		}
 
 		// Add localized content since it was removed with dequeue scripts.
-		printf( "<script type='text/javascript'>\n%s\n</script>\n", $localized ); // @codingStandardsIgnoreLine - WordPress.XSS.EscapeOutput.OutputNotEscaped.
+		printf( "<script type='text/javascript'>\n%s\n</script>\n", $localized ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Needs review.
 	}
 }
 

--- a/lib/api/init.php
+++ b/lib/api/init.php
@@ -3,7 +3,7 @@
  *
  * Load the API components.
  *
- * @since 1.5.0
+ * @since   1.5.0
  *
  * @package Beans\Framework\API
  */
@@ -18,7 +18,7 @@ define( 'BEANS_API', true );
 
 // Mode.
 if ( ! defined( 'SCRIPT_DEBUG' ) ) {
-	define( 'SCRIPT_DEBUG', false ); // @codingStandardsIgnoreLine - WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound.
+	define( 'SCRIPT_DEBUG', false ); // @phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- Valid use case as we need it defined.
 }
 
 // Assets.

--- a/lib/api/init.php
+++ b/lib/api/init.php
@@ -3,7 +3,7 @@
  *
  * Load the API components.
  *
- * @since   1.5.0
+ * @since 1.5.0
  *
  * @package Beans\Framework\API
  */

--- a/lib/api/utilities/functions.php
+++ b/lib/api/utilities/functions.php
@@ -86,11 +86,11 @@ function beans_remove_dir( $dir_path ) {
 		if ( is_dir( $path ) ) {
 			beans_remove_dir( $path );
 		} else {
-			@unlink( $path ); // @codingStandardsIgnoreLine - Generic.PHP.NoSilencedErrors.Discouraged  This is a valid use case.
+			@unlink( $path ); // phpcs:disable Generic.PHP.NoSilencedErrors.Discouraged -- Valid use cases.
 		}
 	}
 
-	return @rmdir( $dir_path ); // @codingStandardsIgnoreLine - Generic.PHP.NoSilencedErrors.Discouraged This is a valid use case.
+	return @rmdir( $dir_path ); // phpcs:disable Generic.PHP.NoSilencedErrors.Discouraged -- Valid use cases.
 }
 
 /**
@@ -294,7 +294,7 @@ function beans_sanitize_path( $path ) {
 function beans_get( $needle, $haystack = false, $default = null ) {
 
 	if ( false === $haystack ) {
-		$haystack = $_GET; // @codingStandardsIgnoreLine - WordPress.CSRF.NonceVerification.NoNonceVerification as the nonce verification check should be at the form processing level.
+		$haystack = $_GET; // phpcs:ignore WordPress.CSRF.NonceVerification.NoNonceVerification -- The nonce verification check should be at the form processing level.
 	}
 
 	$haystack = (array) $haystack;
@@ -317,7 +317,7 @@ function beans_get( $needle, $haystack = false, $default = null ) {
  * @return string Returns the value if found; else $default is returned.
  */
 function beans_post( $needle, $default = null ) {
-	return beans_get( $needle, $_POST, $default ); // @codingStandardsIgnoreLine - WordPress.CSRF.NonceVerification.NoNonceVerification as the nonce verification check should be at the form processing level.
+	return beans_get( $needle, $_POST, $default ); // phpcs:ignore WordPress.CSRF.NonceVerification.NoNonceVerification -- The nonce verification check should be at the form processing level.
 }
 
 /**
@@ -360,7 +360,7 @@ function beans_get_or_post( $needle, $default = null ) {
  */
 function beans_in_multi_array( $needle, $haystack, $strict = false ) {
 
-	if ( in_array( $needle, $haystack, $strict ) ) { // @codingStandardsIgnoreLine - WordPress.PHP.StrictInArray.MissingTrueStrict requires 3rd argument to be true or false and not a variable.
+	if ( in_array( $needle, $haystack, $strict ) ) { // phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict -- The rule does not account for when we are passing a boolean within a variable as the 3rd argument.
 		return true;
 	}
 

--- a/lib/api/utilities/functions.php
+++ b/lib/api/utilities/functions.php
@@ -86,11 +86,11 @@ function beans_remove_dir( $dir_path ) {
 		if ( is_dir( $path ) ) {
 			beans_remove_dir( $path );
 		} else {
-			@unlink( $path ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged -- Valid use cases.
+			@unlink( $path ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged -- Valid use case.
 		}
 	}
 
-	return @rmdir( $dir_path ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged -- Valid use cases.
+	return @rmdir( $dir_path ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged -- Valid use case.
 }
 
 /**

--- a/lib/api/utilities/functions.php
+++ b/lib/api/utilities/functions.php
@@ -86,11 +86,11 @@ function beans_remove_dir( $dir_path ) {
 		if ( is_dir( $path ) ) {
 			beans_remove_dir( $path );
 		} else {
-			@unlink( $path ); // phpcs:disable Generic.PHP.NoSilencedErrors.Discouraged -- Valid use cases.
+			@unlink( $path ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged -- Valid use cases.
 		}
 	}
 
-	return @rmdir( $dir_path ); // phpcs:disable Generic.PHP.NoSilencedErrors.Discouraged -- Valid use cases.
+	return @rmdir( $dir_path ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged -- Valid use cases.
 }
 
 /**

--- a/lib/api/utilities/polyfills.php
+++ b/lib/api/utilities/polyfills.php
@@ -42,7 +42,7 @@ if ( ! function_exists( 'array_replace_recursive' ) ) {
 			$from_base = beans_get( $key, $array1 );
 
 			if ( is_array( $value ) && is_array( $from_base ) ) {
-				$array1[ $key ] = array_replace_recursive( $from_base, $value ); // @codingStandardsIgnoreLine - PHPCompatibility.PHP.NewFunctions.array_replace_recursiveFound) - Sniffer is not picking up the polyfill.
+				$array1[ $key ] = array_replace_recursive( $from_base, $value ); // phpcs:ignore PHPCompatibility.PHP.NewFunctions.array_replace_recursiveFound -- This polyfill provides the construct for PHP 5.2.
 			} else {
 				$array1[ $key ] = $value;
 			}

--- a/lib/api/widget/functions.php
+++ b/lib/api/widget/functions.php
@@ -6,7 +6,7 @@
  *
  * @package Beans\Framework\API\Widgets
  *
- * @since   1.0.0
+ * @since 1.0.0
  */
 
 /**
@@ -25,22 +25,21 @@
  *
  * @since 1.0.0
  *
- * @param array $args                       {
- *                                          Optional. Arguments used by the widget area.
+ * @param array $args {
+ *      Optional. Arguments used by the widget area.
  *
- * @type string $id                         Optional. The unique identifier by which the widget area will be called.
- * @type string $name                       Optional. The name or title of the widget area displayed in the
- *                                           admin dashboard.
- * @type string $description                Optional. The widget area description.
- * @type string $beans_type                 Optional. The widget area type. Accepts 'stack', 'grid' or 'offcanvas'.
- *                                           Default stack.
- * @type bool   $beans_show_widget_title    Optional. Whether to show the widget title or not. Default true.
- * @type bool   $beans_show_widget_badge    Optional. Whether to show the widget badge or not. Default false.
- * @type bool   $beans_widget_badge_content Optional. The badge content. This may contain widget shortcodes
- *                                           {@see beans_widget_shortcodes()}. Default 'Hello'.
+ *      @type string $id                         Optional. The unique identifier by which the widget area will be called.
+ *      @type string $name                       Optional. The name or title of the widget area displayed in the
+ *                                               admin dashboard.
+ *      @type string $description                Optional. The widget area description.
+ *      @type string $beans_type                 Optional. The widget area type. Accepts 'stack', 'grid' or 'offcanvas'.
+ *                                               Default is stack.
+ *      @type bool   $beans_show_widget_title    Optional. Whether to show the widget title or not. Default true.
+ *      @type bool   $beans_show_widget_badge    Optional. Whether to show the widget badge or not. Default false.
+ *      @type bool   $beans_widget_badge_content Optional. The badge content. This may contain widget shortcodes
+ *                                               {@see beans_widget_shortcodes()}. Default is 'Hello'.
  * }
- *
- * @param array $widget_control             Optional.
+ * @param array $widget_control Optional.
  *
  * @return string The widget area ID is added to the $wp_registered_sidebars globals when the widget area is setup.
  */

--- a/lib/api/widget/functions.php
+++ b/lib/api/widget/functions.php
@@ -6,7 +6,7 @@
  *
  * @package Beans\Framework\API\Widgets
  *
- * @since 1.0.0
+ * @since   1.0.0
  */
 
 /**
@@ -25,21 +25,22 @@
  *
  * @since 1.0.0
  *
- * @param array $args {
- *     Optional. Arguments used by the widget area.
+ * @param array $args                       {
+ *                                          Optional. Arguments used by the widget area.
  *
- *     @type string $id                      Optional. The unique identifier by which the widget area will be called.
- *     @type string $name                    Optional. The name or title of the widget area displayed in the
+ * @type string $id                         Optional. The unique identifier by which the widget area will be called.
+ * @type string $name                       Optional. The name or title of the widget area displayed in the
  *                                           admin dashboard.
- *     @type string $description             Optional. The widget area description.
- *     @type string $beans_type                 Optional. The widget area type. Accepts 'stack', 'grid' or 'offcanvas'.
+ * @type string $description                Optional. The widget area description.
+ * @type string $beans_type                 Optional. The widget area type. Accepts 'stack', 'grid' or 'offcanvas'.
  *                                           Default stack.
- *     @type bool   $beans_show_widget_title    Optional. Whether to show the widget title or not. Default true.
- *     @type bool   $beans_show_widget_badge    Optional. Whether to show the widget badge or not. Default false.
- *     @type bool   $beans_widget_badge_content Optional. The badge content. This may contain widget shortcodes
+ * @type bool   $beans_show_widget_title    Optional. Whether to show the widget title or not. Default true.
+ * @type bool   $beans_show_widget_badge    Optional. Whether to show the widget badge or not. Default false.
+ * @type bool   $beans_widget_badge_content Optional. The badge content. This may contain widget shortcodes
  *                                           {@see beans_widget_shortcodes()}. Default 'Hello'.
  * }
- * @param array $widget_control Optional.
+ *
+ * @param array $widget_control             Optional.
  *
  * @return string The widget area ID is added to the $wp_registered_sidebars globals when the widget area is setup.
  */
@@ -111,8 +112,8 @@ function beans_is_active_widget_area( $id ) {
 /**
  * Check whether a widget area is registered.
  *
- * While {@see beans_is_active_widget_area()} checks if a widget area contains widgets, this function only checks if a widget
- * area is registered.
+ * While {@see beans_is_active_widget_area()} checks if a widget area contains widgets, this function only checks if a
+ * widget area is registered.
  *
  * @since 1.0.0
  *
@@ -155,16 +156,16 @@ function beans_widget_area( $id ) {
 	 */
 	do_action( 'beans_widget_area_init' );
 
-		ob_start();
+	ob_start();
 
-			/**
-			 * Fires when {@see beans_widget_area()} is called.
-			 *
-			 * @since 1.0.0
-			 */
-			do_action( 'beans_widget_area' );
+	/**
+	 * Fires when {@see beans_widget_area()} is called.
+	 *
+	 * @since 1.0.0
+	 */
+	do_action( 'beans_widget_area' );
 
-		$output = ob_get_clean();
+	$output = ob_get_clean();
 
 	// Reset widget area global to reduce memory usage.
 	_beans_reset_widget_area();
@@ -321,7 +322,7 @@ function beans_widget_shortcodes( $content ) {
 /**
  * Set up widget area global data.
  *
- * @since 1.0.0
+ * @since  1.0.0
  * @ignore
  * @access private
  *
@@ -337,12 +338,15 @@ function _beans_setup_widget_area( $id ) {
 	}
 
 	// Add widget area delimiters. This is used to split wp sidebar as well as the widgets title.
-	$wp_registered_sidebars[ $id ] = array_merge( $wp_registered_sidebars[ $id ], array( // @codingStandardsIgnoreLine - WordPress.Variables.GlobalVariables.OverrideProhibited.
-		'before_widget' => '<!--widget-%1$s-->',
-		'after_widget'  => '<!--widget-end-->',
-		'before_title'  => '<!--title-start-->',
-		'after_title'   => '<!--title-end-->',
-	) );
+	$wp_registered_sidebars[ $id ] = array_merge( // phpcs:ignore WordPress.Variables.GlobalVariables.OverrideProhibited -- Valid use case.
+		$wp_registered_sidebars[ $id ],
+		array(
+			'before_widget' => '<!--widget-%1$s-->',
+			'after_widget'  => '<!--widget-end-->',
+			'before_title'  => '<!--title-start-->',
+			'after_title'   => '<!--title-end-->',
+		)
+	);
 
 	// Start building widget area global before dynamic_sidebar is called.
 	$_beans_widget_area = $wp_registered_sidebars[ $id ];
@@ -359,7 +363,7 @@ function _beans_setup_widget_area( $id ) {
 	// Prepare widgets count.
 	preg_match_all( '#<!--widget-end-->#', $sidebar, $counter );
 
-	// Continue building widget area global with the splited sidebar elements.
+	// Continue building widget area global with the split sidebar elements.
 	$_beans_widget_area['widgets_count']  = count( $counter[0] );
 	$_beans_widget_area['current_widget'] = 0;
 
@@ -376,7 +380,7 @@ function _beans_setup_widget_area( $id ) {
 /**
  * Setup widget area global widgets data.
  *
- * @since 1.0.0
+ * @since  1.0.0
  * @ignore
  * @access private
  *
@@ -478,7 +482,7 @@ function _beans_setup_widgets( $widget_area_content ) {
 /**
  * Setup widget global data.
  *
- * @since 1.0.0
+ * @since  1.0.0
  * @ignore
  * @access private
  *
@@ -495,7 +499,7 @@ function _beans_setup_widget( $id ) {
 /**
  * Reset widget area global data.
  *
- * @since 1.0.0
+ * @since  1.0.0
  * @ignore
  * @access private
  *
@@ -508,7 +512,7 @@ function _beans_reset_widget_area() {
 /**
  * Reset widget global data.
  *
- * @since 1.0.0
+ * @since  1.0.0
  * @ignore
  * @access private
  *
@@ -519,13 +523,13 @@ function _beans_reset_widget() {
 }
 
 /**
- * Build widget area subfilters.
+ * Build widget area sub-filters.
  *
- * @since 1.0.0
+ * @since  1.0.0
  * @ignore
  * @access private
  *
- * @return array
+ * @return string
  */
 function _beans_widget_area_subfilters() {
 	global $_beans_widget_area;
@@ -535,13 +539,13 @@ function _beans_widget_area_subfilters() {
 }
 
 /**
- * Build widget subfilters.
+ * Build widget sub-filters.
  *
- * @since 1.0.0
+ * @since  1.0.0
  * @ignore
  * @access private
  *
- * @return array
+ * @return string
  */
 function _beans_widget_subfilters() {
 	global $_beans_widget_area, $_beans_widget;
@@ -559,13 +563,13 @@ add_action( 'the_widget', '_beans_force_the_widget', 10, 3 );
 /**
  * Force atypical widget added using the_widget() to have a correctly registered id.
  *
- * @since 1.0.0
+ * @since  1.0.0
  * @ignore
  * @access private
  *
- * @param string $widget The widget's PHP class name (see class-wp-widget.php).
+ * @param string $widget   The widget's PHP class name (see class-wp-widget.php).
  * @param array  $instance Optional. The widget's instance settings. Default empty array.
- * @param array  $args Array of arguments to configure the display of the widget.
+ * @param array  $args     Array of arguments to configure the display of the widget.
  *
  * @return void
  */

--- a/lib/api/wp-customize/class.php
+++ b/lib/api/wp-customize/class.php
@@ -194,7 +194,7 @@ if ( class_exists( 'WP_Customize_Control' ) ) :
 	 *
 	 * @package Beans\Framework\API\WP_Customize
 	 */
-	class _Beans_WP_Customize_Control extends WP_Customize_Control { // phpcs:ignore Generic.Files.OneClassPerFile.MultipleFound -- Will be fixed.
+	class _Beans_WP_Customize_Control extends WP_Customize_Control { // phpcs:ignore Generic.Files.OneClassPerFile.MultipleFound, Generic.Classes.OpeningBraceSameLine.ContentAfterBrace -- Will be fixed.
 
 		/**
 		 * Field data.

--- a/lib/api/wp-customize/class.php
+++ b/lib/api/wp-customize/class.php
@@ -36,7 +36,7 @@ final class _Beans_WP_Customize {
 	 * Constructor.
 	 *
 	 * @param string $section Field section.
-	 * @param array  $args Metabox arguments.
+	 * @param array  $args Meta box arguments.
 	 */
 	public function __construct( $section, $args ) {
 		$defaults = array(
@@ -113,7 +113,7 @@ final class _Beans_WP_Customize {
 	 * @ignore
 	 *
 	 * @param WP_Customize_Manager $wp_customize WP Customizer Manager object.
-	 * @param array                $field Metabox settings.
+	 * @param array                $field Meta box settings.
 	 *
 	 * @return void
 	 */
@@ -145,7 +145,7 @@ final class _Beans_WP_Customize {
 	 * @ignore
 	 *
 	 * @param WP_Customize_Manager $wp_customize WP Customizer Manager object.
-	 * @param array                $field Metabox settings.
+	 * @param array                $field Meta box settings.
 	 *
 	 * @return void
 	 */
@@ -170,7 +170,7 @@ final class _Beans_WP_Customize {
 	}
 
 	/**
-	 * Sanatize value.
+	 * Sanitize the value.
 	 *
 	 * @since 1.0.0
 	 *
@@ -194,7 +194,7 @@ if ( class_exists( 'WP_Customize_Control' ) ) :
 	 *
 	 * @package Beans\Framework\API\WP_Customize
 	 */
-	class _Beans_WP_Customize_Control extends WP_Customize_Control { // @codingStandardsIgnoreLine - Generic.Files.OneClassPerFile.MultipleFound.
+	class _Beans_WP_Customize_Control extends WP_Customize_Control { // phpcs:ignore Generic.Files.OneClassPerFile.MultipleFound -- Will be fixed.
 
 		/**
 		 * Field data.

--- a/tests/phpunit/integration/api/actions/includes/class-actions-test-case.php
+++ b/tests/phpunit/integration/api/actions/includes/class-actions-test-case.php
@@ -209,6 +209,6 @@ abstract class Actions_Test_Case extends WP_UnitTestCase {
 
 		$post_id = self::factory()->post->create( array( 'post_title' => 'Hello Beans' ) );
 		$this->go_to( get_permalink( $post_id ) );
-		do_action( 'template_redirect' ); // @codingStandardsIgnoreLine
+		do_action( 'template_redirect' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Valid use case as we need to fire this action as part of our tests.
 	}
 }

--- a/tests/phpunit/integration/api/filters/includes/class-filters-test-case.php
+++ b/tests/phpunit/integration/api/filters/includes/class-filters-test-case.php
@@ -66,6 +66,6 @@ abstract class Filters_Test_Case extends WP_UnitTestCase {
 	protected function go_to_post() {
 		$post_id = self::factory()->post->create( array( 'post_title' => 'Hello Beans' ) );
 		$this->go_to( get_permalink( $post_id ) );
-		do_action( 'template_redirect' ); // @codingStandardsIgnoreLine
+		do_action( 'template_redirect' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Valid use case as we need to fire this action as part of our tests.
 	}
 }

--- a/tests/phpunit/integration/bootstrap.php
+++ b/tests/phpunit/integration/bootstrap.php
@@ -11,15 +11,15 @@
  */
 
 if ( ! file_exists( '../../../wp-content' ) ) {
-	trigger_error( 'Unable to run the integration tests, because the wp-content folder does not exist.', E_USER_ERROR );  // @codingStandardsIgnoreLine.
+	trigger_error( 'Unable to run the integration tests, because the wp-content folder does not exist.', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Valid use case for our testing suite.
 }
 
 define( 'BEANS_TESTS_DIR', __DIR__ );
 define( 'BEANS_THEME_DIR', dirname( dirname( dirname( __DIR__ ) ) ) );
-define( 'WP_CONTENT_DIR', dirname( dirname( dirname( getcwd() ) ) ) . '/wp-content/' ); // @codingStandardsIgnoreLine.
+define( 'WP_CONTENT_DIR', dirname( dirname( dirname( getcwd() ) ) ) . '/wp-content/' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- Our tests need to define this constant.
 
 if ( ! defined( 'WP_PLUGIN_DIR' ) ) {
-	define( 'WP_PLUGIN_DIR', WP_CONTENT_DIR . 'plugins/' ); // @codingStandardsIgnoreLine.
+	define( 'WP_PLUGIN_DIR', WP_CONTENT_DIR . 'plugins/' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- When this constant is not already defined, we define it here. It's a valid use case for our testing suite.
 }
 
 /**
@@ -44,7 +44,7 @@ function beans_get_wp_tests_dir() {
 
 	// Check it again. If it doesn't exist, stop here and post a message as to why we stopped.
 	if ( ! file_exists( $tests_dir . '/includes/' ) ) {
-		trigger_error( 'Unable to run the integration tests, because the WordPress test suite could not be located.', E_USER_ERROR );  // @codingStandardsIgnoreLine.
+		trigger_error( 'Unable to run the integration tests, because the WordPress test suite could not be located.', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Valid use case for our testing suite.
 	}
 
 	// Strip off the trailing directory separator, if it exists.

--- a/tests/phpunit/unit/api/actions/beansRenderAction.php
+++ b/tests/phpunit/unit/api/actions/beansRenderAction.php
@@ -61,7 +61,7 @@ class Tests_BeansRenderAction extends Test_Case {
 			$this->assertEquals( $expected_args[ $args[0] ], $args[1] );
 
 			// Let's echo out to ensure this callback will was called.
-			echo $args[1][0];  // @codingStandardsIgnoreLine - WordPress.XSS.EscapeOutput.OutputNotEscaped - reason: we are not testing escaping functionality.
+			echo $args[1][0];  // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Not testing escaping functionality.
 		};
 		add_action( 'beans_stub', $callback );
 		$this->assertTrue( has_action( 'beans_stub' ) );

--- a/tests/phpunit/unit/api/actions/stubs/class-action-stub.php
+++ b/tests/phpunit/unit/api/actions/stubs/class-action-stub.php
@@ -36,6 +36,6 @@ class Actions_Stub {
 	 * @param string|int $message Message to echo.
 	 */
 	public static function echo_static( $message ) {
-		echo $message; // @codingStandardsIgnoreLine - WordPress.XSS.EscapeOutput.OutputNotEscaped - reason: we are not testing escaping functionality.
+		echo $message; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Not testing escaping functionality.
 	}
 }

--- a/tests/phpunit/unit/api/utilities/beansRenderFunction.php
+++ b/tests/phpunit/unit/api/utilities/beansRenderFunction.php
@@ -56,12 +56,12 @@ class Tests_BeansRenderFunction extends Test_Case {
 		$this->assertSame( 'foo', beans_render_function( 'callback_for_render_function', 'foo' ) );
 
 		$callback = function ( $foo, $bar, $baz ) {
-			echo "{$foo} {$bar} {$baz}"; // @codingStandardsIgnoreLine - WordPress.XSS.EscapeOutput.OutputNotEscaped - reason: we are not testing escaping functionality.
+			echo "{$foo} {$bar} {$baz}"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Not testing escaping functionality.
 		};
 		$this->assertSame( 'foo bar baz', beans_render_function( $callback, 'foo', 'bar', 'baz' ) );
 
 		$callback = function ( $array, $baz ) {
-			echo join( ' ', $array ) . ' ' . $baz; // @codingStandardsIgnoreLine - WordPress.XSS.EscapeOutput.OutputNotEscaped - reason: we are not testing escaping functionality.
+			echo join( ' ', $array ) . ' ' . $baz; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Not testing escaping functionality.
 		};
 		$this->assertSame(
 			'foo bar baz',
@@ -70,7 +70,7 @@ class Tests_BeansRenderFunction extends Test_Case {
 
 		$callback = function ( $object ) {
 			$this->assertObjectHasAttribute( 'foo', $object );
-			echo $object->foo; // @codingStandardsIgnoreLine - WordPress.XSS.EscapeOutput.OutputNotEscaped - reason: we are not testing escaping functionality.
+			echo $object->foo; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Not testing escaping functionality.
 		};
 		$this->assertSame(
 			'beans',

--- a/tests/phpunit/unit/api/utilities/beansRenderFunctionArray.php
+++ b/tests/phpunit/unit/api/utilities/beansRenderFunctionArray.php
@@ -51,7 +51,7 @@ class Tests_BeansRenderFunctionArray extends Test_Case {
 	public function test_should_work_with_arguments() {
 
 		$callback = function ( $foo, $bar, $baz ) {
-			echo "{$foo} {$bar} {$baz}"; // @codingStandardsIgnoreLine - WordPress.XSS.EscapeOutput.OutputNotEscaped - reason: we are not testing escaping functionality.
+			echo "{$foo} {$bar} {$baz}"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Not testing escaping functionality.
 		};
 		$this->assertSame(
 			'foo bar baz',
@@ -60,7 +60,7 @@ class Tests_BeansRenderFunctionArray extends Test_Case {
 
 		$callback = function ( $array, $baz ) {
 			$this->assertCount( 2, $array );
-			echo join( ' ', $array ) . ' ' . $baz; // @codingStandardsIgnoreLine - WordPress.XSS.EscapeOutput.OutputNotEscaped - reason: we are not testing escaping functionality.
+			echo join( ' ', $array ) . ' ' . $baz; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Not testing escaping functionality.
 		};
 		$this->assertSame(
 			'foo bar baz',
@@ -72,7 +72,7 @@ class Tests_BeansRenderFunctionArray extends Test_Case {
 			$this->assertArrayHasKey( 'bar', $array1 );
 			$this->assertCount( 1, $array2 );
 			$this->assertArrayHasKey( 'baz', $array2 );
-			echo $array1['foo']; // @codingStandardsIgnoreLine - WordPress.XSS.EscapeOutput.OutputNotEscaped - reason: we are not testing escaping functionality.
+			echo $array1['foo']; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Not testing escaping functionality.
 		};
 		$this->assertSame(
 			'oof',

--- a/tests/phpunit/unit/bootstrap.php
+++ b/tests/phpunit/unit/bootstrap.php
@@ -11,7 +11,7 @@
  */
 
 if ( version_compare( phpversion(), '5.6.0', '<' ) ) {
-	trigger_error( 'Beans Unit Tests require PHP 5.6 or higher.', E_USER_ERROR );  // @codingStandardsIgnoreLine.
+	trigger_error( 'Beans Unit Tests require PHP 5.6 or higher.', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Valid use case for our testing suite.
 }
 
 define( 'BEANS_TESTS_DIR', __DIR__ );
@@ -20,14 +20,14 @@ define( 'BEANS_TESTS_LIB_DIR', BEANS_THEME_DIR . 'lib' . DIRECTORY_SEPARATOR );
 
 // Let's define ABSPATH as it is in WordPress, i.e. relative to the filesystem's WordPress root path.
 if ( ! defined( 'ABSPATH' ) ) {
-	define( 'ABSPATH', dirname( dirname( dirname( BEANS_THEME_DIR ) ) ) . '/' ); // @codingStandardsIgnoreLine - WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound - ABSPATH is required.
+	define( 'ABSPATH', dirname( dirname( dirname( BEANS_THEME_DIR ) ) ) . '/' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- Valid use case for our testing suite.
 }
 
 // Time to load Composer's autoloader.
 $beans_autoload_path = BEANS_THEME_DIR . 'vendor/';
 
 if ( ! file_exists( $beans_autoload_path . 'autoload.php' ) ) {
-	trigger_error( 'Whoops, we need Composer before we start running tests.  Please type: `composer install`.  When done, try running `phpunit` again.', E_USER_ERROR );  // @codingStandardsIgnoreLine.
+	trigger_error( 'Whoops, we need Composer before we start running tests.  Please type: `composer install`.  When done, try running `phpunit` again.', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Valid use case for our testing suite.
 }
 require_once $beans_autoload_path . 'autoload.php';
 unset( $beans_autoload_path );

--- a/tests/phpunit/unit/class-test-case.php
+++ b/tests/phpunit/unit/class-test-case.php
@@ -39,8 +39,7 @@ abstract class Test_Case extends TestCase {
 		} );
 
 		Functions\when( 'wp_json_encode' )->alias( function ( $array ) {
-			// @codingStandardsIgnoreLine - WordPress.WP.AlternativeFunctions.json_encode_json_encode - we are mocking the function here.
-			return json_encode( $array );
+			return json_encode( $array ); // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- Required as part of our mock.
 		} );
 	}
 


### PR DESCRIPTION
Credit to @GaryJones - This PR upgrades our PHP sniffers to use the latest version, thereby allowing us to remove the deprecated `// @coding...` ignore declarations.

It standardizes our ignore syntax to be:

```
// phpcs:ignore Rule.To.Be.Ignored, Another.Rule.To.Be.Ignored -- Reason why we are ignoring this rule(s)
```

Closes #144 