### PR TITLE
Load original functions after initializing Patchwork.

### DIFF
--- a/tests/phpunit/unit/api/actions/includes/class-actions-test-case.php
+++ b/tests/phpunit/unit/api/actions/includes/class-actions-test-case.php
@@ -43,7 +43,6 @@ abstract class Actions_Test_Case extends Test_Case {
 		static::$test_ids     = array_keys( static::$test_actions );
 
 		require_once BEANS_TESTS_LIB_DIR . 'api/actions/functions.php';
-		require_once BEANS_TESTS_LIB_DIR . 'api/utilities/functions.php';
 	}
 
 	/**
@@ -67,6 +66,17 @@ abstract class Actions_Test_Case extends Test_Case {
 
 		static::$test_actions = null;
 		static::$test_ids     = null;
+	}
+
+	/**
+	 * Prepares the test environment before each test.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		$this->load_original_functions( array(
+			'api/utilities/functions.php',
+		) );
 	}
 
 	/**

--- a/tests/phpunit/unit/api/fields/includes/class-fields-test-case.php
+++ b/tests/phpunit/unit/api/fields/includes/class-fields-test-case.php
@@ -34,9 +34,8 @@ abstract class Fields_Test_Case extends Test_Case {
 
 		static::$test_data = require dirname( __DIR__ ) . DIRECTORY_SEPARATOR . 'fixtures/test-fields.php';
 
-		require_once BEANS_TESTS_LIB_DIR . 'api/utilities/functions.php';
 		require_once BEANS_TESTS_LIB_DIR . 'api/fields/functions.php';
-		require_once BEANS_THEME_DIR . 'lib/api/fields/class-beans-fields.php';
+		require_once BEANS_TESTS_LIB_DIR . 'api/fields/class-beans-fields.php';
 	}
 
 	/**
@@ -44,6 +43,10 @@ abstract class Fields_Test_Case extends Test_Case {
 	 */
 	public function setUp() {
 		parent::setUp();
+
+		$this->load_original_functions( array(
+			'api/utilities/functions.php',
+		) );
 
 		foreach ( array( 'esc_attr', 'esc_html', 'esc_textarea', 'esc_url', 'wp_kses_post', '__' ) as $wp_function ) {
 			Monkey\Functions\when( $wp_function )->returnArg();

--- a/tests/phpunit/unit/api/filters/includes/class-filters-test-case.php
+++ b/tests/phpunit/unit/api/filters/includes/class-filters-test-case.php
@@ -35,8 +35,17 @@ abstract class Filters_Test_Case extends Test_Case {
 		require_once dirname( __DIR__ ) . DIRECTORY_SEPARATOR . 'stubs/functions.php';
 
 		static::$test_filters = require dirname( __DIR__ ) . DIRECTORY_SEPARATOR . 'fixtures/test-filters.php';
+	}
 
-		require_once BEANS_TESTS_LIB_DIR . 'api/filters/functions.php';
+	/**
+	 * Prepares the test environment before each test.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		$this->load_original_functions( array(
+			'api/utilities/functions.php',
+		) );
 	}
 
 	/**

--- a/tests/phpunit/unit/api/html/includes/class-html-test-case.php
+++ b/tests/phpunit/unit/api/html/includes/class-html-test-case.php
@@ -46,4 +46,15 @@ abstract class HTML_Test_Case extends Test_Case {
 		require_once BEANS_TESTS_LIB_DIR . 'api/html/class-beans-attribute.php';
 		require_once BEANS_TESTS_LIB_DIR . 'api/html/functions.php';
 	}
+
+	/**
+	 * Prepares the test environment before each test.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		$this->load_original_functions( array(
+			'api/filters/functions.php',
+		) );
+	}
 }

--- a/tests/phpunit/unit/api/post-meta/beansGetPostMeta.php
+++ b/tests/phpunit/unit/api/post-meta/beansGetPostMeta.php
@@ -16,8 +16,8 @@ use Brain\Monkey;
  * Class Tests_BeansGetPostMeta
  *
  * @package Beans\Framework\Tests\Unit\API\Post_Meta
- * @group   unit-tests
  * @group   api
+ * @group   api-post-meta
  */
 class Tests_BeansGetPostMeta extends Test_Case {
 

--- a/tests/phpunit/unit/api/post-meta/beansGetPostMeta.php
+++ b/tests/phpunit/unit/api/post-meta/beansGetPostMeta.php
@@ -28,6 +28,10 @@ class Tests_BeansGetPostMeta extends Test_Case {
 		parent::setUp();
 
 		require_once BEANS_TESTS_LIB_DIR . 'api/post-meta/functions.php';
+
+		$this->load_original_functions( array(
+			'api/utilities/functions.php',
+		) );
 	}
 
 	/**

--- a/tests/phpunit/unit/api/template/includes/class-template-test-case.php
+++ b/tests/phpunit/unit/api/template/includes/class-template-test-case.php
@@ -48,6 +48,10 @@ abstract class Template_Test_Case extends Test_Case {
 	protected function setUp() {
 		parent::setUp();
 
+		$this->load_original_functions( array(
+			'api/utilities/functions.php',
+		) );
+
 		$this->set_up_virtual_filesystem();
 
 		if ( ! defined( 'BEANS_STRUCTURE_PATH' ) ) {

--- a/tests/phpunit/unit/api/term-meta/beansGetTermMeta.php
+++ b/tests/phpunit/unit/api/term-meta/beansGetTermMeta.php
@@ -27,6 +27,10 @@ class Tests_BeansGetTermMeta extends Test_Case {
 		parent::setUp();
 
 		require_once BEANS_TESTS_LIB_DIR . 'api/term-meta/functions.php';
+
+		$this->load_original_functions( array(
+			'api/utilities/functions.php',
+		) );
 	}
 
 	/**

--- a/tests/phpunit/unit/api/term-meta/beansGetTermMeta.php
+++ b/tests/phpunit/unit/api/term-meta/beansGetTermMeta.php
@@ -46,7 +46,8 @@ class Tests_BeansGetTermMeta extends Test_Case {
 	}
 
 	/**
-	 * Test beans_get_term_meta() should return default when given and queried object has a term_id but term meta does not exist.
+	 * Test beans_get_term_meta() should return default when given and queried object has a term_id but term meta does
+	 * not exist.
 	 */
 	public function test_should_return_default_when_default_given_and_queried_obj_has_term_id_but_term_meta_not_set() {
 		Monkey\Functions\expect( 'get_queried_object' )
@@ -62,7 +63,8 @@ class Tests_BeansGetTermMeta extends Test_Case {
 	}
 
 	/**
-	 * Test beans_get_term_meta() should return meta term's value when queried object has a term_id and meta for that id exists.
+	 * Test beans_get_term_meta() should return meta term's value when queried object has a term_id and meta for that
+	 * id exists.
 	 */
 	public function test_should_return_term_meta_when_queried_object_has_term_id_and_meta_is_set() {
 		Monkey\Functions\expect( 'get_queried_object' )
@@ -94,7 +96,8 @@ class Tests_BeansGetTermMeta extends Test_Case {
 	}
 
 	/**
-	 * Test beans_get_term_meta() should return meta term's value when term_id is tag_ID and term meta for that id exists.
+	 * Test beans_get_term_meta() should return meta term's value when term_id is tag_ID and term meta for that id
+	 * exists.
 	 */
 	public function test_should_return_term_meta_when_default_given_and_term_id_is_tag_id_and_term_meta_exists() {
 		$_GET['tag_ID'] = 1;


### PR DESCRIPTION
Moved dependency files out of the pre setup and into the setup method, i.e. to ensure they are loaded after Patchwork initializes (through Brain Monkey).