### PR TITLE
Added load original functions before monkey patch.

### DIFF
--- a/tests/phpunit/unit/api/layout/beansGetDefaultLayout.php
+++ b/tests/phpunit/unit/api/layout/beansGetDefaultLayout.php
@@ -16,8 +16,8 @@ use Brain\Monkey;
  * Class Tests_BeansGetDefaultLayout
  *
  * @package Beans\Framework\Tests\Unit\API\Layout
- * @group   unit-tests
  * @group   api
+ * @group   api-layout
  */
 class Tests_BeansGetDefaultLayout extends Test_Case {
 
@@ -28,6 +28,10 @@ class Tests_BeansGetDefaultLayout extends Test_Case {
 		parent::setUp();
 
 		require_once BEANS_TESTS_LIB_DIR . 'api/layout/functions.php';
+
+		$this->load_original_functions( array(
+			'api/widget/functions.php',
+		) );
 	}
 
 	/**

--- a/tests/phpunit/unit/api/layout/beansGetLayout.php
+++ b/tests/phpunit/unit/api/layout/beansGetLayout.php
@@ -16,8 +16,8 @@ use Brain\Monkey;
  * Class Tests_BeansGetLayout
  *
  * @package Beans\Framework\Tests\Unit\API\Layout
- * @group   unit-tests
  * @group   api
+ * @group   api-layout
  */
 class Tests_BeansGetLayout extends Test_Case {
 
@@ -28,6 +28,11 @@ class Tests_BeansGetLayout extends Test_Case {
 		parent::setUp();
 
 		require_once BEANS_TESTS_LIB_DIR . 'api/layout/functions.php';
+
+		$this->load_original_functions( array(
+			'api/post-meta/functions.php',
+			'api/term-meta/functions.php',
+		) );
 	}
 
 	/**

--- a/tests/phpunit/unit/api/layout/beansGetLayoutClass.php
+++ b/tests/phpunit/unit/api/layout/beansGetLayoutClass.php
@@ -16,8 +16,8 @@ use Brain\Monkey;
  * Class Tests_BeansGetLayoutClass
  *
  * @package Beans\Framework\Tests\Unit\API\Layout
- * @group   unit-tests
  * @group   api
+ * @group   api-layout
  */
 class Tests_BeansGetLayoutClass extends Test_Case {
 
@@ -28,7 +28,11 @@ class Tests_BeansGetLayoutClass extends Test_Case {
 		parent::setUp();
 
 		require_once BEANS_TESTS_LIB_DIR . 'api/layout/functions.php';
-		require_once BEANS_TESTS_LIB_DIR . 'api/utilities/functions.php';
+
+		$this->load_original_functions( array(
+			'api/utilities/functions.php',
+			'api/post-meta/functions.php',
+		) );
 	}
 
 	/**

--- a/tests/phpunit/unit/class-test-case.php
+++ b/tests/phpunit/unit/class-test-case.php
@@ -27,7 +27,7 @@ abstract class Test_Case extends TestCase {
 		parent::setUp();
 		Monkey\setUp();
 
-		Functions\when( 'wp_normalize_path' )->alias( function ( $path ) {
+		Functions\when( 'wp_normalize_path' )->alias( function( $path ) {
 			$path = str_replace( '\\', '/', $path );
 			$path = preg_replace( '|(?<=.)/+|', '/', $path );
 
@@ -38,7 +38,7 @@ abstract class Test_Case extends TestCase {
 			return $path;
 		} );
 
-		Functions\when( 'wp_json_encode' )->alias( function ( $array ) {
+		Functions\when( 'wp_json_encode' )->alias( function( $array ) {
 			return json_encode( $array ); // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- Required as part of our mock.
 		} );
 	}
@@ -49,5 +49,24 @@ abstract class Test_Case extends TestCase {
 	protected function tearDown() {
 		Monkey\tearDown();
 		parent::tearDown();
+	}
+
+	/**
+	 * Load the original Beans' functions into memory before we start.
+	 *
+	 * Then in our tests, we monkey patch via Brain Monkey, which redefines the original function.
+	 * At tear down, the original function is restored in Brain Monkey, by calling Patchwork\restoreAll().
+	 *
+	 * @since 1.0.0
+	 *
+	 * @param array $files Array of files to load into memory.
+	 *
+	 * @return void
+	 */
+	protected function load_original_functions( array $files ) {
+
+		foreach ( $files as $file ) {
+			require_once BEANS_TESTS_LIB_DIR . $file;
+		}
 	}
 }


### PR DESCRIPTION
Added ability to load original functions into memory before the monkey patch redefines the function.

The tests were failing due to the original functions not being loaded into memory _before_
using Brain Monkey and Patchwork.  The sequence to redefine an original function is:

1. Load the original function into memory.
2. Monkey patch it with Brain Monkey expect() or when(), which redefines that function for our unit tests.
3. Then restore the function back to its original declaration, which is handled at tear down by Brain Monkey.