### PR TITLE
Replaced deprecated phpcs rule ignores for Fields API.

### DIFF
--- a/lib/api/fields/functions.php
+++ b/lib/api/fields/functions.php
@@ -15,24 +15,23 @@
  * @since 1.0.0
  *
  * @param array  $fields      {
- *                            Array of fields to register.
+ *      Array of fields to register.
  *
- * @type string  $id          A unique id used for the field. This id will also be used to save the value in the
- *       database.
- * @type string  $type        The type of field to use. Please refer to the Beans core field types for more
- *       information. Custom field types are accepted here.
- * @type string  $label       The field label. Default false.
- * @type string  $description The field description. The description can be truncated using <!--more--> as a delimiter.
- *       Default false.
- * @type array   $attributes  An array of attributes to add to the field. The array key defines the attribute name and
- *       the array value defines the attribute value. Default array.
- * @type mixed   $default     The default field value. Default false.
- * @type array   $fields      Must only be used for the 'group' field type. The array arguments are similar to the
- *       {@see beans_register_fields()} $fields arguments.
- * @type bool    $db_group    Must only be used for the 'group' field type. It defines whether the group of fields
- *       should be saved as a group or as individual entries in the database. Default false.
+ *      @type string  $id          A unique id used for the field. This id will also be used to save the value in the
+ *                                 database.
+ *      @type string  $type        The type of field to use. Please refer to the Beans core field types for more
+ *                                 information. Custom field types are accepted here.
+ *      @type string  $label       The field label. Default false.
+ *      @type string  $description The field description. The description can be truncated using <!--more--> as a
+ *                                 delimiter. Default false.
+ *      @type array   $attributes  An array of attributes to add to the field. The array key defines the attribute name
+ *                                 and the array value defines the attribute value. Default array.
+ *      @type mixed   $default     The default field value. Default false.
+ *      @type array   $fields      Must only be used for the 'group' field type. The array arguments are similar to the
+ *                                 {@see beans_register_fields()} $fields arguments.
+ *      @type bool    $db_group    Must only be used for the 'group' field type. It defines whether the group of fields
+ *                                 should be saved as a group or as individual entries in the database. Default false.
  * }
- *
  * @param string $context     The context in which the fields are used. 'option' for options/settings pages,
  *                            'post_meta' for post fields, 'term_meta' for taxonomies fields and 'wp_customize' for WP
  *                            customizer fields.
@@ -61,11 +60,11 @@ function beans_register_fields( array $fields, $context, $section ) {
  *
  * @since 1.0.0
  *
- * @param string $context The context in which the fields are used. 'option' for options/settings pages, 'post_meta'
- *                        for post fields, 'term_meta' for taxonomies fields and 'wp_customize' for WP customizer
- *                        fields.
- * @param string $section Optional. A section ID to define a group of fields. This is mostly used for metaboxes and WP
- *                        Customizer sections.
+ * @param string      $context The context in which the fields are used. 'option' for options/settings pages,
+ *                             'post_meta' for post fields, 'term_meta' for taxonomies fields and 'wp_customize' for WP
+ *                             customizer fields.
+ * @param string|bool $section Optional. A section ID to define a group of fields. This is mostly used for metaboxes
+ *                             and WP Customizer sections.
  *
  * @return array|bool Array of registered fields on success, false on failure.
  */

--- a/lib/api/fields/types/text.php
+++ b/lib/api/fields/types/text.php
@@ -26,6 +26,6 @@ function beans_field_text( array $field ) {
 		esc_attr( $field['id'] ),
 		esc_attr( $field['name'] ),
 		esc_attr( $field['value'] ),
-		beans_esc_attributes( $field['attributes'] ) // @codingStandardsIgnoreLine - WordPress.XSS.EscapeOutput.OutputNotEscaped - Escaping is handled in the function.
+		beans_esc_attributes( $field['attributes'] ) // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Escaping is handled in the function.
 	);
 }

--- a/lib/api/fields/types/textarea.php
+++ b/lib/api/fields/types/textarea.php
@@ -25,7 +25,7 @@ function beans_field_textarea( array $field ) {
 	printf( '<textarea id="%s" name="%s" %s>%s</textarea>',
 		esc_attr( $field['id'] ),
 		esc_attr( $field['name'] ),
-		beans_esc_attributes( $field['attributes'] ), // @codingStandardsIgnoreLine - WordPress.XSS.EscapeOutput.OutputNotEscaped - Escaping is handled in the function.
+		beans_esc_attributes( $field['attributes'] ), // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Escaping is handled in the function.
 		esc_textarea( $field['value'] )
 	);
 }

--- a/lib/api/fields/types/views/activation.php
+++ b/lib/api/fields/types/views/activation.php
@@ -11,4 +11,4 @@
 ?>
 
 <input type="hidden" value="0" name="<?php echo esc_attr( $field['name'] ); ?>" />
-<input id="<?php echo esc_html( $field['id'] ); ?>" type="checkbox" name="<?php echo esc_attr( $field['name'] ); ?>" value="1"<?php checked( $field['value'], 1 ); ?> <?php echo beans_esc_attributes( $field['attributes'] ); ?>/><?php // @codingStandardsIgnoreLine - WordPress.XSS.EscapeOutput.OutputNotEscaped - Escaping is handled in the function. ?>
+<input id="<?php echo esc_html( $field['id'] ); ?>" type="checkbox" name="<?php echo esc_attr( $field['name'] ); ?>" value="1"<?php checked( $field['value'], 1 ); ?> <?php echo beans_esc_attributes( $field['attributes'] ); ?>/><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Escaping is handled in the function. ?>

--- a/lib/api/fields/types/views/checkbox.php
+++ b/lib/api/fields/types/views/checkbox.php
@@ -11,7 +11,7 @@
 ?>
 
 <input type="hidden" value="0" name="<?php echo esc_attr( $field['name'] ); ?>" />
-<input id="<?php echo esc_html( $field['id'] ); ?>" type="checkbox" name="<?php echo esc_attr( $field['name'] ); ?>" value="1"<?php checked( $field['value'], 1 ); ?> <?php echo beans_esc_attributes( $field['attributes'] ); ?>/><?php // @codingStandardsIgnoreLine - WordPress.XSS.EscapeOutput.OutputNotEscaped - Escaping is handled in the function. ?>
+<input id="<?php echo esc_html( $field['id'] ); ?>" type="checkbox" name="<?php echo esc_attr( $field['name'] ); ?>" value="1"<?php checked( $field['value'], 1 ); ?> <?php echo beans_esc_attributes( $field['attributes'] ); ?>/><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Escaping is handled in the function. ?>
 
 <?php if ( $checkbox_label ) : ?>
 <span class="bs-checkbox-label"><?php echo esc_html( $checkbox_label ); ?></span>

--- a/lib/api/fields/types/views/field-description.php
+++ b/lib/api/fields/types/views/field-description.php
@@ -11,4 +11,4 @@
 ?>
 
 <br /><a class="bs-read-more" href="#"><?php esc_html_e( 'More...', 'tm-beans' ); ?></a>
-<div class="bs-extended-content" style="display: none;"><?php echo $extended; // @codingStandardsIgnoreLine - WordPress.XSS.EscapeOutput.OutputNotEscaped - To optimize, escaping is handled in the calling function. ?></div>
+<div class="bs-extended-content" style="display: none;"><?php echo $extended; ?></div><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- To optimize, escaping is handled in the calling function. ?>

--- a/lib/api/fields/types/views/image.php
+++ b/lib/api/fields/types/views/image.php
@@ -8,6 +8,7 @@
  * @since   1.5.0 Moved to view file.
  */
 
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Variables are used within a function's scope.
 ?>
 
 <button class="bs-add-image button button-small" type="button" <?php echo isset( $hide_add_link ) ? 'style="display: none"' : ''; ?>><?php echo esc_html( $link_text ); ?></button>
@@ -22,12 +23,12 @@ foreach ( $images as $image_id ) :
 		continue;
 	}
 
-	$attributes = _beans_get_image_id_attributes( $image_id, $field, $is_multiple ); // @codingStandardsIgnoreLine. WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound - Called from within a function and not within global scope.
-	$image_url  = _beans_get_image_url( $image_id );  // @codingStandardsIgnoreLine. WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound - Called from within a function and not within global scope.
-	$image_alt  = $image_url ? _beans_get_image_alt( $image_id ) : '';  // @codingStandardsIgnoreLine. WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound - Called from within a function and not within global scope.
+	$attributes = _beans_get_image_id_attributes( $image_id, $field, $is_multiple );
+	$image_url  = _beans_get_image_url( $image_id );
+	$image_alt  = $image_url ? _beans_get_image_alt( $image_id ) : '';
 ?>
 	<div class="bs-image-wrap<?php echo 'placeholder' === $image_id ? ' bs-image-template' : ''; ?>">
-        <input <?php echo beans_esc_attributes( $attributes ); ?> /><?php // @codingStandardsIgnoreLine. WordPress.XSS.EscapeOutput.OutputNotEscaped - Escaping is handled in the function. ?>
+		<input <?php echo beans_esc_attributes( $attributes ); ?> /><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Escaping is handled in the function. ?>
 		<img src="<?php echo $image_url ? esc_url( $image_url ) : ''; ?>" alt="<?php echo $image_alt ? esc_attr( $image_alt ) : ''; ?>">
 		<div class="bs-toolbar">
 			<?php
@@ -51,3 +52,5 @@ foreach ( $images as $image_id ) :
 	</div>
 <?php endforeach; ?>
 </div>
+<?php
+// phpcs:enable

--- a/lib/api/fields/types/views/radio.php
+++ b/lib/api/fields/types/views/radio.php
@@ -8,6 +8,7 @@
  * @since   1.5.0 Moved to view file.
  */
 
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Variables are used within a function's scope.
 ?>
 
 <fieldset>
@@ -15,27 +16,28 @@
 <?php
 
 // Clean the field's ID prefix once before we start the loop.
-$id_prefix = esc_attr( $field['id'] . '_' ); // @codingStandardsIgnoreLine. WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound - Called from within a function and not within global scope.
+$id_prefix = esc_attr( $field['id'] . '_' );
 
-foreach ( $field['options'] as $value => $radio ) : // @codingStandardsIgnoreLine. WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound - Called from within a function and not within global scope.
-    $is_image = _beans_is_radio_image( $radio ); // @codingStandardsIgnoreLine. WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound - Called from within a function and not within global scope.
+foreach ( $field['options'] as $value => $radio ) :
+	$is_image = _beans_is_radio_image( $radio );
 
 	// Clean the value here to avoid calling esc_attr() again and again for the same value.
-	$clean_value = esc_attr( $value ); // @codingStandardsIgnoreLine. WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound - Called from within a function and not within global scope.
-    $clean_id    = $id_prefix . $clean_value; // @codingStandardsIgnoreLine. WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound - Called from within a function and not within global scope.
+	$clean_value = esc_attr( $value );
+	$clean_id    = $id_prefix . $clean_value;
 ?>
-		<label class="<?php echo $is_image ? 'bs-has-image' : ''; ?>" for="<?php echo $clean_id; // @codingStandardsIgnoreLine - WordPress.XSS.EscapeOutput.OutputNotEscaped - Escaped above. ?>">
+		<label class="<?php echo $is_image ? 'bs-has-image' : ''; ?>" for="<?php echo $clean_id; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Escaped above. ?>">
 		<?php
 		if ( $is_image ) :
-			$image = _beans_standardize_radio_image( $value, $radio );  // @codingStandardsIgnoreLine. WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound - Called from within a function and not within global scope.
+			$image = _beans_standardize_radio_image( $value, $radio );
 		?>
 			<span class="screen-reader-text"><?php echo esc_html( $image['screen_reader_text'] ); ?></span>
 			<img src="<?php echo esc_url( $image['src'] ); ?>" alt="<?php echo esc_html( $image['alt'] ); ?>" />
-			<input id="<?php echo $clean_id; ?>" class="screen-reader-text" type="radio" name="<?php echo esc_attr( $field['name'] ); ?>" value="<?php echo $clean_value; ?>"<?php checked( $value, $field['value'], 1 ); echo beans_esc_attributes( $field['attributes'] ); ?> /> <?php // @codingStandardsIgnoreLine - WordPress.XSS.EscapeOutput.OutputNotEscaped - Escaped above. ?>
+			<input id="<?php echo $clean_id; ?>" class="screen-reader-text" type="radio" name="<?php echo esc_attr( $field['name'] ); ?>" value="<?php echo $clean_value; ?>"<?php checked( $value, $field['value'], 1 ); ?><?php echo beans_esc_attributes( $field['attributes'] ); ?> /> <?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- The variable is escaped above. beans_esc_attributes is escaped by the function. ?>
 		<?php endif; ?>
 
 <?php if ( ! $is_image ) : ?>
-	<input id="<?php echo $clean_id; ?>" type="radio" name="<?php echo esc_attr( $field['name'] ); ?>" value="<?php echo $clean_value; ?>"<?php checked( $value, $field['value'], 1 ); echo beans_esc_attributes( $field['attributes'] ); ?> /> <?php // @codingStandardsIgnoreLine - WordPress.XSS.EscapeOutput.OutputNotEscaped - Escaped above.
+	<input id="<?php echo $clean_id; ?>" type="radio" name="<?php echo esc_attr( $field['name'] ); ?>" value="<?php echo $clean_value; ?>"<?php checked( $value, $field['value'], 1 ); ?><?php echo beans_esc_attributes( $field['attributes'] ); ?> /> <?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- The variable is escaped above. beans_esc_attributes is escaped by the function. ?>
+	<?php
 	echo wp_kses_post( $radio );
 endif;
 ?>
@@ -44,3 +46,5 @@ endif;
 endforeach;
 ?>
 </fieldset>
+<?php
+// phpcs:enable

--- a/lib/api/fields/types/views/select.php
+++ b/lib/api/fields/types/views/select.php
@@ -10,8 +10,8 @@
 
 ?>
 
-<select id="<?php echo esc_html( $field['id'] ); ?>" name="<?php echo esc_attr( $field['name'] ); ?>" <?php echo beans_esc_attributes( $field['attributes'] ); ?>><?php // @codingStandardsIgnoreLine - WordPress.XSS.EscapeOutput.OutputNotEscaped - Escaping is handled in the function. ?>
-<?php foreach ( $field['options'] as $value => $label ) : // @codingStandardsIgnoreLine. WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound - Called from within a function and not within global scope. ?>
+<select id="<?php echo esc_html( $field['id'] ); ?>" name="<?php echo esc_attr( $field['name'] ); ?>" <?php echo beans_esc_attributes( $field['attributes'] ); ?>><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Escaping is handled in the function. ?>
+<?php foreach ( $field['options'] as $value => $label ) : // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Called from within a function and not within global scope. ?>
 	<option value="<?php echo esc_attr( $value ); ?>"<?php selected( $value, $field['value'] ); ?>><?php echo esc_html( $label ); ?></option>
 <?php endforeach; ?>
 </select>

--- a/lib/api/fields/types/views/slider.php
+++ b/lib/api/fields/types/views/slider.php
@@ -11,7 +11,7 @@
 ?>
 
 <div class="bs-slider-wrap" slider_min="<?php echo (int) $field['min']; ?>" slider_max="<?php echo (int) $field['max']; ?>" slider_interval="<?php echo (int) $field['interval']; ?>">
-    <input id="<?php echo esc_html( $field['id'] ); ?>" type="text" value="<?php echo esc_attr( $field['value'] ); ?>" name="<?php echo esc_attr( $field['name'] ); ?>" style="display: none;" <?php echo beans_esc_attributes( $field['attributes'] ); ?>/><?php // @codingStandardsIgnoreLine - WordPress.XSS.EscapeOutput.OutputNotEscaped - Escaping is handled in the function. ?>
+	<input id="<?php echo esc_html( $field['id'] ); ?>" type="text" value="<?php echo esc_attr( $field['value'] ); ?>" name="<?php echo esc_attr( $field['name'] ); ?>" style="display: none;" <?php echo beans_esc_attributes( $field['attributes'] ); ?>/><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Escaping is handled in the function. ?>
 </div>
 <span class="bs-slider-value"><?php echo esc_html( $field['value'] ); ?></span>
 

--- a/tests/phpunit/integration/api/html/beansAddAttribute.php
+++ b/tests/phpunit/integration/api/html/beansAddAttribute.php
@@ -36,7 +36,7 @@ class Tests_BeansAddAttribute extends HTML_Test_Case {
 			$this->assertSame( 10, has_filter( $hook, array( $attributes, 'add' ), 10 ) );
 			$expected              = $markup_attributes;
 			$expected['data-test'] = '';
-			$this->assertSame( $expected, apply_filters( $hook, $markup_attributes ) ); // @codingStandardsIgnoreLine - WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound  The hook's name is in the value.
+			$this->assertSame( $expected, apply_filters( $hook, $markup_attributes ) ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
 
 			// Clean up.
 			remove_filter( $hook, array( $attributes, 'add' ), 10 );
@@ -62,7 +62,7 @@ class Tests_BeansAddAttribute extends HTML_Test_Case {
 			$this->assertSame( 10, has_filter( $hook, array( $attributes, 'add' ), 10 ) );
 			$expected           = $markup['attributes'];
 			$expected['class'] .= ' beans-test';
-			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // @codingStandardsIgnoreLine - WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound  The hook's name is in the value.
+			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
 
 			// Clean up.
 			remove_filter( $hook, array( $attributes, 'add' ), 10 );

--- a/tests/phpunit/integration/api/html/beansRemoveAttribute.php
+++ b/tests/phpunit/integration/api/html/beansRemoveAttribute.php
@@ -37,7 +37,7 @@ class Tests_BeansRemoveAttribute extends HTML_Test_Case {
 			$this->assertSame( 10, has_filter( $hook, array( $attributes, 'remove' ), 10 ) );
 			$expected = $markup['attributes'];
 			unset( $expected[ $attribute ] );
-			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // @codingStandardsIgnoreLine - WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound  The hook's name is in the value.
+			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
 
 			// Clean up.
 			remove_filter( $hook, array( $attributes, 'remove' ), 10 );
@@ -60,7 +60,7 @@ class Tests_BeansRemoveAttribute extends HTML_Test_Case {
 			$this->assertSame( 10, has_filter( $hook, array( $attributes, 'remove' ), 10 ) );
 			$expected               = $markup['attributes'];
 			$expected[ $attribute ] = str_replace( $value, '', $expected[ $attribute ] );
-			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // @codingStandardsIgnoreLine - WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound  The hook's name is in the value.
+			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
 
 			// Clean up.
 			remove_filter( $hook, array( $attributes, 'remove' ), 10 );

--- a/tests/phpunit/integration/api/html/beansReplaceAttribute.php
+++ b/tests/phpunit/integration/api/html/beansReplaceAttribute.php
@@ -38,7 +38,7 @@ class Tests_BeansReplaceAttribute extends HTML_Test_Case {
 			$this->assertSame( 10, has_filter( $hook, array( $attributes, 'replace' ), 10 ) );
 			$expected               = $markup['attributes'];
 			$expected[ $attribute ] = str_replace( $value, 'beans-test', $expected[ $attribute ] );
-			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // @codingStandardsIgnoreLine - WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound  The hook's name is in the value.
+			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
 
 			// Clean up.
 			remove_filter( $hook, array( $attributes, 'replace' ), 10 );
@@ -61,7 +61,7 @@ class Tests_BeansReplaceAttribute extends HTML_Test_Case {
 			$this->assertSame( 10, has_filter( $hook, array( $attributes, 'replace' ), 10 ) );
 			$expected               = $markup['attributes'];
 			$expected[ $attribute ] = str_replace( $value, 'beans-test', $expected[ $attribute ] );
-			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // @codingStandardsIgnoreLine - WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound  The hook's name is in the value.
+			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
 
 			// Clean up.
 			remove_filter( $hook, array( $attributes, 'replace' ), 10 );
@@ -84,7 +84,7 @@ class Tests_BeansReplaceAttribute extends HTML_Test_Case {
 			$this->assertSame( 10, has_filter( $hook, array( $attributes, 'replace' ), 10 ) );
 			$expected               = $markup['attributes'];
 			$expected[ $attribute ] = null;
-			$actual = apply_filters( $hook, $markup['attributes'] ); // @codingStandardsIgnoreLine - WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound  The hook's name is in the value.
+			$actual                 = apply_filters( $hook, $markup['attributes'] ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
 			$this->assertSame( $expected, $actual );
 			$this->assertNotSame( $value, $actual[ $attribute ] );
 			$this->assertNull( $actual[ $attribute ] );
@@ -110,7 +110,7 @@ class Tests_BeansReplaceAttribute extends HTML_Test_Case {
 			$this->assertSame( 10, has_filter( $hook, array( $attributes, 'replace' ), 10 ) );
 			$expected               = $markup['attributes'];
 			$expected[ $attribute ] = '';
-			$actual = apply_filters( $hook, $markup['attributes'] ); // @codingStandardsIgnoreLine - WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound  The hook's name is in the value.
+			$actual                 = apply_filters( $hook, $markup['attributes'] ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
 			$this->assertSame( $expected, $actual );
 			$this->assertNotSame( $value, $actual[ $attribute ] );
 			$this->assertSame( '', $actual[ $attribute ] );

--- a/tests/phpunit/unit/api/html/beansAddAttribute.php
+++ b/tests/phpunit/unit/api/html/beansAddAttribute.php
@@ -43,7 +43,7 @@ class Tests_BeansAddAttribute extends HTML_Test_Case {
 			$this->assertTrue( has_filter( $hook, array( $attributes, 'add' ), 10 ) );
 			$expected              = $markup_attributes;
 			$expected['data-test'] = '';
-			$this->assertSame( $expected, apply_filters( $hook, $markup_attributes ) ); // @codingStandardsIgnoreLine - WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound  The hook's name is in the value.
+			$this->assertSame( $expected, apply_filters( $hook, $markup_attributes ) ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
 
 			// Clean up.
 			remove_filter( $hook, array( $attributes, 'add' ), 10 );
@@ -75,7 +75,7 @@ class Tests_BeansAddAttribute extends HTML_Test_Case {
 			$this->assertTrue( has_filter( $hook, array( $attributes, 'add' ), 10 ) );
 			$expected           = $markup['attributes'];
 			$expected['class'] .= ' beans-test';
-			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // @codingStandardsIgnoreLine - WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound  The hook's name is in the value.
+			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
 
 			// Clean up.
 			remove_filter( $hook, array( $attributes, 'add' ), 10 );

--- a/tests/phpunit/unit/api/html/beansRemoveAttribute.php
+++ b/tests/phpunit/unit/api/html/beansRemoveAttribute.php
@@ -44,7 +44,7 @@ class Tests_BeansRemoveAttribute extends HTML_Test_Case {
 			$this->assertTrue( has_filter( $hook, array( $attributes, 'remove' ), 10 ) );
 			$expected = $markup['attributes'];
 			unset( $expected[ $attribute ] );
-			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // @codingStandardsIgnoreLine - WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound  The hook's name is in the value.
+			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
 
 			// Clean up.
 			remove_filter( $hook, array( $attributes, 'remove' ), 10 );
@@ -73,7 +73,7 @@ class Tests_BeansRemoveAttribute extends HTML_Test_Case {
 			$this->assertTrue( has_filter( $hook, array( $attributes, 'remove' ), 10 ) );
 			$expected               = $markup['attributes'];
 			$expected[ $attribute ] = str_replace( $value, '', $expected[ $attribute ] );
-			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // @codingStandardsIgnoreLine - WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound  The hook's name is in the value.
+			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
 
 			// Clean up.
 			remove_filter( $hook, array( $attributes, 'remove' ), 10 );

--- a/tests/phpunit/unit/api/html/beansReplaceAttribute.php
+++ b/tests/phpunit/unit/api/html/beansReplaceAttribute.php
@@ -45,7 +45,7 @@ class Tests_BeansReplaceAttribute extends HTML_Test_Case {
 			$this->assertTrue( has_filter( $hook, array( $attributes, 'replace' ), 10 ) );
 			$expected               = $markup['attributes'];
 			$expected[ $attribute ] = str_replace( $value, 'beans-test', $expected[ $attribute ] );
-			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // @codingStandardsIgnoreLine - WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound  The hook's name is in the value.
+			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
 
 			// Clean up.
 			remove_filter( $hook, array( $attributes, 'replace' ), 10 );
@@ -75,7 +75,7 @@ class Tests_BeansReplaceAttribute extends HTML_Test_Case {
 			$this->assertTrue( has_filter( $hook, array( $attributes, 'replace' ), 10 ) );
 			$expected               = $markup['attributes'];
 			$expected[ $attribute ] = str_replace( $value, 'beans-test', $expected[ $attribute ] );
-			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // @codingStandardsIgnoreLine - WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound  The hook's name is in the value.
+			$this->assertSame( $expected, apply_filters( $hook, $markup['attributes'] ) ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
 
 			// Clean up.
 			remove_filter( $hook, array( $attributes, 'replace' ), 10 );
@@ -104,7 +104,7 @@ class Tests_BeansReplaceAttribute extends HTML_Test_Case {
 			$this->assertTrue( has_filter( $hook, array( $attributes, 'replace' ), 10 ) );
 			$expected               = $markup['attributes'];
 			$expected[ $attribute ] = null;
-			$actual                 = apply_filters( $hook, $markup['attributes'] ); // @codingStandardsIgnoreLine - WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound  The hook's name is in the value.
+			$actual                 = apply_filters( $hook, $markup['attributes'] ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
 			$this->assertSame( $expected, $actual );
 			$this->assertNotSame( $value, $actual[ $attribute ] );
 			$this->assertNull( $actual[ $attribute ] );
@@ -136,7 +136,7 @@ class Tests_BeansReplaceAttribute extends HTML_Test_Case {
 			$this->assertTrue( has_filter( $hook, array( $attributes, 'replace' ), 10 ) );
 			$expected               = $markup['attributes'];
 			$expected[ $attribute ] = '';
-			$actual                 = apply_filters( $hook, $markup['attributes'] ); // @codingStandardsIgnoreLine - WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound  The hook's name is in the value.
+			$actual                 = apply_filters( $hook, $markup['attributes'] ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
 			$this->assertSame( $expected, $actual );
 			$this->assertNotSame( $value, $actual[ $attribute ] );
 			$this->assertSame( '', $actual[ $attribute ] );


### PR DESCRIPTION
This PR replaces the deprecated `// @coding...` phpcs and wpcs rule ignores.