### PR TITLE
Replaced deprecated phpcs rule ignores for api/html/attributes

### DIFF
--- a/tests/phpunit/integration/api/html/beansAddAttribute.php
+++ b/tests/phpunit/integration/api/html/beansAddAttribute.php
@@ -36,7 +36,7 @@ class Tests_BeansAddAttribute extends HTML_Test_Case {
 			$this->assertSame( 10, has_filter( $hook, array( $attributes, 'add' ), 10 ) );
 			$expected              = $markup_attributes;
 			$expected['data-test'] = '';
-			$this->assertSame( $expected, apply_filters( $hook, $markup_attributes ) ); // @codingStandardsIgnoreLine - WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound  The hook's name is in the value.
+			$this->assertSame( $expected, apply_filters( $hook, $markup_attributes ) ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
 
 			// Clean up.
 			remove_filter( $hook, array( $attributes, 'add' ), 10 );
@@ -62,7 +62,7 @@ class Tests_BeansAddAttribute extends HTML_Test_Case {
 			$this->assertSame( 10, has_filter( $hook, array( $attributes, 'add' ), 10 ) );
 			$expected           = $markup['attributes'];
 			$expected['class'] .= ' beans-test';
-			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // @codingStandardsIgnoreLine - WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound  The hook's name is in the value.
+			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
 
 			// Clean up.
 			remove_filter( $hook, array( $attributes, 'add' ), 10 );

--- a/tests/phpunit/integration/api/html/beansRemoveAttribute.php
+++ b/tests/phpunit/integration/api/html/beansRemoveAttribute.php
@@ -37,7 +37,7 @@ class Tests_BeansRemoveAttribute extends HTML_Test_Case {
 			$this->assertSame( 10, has_filter( $hook, array( $attributes, 'remove' ), 10 ) );
 			$expected = $markup['attributes'];
 			unset( $expected[ $attribute ] );
-			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // @codingStandardsIgnoreLine - WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound  The hook's name is in the value.
+			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
 
 			// Clean up.
 			remove_filter( $hook, array( $attributes, 'remove' ), 10 );
@@ -60,7 +60,7 @@ class Tests_BeansRemoveAttribute extends HTML_Test_Case {
 			$this->assertSame( 10, has_filter( $hook, array( $attributes, 'remove' ), 10 ) );
 			$expected               = $markup['attributes'];
 			$expected[ $attribute ] = str_replace( $value, '', $expected[ $attribute ] );
-			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // @codingStandardsIgnoreLine - WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound  The hook's name is in the value.
+			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
 
 			// Clean up.
 			remove_filter( $hook, array( $attributes, 'remove' ), 10 );

--- a/tests/phpunit/integration/api/html/beansReplaceAttribute.php
+++ b/tests/phpunit/integration/api/html/beansReplaceAttribute.php
@@ -84,7 +84,7 @@ class Tests_BeansReplaceAttribute extends HTML_Test_Case {
 			$this->assertSame( 10, has_filter( $hook, array( $attributes, 'replace' ), 10 ) );
 			$expected               = $markup['attributes'];
 			$expected[ $attribute ] = null;
-			$actual = apply_filters( $hook, $markup['attributes'] ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
+			$actual                 = apply_filters( $hook, $markup['attributes'] ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
 			$this->assertSame( $expected, $actual );
 			$this->assertNotSame( $value, $actual[ $attribute ] );
 			$this->assertNull( $actual[ $attribute ] );
@@ -110,7 +110,7 @@ class Tests_BeansReplaceAttribute extends HTML_Test_Case {
 			$this->assertSame( 10, has_filter( $hook, array( $attributes, 'replace' ), 10 ) );
 			$expected               = $markup['attributes'];
 			$expected[ $attribute ] = '';
-			$actual = apply_filters( $hook, $markup['attributes'] ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
+			$actual                 = apply_filters( $hook, $markup['attributes'] ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
 			$this->assertSame( $expected, $actual );
 			$this->assertNotSame( $value, $actual[ $attribute ] );
 			$this->assertSame( '', $actual[ $attribute ] );

--- a/tests/phpunit/integration/api/html/beansReplaceAttribute.php
+++ b/tests/phpunit/integration/api/html/beansReplaceAttribute.php
@@ -38,7 +38,7 @@ class Tests_BeansReplaceAttribute extends HTML_Test_Case {
 			$this->assertSame( 10, has_filter( $hook, array( $attributes, 'replace' ), 10 ) );
 			$expected               = $markup['attributes'];
 			$expected[ $attribute ] = str_replace( $value, 'beans-test', $expected[ $attribute ] );
-			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // @codingStandardsIgnoreLine - WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound  The hook's name is in the value.
+			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
 
 			// Clean up.
 			remove_filter( $hook, array( $attributes, 'replace' ), 10 );
@@ -61,7 +61,7 @@ class Tests_BeansReplaceAttribute extends HTML_Test_Case {
 			$this->assertSame( 10, has_filter( $hook, array( $attributes, 'replace' ), 10 ) );
 			$expected               = $markup['attributes'];
 			$expected[ $attribute ] = str_replace( $value, 'beans-test', $expected[ $attribute ] );
-			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // @codingStandardsIgnoreLine - WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound  The hook's name is in the value.
+			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
 
 			// Clean up.
 			remove_filter( $hook, array( $attributes, 'replace' ), 10 );
@@ -84,7 +84,7 @@ class Tests_BeansReplaceAttribute extends HTML_Test_Case {
 			$this->assertSame( 10, has_filter( $hook, array( $attributes, 'replace' ), 10 ) );
 			$expected               = $markup['attributes'];
 			$expected[ $attribute ] = null;
-			$actual = apply_filters( $hook, $markup['attributes'] ); // @codingStandardsIgnoreLine - WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound  The hook's name is in the value.
+			$actual = apply_filters( $hook, $markup['attributes'] ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
 			$this->assertSame( $expected, $actual );
 			$this->assertNotSame( $value, $actual[ $attribute ] );
 			$this->assertNull( $actual[ $attribute ] );
@@ -110,7 +110,7 @@ class Tests_BeansReplaceAttribute extends HTML_Test_Case {
 			$this->assertSame( 10, has_filter( $hook, array( $attributes, 'replace' ), 10 ) );
 			$expected               = $markup['attributes'];
 			$expected[ $attribute ] = '';
-			$actual = apply_filters( $hook, $markup['attributes'] ); // @codingStandardsIgnoreLine - WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound  The hook's name is in the value.
+			$actual = apply_filters( $hook, $markup['attributes'] ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
 			$this->assertSame( $expected, $actual );
 			$this->assertNotSame( $value, $actual[ $attribute ] );
 			$this->assertSame( '', $actual[ $attribute ] );

--- a/tests/phpunit/unit/api/html/beansAddAttribute.php
+++ b/tests/phpunit/unit/api/html/beansAddAttribute.php
@@ -43,7 +43,7 @@ class Tests_BeansAddAttribute extends HTML_Test_Case {
 			$this->assertTrue( has_filter( $hook, array( $attributes, 'add' ), 10 ) );
 			$expected              = $markup_attributes;
 			$expected['data-test'] = '';
-			$this->assertSame( $expected, apply_filters( $hook, $markup_attributes ) ); // @codingStandardsIgnoreLine - WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound  The hook's name is in the value.
+			$this->assertSame( $expected, apply_filters( $hook, $markup_attributes ) ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
 
 			// Clean up.
 			remove_filter( $hook, array( $attributes, 'add' ), 10 );
@@ -75,7 +75,7 @@ class Tests_BeansAddAttribute extends HTML_Test_Case {
 			$this->assertTrue( has_filter( $hook, array( $attributes, 'add' ), 10 ) );
 			$expected           = $markup['attributes'];
 			$expected['class'] .= ' beans-test';
-			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // @codingStandardsIgnoreLine - WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound  The hook's name is in the value.
+			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
 
 			// Clean up.
 			remove_filter( $hook, array( $attributes, 'add' ), 10 );

--- a/tests/phpunit/unit/api/html/beansRemoveAttribute.php
+++ b/tests/phpunit/unit/api/html/beansRemoveAttribute.php
@@ -44,7 +44,7 @@ class Tests_BeansRemoveAttribute extends HTML_Test_Case {
 			$this->assertTrue( has_filter( $hook, array( $attributes, 'remove' ), 10 ) );
 			$expected = $markup['attributes'];
 			unset( $expected[ $attribute ] );
-			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // @codingStandardsIgnoreLine - WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound  The hook's name is in the value.
+			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
 
 			// Clean up.
 			remove_filter( $hook, array( $attributes, 'remove' ), 10 );
@@ -73,7 +73,7 @@ class Tests_BeansRemoveAttribute extends HTML_Test_Case {
 			$this->assertTrue( has_filter( $hook, array( $attributes, 'remove' ), 10 ) );
 			$expected               = $markup['attributes'];
 			$expected[ $attribute ] = str_replace( $value, '', $expected[ $attribute ] );
-			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // @codingStandardsIgnoreLine - WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound  The hook's name is in the value.
+			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
 
 			// Clean up.
 			remove_filter( $hook, array( $attributes, 'remove' ), 10 );

--- a/tests/phpunit/unit/api/html/beansReplaceAttribute.php
+++ b/tests/phpunit/unit/api/html/beansReplaceAttribute.php
@@ -45,7 +45,7 @@ class Tests_BeansReplaceAttribute extends HTML_Test_Case {
 			$this->assertTrue( has_filter( $hook, array( $attributes, 'replace' ), 10 ) );
 			$expected               = $markup['attributes'];
 			$expected[ $attribute ] = str_replace( $value, 'beans-test', $expected[ $attribute ] );
-			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // @codingStandardsIgnoreLine - WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound  The hook's name is in the value.
+			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
 
 			// Clean up.
 			remove_filter( $hook, array( $attributes, 'replace' ), 10 );
@@ -75,7 +75,7 @@ class Tests_BeansReplaceAttribute extends HTML_Test_Case {
 			$this->assertTrue( has_filter( $hook, array( $attributes, 'replace' ), 10 ) );
 			$expected               = $markup['attributes'];
 			$expected[ $attribute ] = str_replace( $value, 'beans-test', $expected[ $attribute ] );
-			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // @codingStandardsIgnoreLine - WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound  The hook's name is in the value.
+			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
 
 			// Clean up.
 			remove_filter( $hook, array( $attributes, 'replace' ), 10 );
@@ -104,7 +104,7 @@ class Tests_BeansReplaceAttribute extends HTML_Test_Case {
 			$this->assertTrue( has_filter( $hook, array( $attributes, 'replace' ), 10 ) );
 			$expected               = $markup['attributes'];
 			$expected[ $attribute ] = null;
-			$actual                 = apply_filters( $hook, $markup['attributes'] ); // @codingStandardsIgnoreLine - WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound  The hook's name is in the value.
+			$actual                 = apply_filters( $hook, $markup['attributes'] ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
 			$this->assertSame( $expected, $actual );
 			$this->assertNotSame( $value, $actual[ $attribute ] );
 			$this->assertNull( $actual[ $attribute ] );
@@ -136,7 +136,7 @@ class Tests_BeansReplaceAttribute extends HTML_Test_Case {
 			$this->assertTrue( has_filter( $hook, array( $attributes, 'replace' ), 10 ) );
 			$expected               = $markup['attributes'];
 			$expected[ $attribute ] = '';
-			$actual                 = apply_filters( $hook, $markup['attributes'] ); // @codingStandardsIgnoreLine - WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound  The hook's name is in the value.
+			$actual                 = apply_filters( $hook, $markup['attributes'] ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
 			$this->assertSame( $expected, $actual );
 			$this->assertNotSame( $value, $actual[ $attribute ] );
 			$this->assertSame( '', $actual[ $attribute ] );


### PR DESCRIPTION
This PR replaces the deprecated `// @coding...` phpcs and wpcs rule ignores.