### PR TITLE
Improved Actions API tests.

### DIFF
--- a/tests/phpunit/integration/api/actions/beansAddAction.php
+++ b/tests/phpunit/integration/api/actions/beansAddAction.php
@@ -17,8 +17,8 @@ require __DIR__ . '/includes/class-actions-test-case.php';
  * Class Tests_BeansAddAction
  *
  * @package Beans\Framework\Tests\Integration\API\Actions
- * @group   integration-tests
  * @group   api
+ * @group   api-actions
  */
 class Tests_BeansAddAction extends Actions_Test_Case {
 

--- a/tests/phpunit/integration/api/actions/beansAddAnonymousAction.php
+++ b/tests/phpunit/integration/api/actions/beansAddAnonymousAction.php
@@ -16,8 +16,8 @@ use WP_UnitTestCase;
  * Class Tests_BeansAddAnonymousAction
  *
  * @package Beans\Framework\Integration\Unit\API\Actions
- * @group   integration-tests
  * @group   api
+ * @group   api-actions
  */
 class Tests_BeansAddAnonymousAction extends WP_UnitTestCase {
 

--- a/tests/phpunit/integration/api/actions/beansModifyAction.php
+++ b/tests/phpunit/integration/api/actions/beansModifyAction.php
@@ -17,8 +17,8 @@ require_once __DIR__ . '/includes/class-actions-test-case.php';
  * Class Tests_BeansModifyAction
  *
  * @package Beans\Framework\Tests\Integration\API\Actions
- * @group   integration-tests
  * @group   api
+ * @group   api-actions
  */
 class Tests_BeansModifyAction extends Actions_Test_Case {
 

--- a/tests/phpunit/integration/api/actions/beansModifyActionArguments.php
+++ b/tests/phpunit/integration/api/actions/beansModifyActionArguments.php
@@ -17,8 +17,8 @@ require_once __DIR__ . '/includes/class-actions-test-case.php';
  * Class Tests_BeansModifyActionArguments
  *
  * @package Beans\Framework\Tests\Integration\API\Actions
- * @group   integration-tests
  * @group   api
+ * @group   api-actions
  */
 class Tests_BeansModifyActionArguments extends Actions_Test_Case {
 

--- a/tests/phpunit/integration/api/actions/beansModifyActionCallback.php
+++ b/tests/phpunit/integration/api/actions/beansModifyActionCallback.php
@@ -17,8 +17,8 @@ require_once __DIR__ . '/includes/class-actions-test-case.php';
  * Class Tests_BeansModifyActionCallback
  *
  * @package Beans\Framework\Tests\Unit\API\Actions
- * @group   integration-tests
  * @group   api
+ * @group   api-actions
  */
 class Tests_BeansModifyActionCallback extends Actions_Test_Case {
 

--- a/tests/phpunit/integration/api/actions/beansModifyActionHook.php
+++ b/tests/phpunit/integration/api/actions/beansModifyActionHook.php
@@ -17,8 +17,8 @@ require_once __DIR__ . '/includes/class-actions-test-case.php';
  * Class Tests_BeansModifyActionHook
  *
  * @package Beans\Framework\Tests\Integration\API\Actions
- * @group   integration-tests
  * @group   api
+ * @group   api-actions
  */
 class Tests_BeansModifyActionHook extends Actions_Test_Case {
 

--- a/tests/phpunit/integration/api/actions/beansModifyActionPriority.php
+++ b/tests/phpunit/integration/api/actions/beansModifyActionPriority.php
@@ -17,8 +17,8 @@ require_once __DIR__ . '/includes/class-actions-test-case.php';
  * Class Tests_BeansModifyActionPriority
  *
  * @package Beans\Framework\Tests\Integration\API\Actions
- * @group   integration-tests
  * @group   api
+ * @group   api-actions
  */
 class Tests_BeansModifyActionPriority extends Actions_Test_Case {
 

--- a/tests/phpunit/integration/api/actions/beansRemoveAction.php
+++ b/tests/phpunit/integration/api/actions/beansRemoveAction.php
@@ -17,8 +17,8 @@ require_once __DIR__ . '/includes/class-actions-test-case.php';
  * Class Tests_BeansRemoveAction
  *
  * @package Beans\Framework\Tests\Integration\API\Actions
- * @group   integration-tests
  * @group   api
+ * @group   api-actions
  */
 class Tests_BeansRemoveAction extends Actions_Test_Case {
 

--- a/tests/phpunit/integration/api/actions/beansReplaceAction.php
+++ b/tests/phpunit/integration/api/actions/beansReplaceAction.php
@@ -17,8 +17,8 @@ require_once __DIR__ . '/includes/class-replace-action-test-case.php';
  * Class Tests_BeansReplaceAction
  *
  * @package Beans\Framework\Tests\Integration\API\Actions
- * @group   integration-tests
  * @group   api
+ * @group   api-actions
  */
 class Tests_BeansReplaceAction extends Replace_Action_Test_Case {
 

--- a/tests/phpunit/integration/api/actions/beansReplaceActionArguments.php
+++ b/tests/phpunit/integration/api/actions/beansReplaceActionArguments.php
@@ -17,8 +17,8 @@ require_once __DIR__ . '/includes/class-replace-action-test-case.php';
  * Class Tests_BeansReplaceActionArguments
  *
  * @package Beans\Framework\Tests\Integration\API\Actions
- * @group   integration-tests
  * @group   api
+ * @group   api-actions
  */
 class Tests_BeansReplaceActionArguments extends Replace_Action_Test_Case {
 

--- a/tests/phpunit/integration/api/actions/beansReplaceActionCallback.php
+++ b/tests/phpunit/integration/api/actions/beansReplaceActionCallback.php
@@ -17,8 +17,8 @@ require_once __DIR__ . '/includes/class-replace-action-test-case.php';
  * Class Tests_BeansReplaceActionCallback
  *
  * @package Beans\Framework\Tests\Integration\API\Actions
- * @group   integration-tests
  * @group   api
+ * @group   api-actions
  */
 class Tests_BeansReplaceActionCallback extends Replace_Action_Test_Case {
 

--- a/tests/phpunit/integration/api/actions/beansReplaceActionHook.php
+++ b/tests/phpunit/integration/api/actions/beansReplaceActionHook.php
@@ -17,8 +17,8 @@ require_once __DIR__ . '/includes/class-replace-action-test-case.php';
  * Class Tests_BeansReplaceActionHook
  *
  * @package Beans\Framework\Tests\Integration\API\Actions
- * @group   integration-tests
  * @group   api
+ * @group   api-actions
  */
 class Tests_BeansReplaceActionHook extends Replace_Action_Test_Case {
 

--- a/tests/phpunit/integration/api/actions/beansReplaceActionPriority.php
+++ b/tests/phpunit/integration/api/actions/beansReplaceActionPriority.php
@@ -17,8 +17,8 @@ require_once __DIR__ . '/includes/class-replace-action-test-case.php';
  * Class Tests_BeansReplaceActionPriority
  *
  * @package Beans\Framework\Tests\Integration\API\Actions
- * @group   integration-tests
  * @group   api
+ * @group   api-actions
  */
 class Tests_BeansReplaceActionPriority extends Replace_Action_Test_Case {
 

--- a/tests/phpunit/integration/api/actions/beansResetAction.php
+++ b/tests/phpunit/integration/api/actions/beansResetAction.php
@@ -17,8 +17,8 @@ require_once __DIR__ . '/includes/class-actions-test-case.php';
  * Class Tests_BeansResetAction
  *
  * @package Beans\Framework\Tests\Integration\API\Actions
- * @group   integration-tests
  * @group   api
+ * @group   api-actions
  */
 class Tests_BeansResetAction extends Actions_Test_Case {
 

--- a/tests/phpunit/integration/api/actions/includes/class-actions-test-case.php
+++ b/tests/phpunit/integration/api/actions/includes/class-actions-test-case.php
@@ -73,7 +73,7 @@ abstract class Actions_Test_Case extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Reset the test fixture.
+	 * Cleans up the test environment after each test.
 	 */
 	public function tearDown() {
 		parent::tearDown();

--- a/tests/phpunit/integration/api/actions/includes/class-replace-action-test-case.php
+++ b/tests/phpunit/integration/api/actions/includes/class-replace-action-test-case.php
@@ -19,7 +19,7 @@ use WP_UnitTestCase;
 abstract class Replace_Action_Test_Case extends Actions_Test_Case {
 
 	/**
-	 * Set up the test fixture.
+	 * Prepares the test environment before each test.
 	 */
 	public function setUp() {
 		$this->reset_beans_registry = false;
@@ -31,7 +31,7 @@ abstract class Replace_Action_Test_Case extends Actions_Test_Case {
 	}
 
 	/**
-	 * Reset the test fixture.
+	 * Cleans up the test environment after each test.
 	 */
 	public function tearDown() {
 		parent::tearDown();

--- a/tests/phpunit/unit/api/actions/beansAddAction.php
+++ b/tests/phpunit/unit/api/actions/beansAddAction.php
@@ -18,8 +18,8 @@ require_once __DIR__ . '/includes/class-actions-test-case.php';
  * Class Tests_BeansAddAction
  *
  * @package Beans\Framework\Tests\Unit\API\Actions
- * @group   unit-tests
  * @group   api
+ * @group   api-actions
  */
 class Tests_BeansAddAction extends Actions_Test_Case {
 

--- a/tests/phpunit/unit/api/actions/beansAddAnonymousAction.php
+++ b/tests/phpunit/unit/api/actions/beansAddAnonymousAction.php
@@ -17,8 +17,8 @@ use Brain\Monkey\Actions;
  * Class Tests_BeansAddAnonymousAction
  *
  * @package Beans\Framework\Tests\Unit\API\Actions
- * @group   unit-tests
  * @group   api
+ * @group   api-actions
  */
 class Tests_BeansAddAnonymousAction extends Test_Case {
 

--- a/tests/phpunit/unit/api/actions/beansAddAnonymousAction.php
+++ b/tests/phpunit/unit/api/actions/beansAddAnonymousAction.php
@@ -23,7 +23,7 @@ use Brain\Monkey\Actions;
 class Tests_BeansAddAnonymousAction extends Test_Case {
 
 	/**
-	 * Setup test fixture.
+	 * Prepares the test environment before each test.
 	 */
 	protected function setUp() {
 		parent::setUp();
@@ -49,9 +49,7 @@ class Tests_BeansAddAnonymousAction extends Test_Case {
 	public function test_should_call_callback() {
 		$object = _beans_add_anonymous_action( 'beans_test_do_foo', array( 'foo_test_callback', array( 'foo' ) ) );
 
-		Functions\when( 'foo_test_callback' )
-			->justReturn( 'foo' );
-
+		Functions\when( 'foo_test_callback' )->justReturn( 'foo' );
 		Actions\expectDone( 'beans_test_do_foo' )
 			->once()
 			->whenHappen( function() use ( $object ) {

--- a/tests/phpunit/unit/api/actions/beansBuildActionArray.php
+++ b/tests/phpunit/unit/api/actions/beansBuildActionArray.php
@@ -16,8 +16,8 @@ use Brain\Monkey;
  * Class Tests_BeansBuildActionArray
  *
  * @package Beans\Framework\Tests\Unit\API\Actions
- * @group   unit-tests
  * @group   api
+ * @group   api-actions
  */
 class Tests_BeansBuildActionArray extends Test_Case {
 

--- a/tests/phpunit/unit/api/actions/beansGetAction.php
+++ b/tests/phpunit/unit/api/actions/beansGetAction.php
@@ -15,8 +15,8 @@ use Beans\Framework\Tests\Unit\API\Actions\Includes\Actions_Test_Case;
  * Class Tests_BeansGetAction
  *
  * @package Beans\Framework\Tests\Unit\API\Actions
- * @group   unit-tests
  * @group   api
+ * @group   api-actions
  */
 class Tests_BeansGetAction extends Actions_Test_Case {
 

--- a/tests/phpunit/unit/api/actions/beansGetCurrentAction.php
+++ b/tests/phpunit/unit/api/actions/beansGetCurrentAction.php
@@ -17,8 +17,8 @@ require_once __DIR__ . '/includes/class-actions-test-case.php';
  * Class Tests_BeansGetCurrentAction
  *
  * @package Beans\Framework\Tests\Unit\API\Actions
- * @group   unit-tests
  * @group   api
+ * @group   api-actions
  */
 class Tests_BeansGetCurrentAction extends Actions_Test_Case {
 

--- a/tests/phpunit/unit/api/actions/beansMergeAction.php
+++ b/tests/phpunit/unit/api/actions/beansMergeAction.php
@@ -17,8 +17,8 @@ require_once __DIR__ . '/includes/class-actions-test-case.php';
  * Class Tests_BeansMergeAction
  *
  * @package Beans\Framework\Tests\Unit\API\Actions
- * @group   unit-tests
  * @group   api
+ * @group   api-actions
  */
 class Tests_BeansMergeAction extends Actions_Test_Case {
 

--- a/tests/phpunit/unit/api/actions/beansModifyAction.php
+++ b/tests/phpunit/unit/api/actions/beansModifyAction.php
@@ -18,8 +18,8 @@ require_once __DIR__ . '/includes/class-actions-test-case.php';
  * Class Tests_BeansModifyAction
  *
  * @package Beans\Framework\Tests\Unit\API\Actions
- * @group   unit-tests
  * @group   api
+ * @group   api-actions
  */
 class Tests_BeansModifyAction extends Actions_Test_Case {
 

--- a/tests/phpunit/unit/api/actions/beansModifyActionArguments.php
+++ b/tests/phpunit/unit/api/actions/beansModifyActionArguments.php
@@ -18,8 +18,8 @@ require_once __DIR__ . '/includes/class-actions-test-case.php';
  * Class Tests_BeansModifyActionArguments
  *
  * @package Beans\Framework\Tests\Unit\API\Actions
- * @group   unit-tests
  * @group   api
+ * @group   api-actions
  */
 class Tests_BeansModifyActionArguments extends Actions_Test_Case {
 

--- a/tests/phpunit/unit/api/actions/beansModifyActionCallback.php
+++ b/tests/phpunit/unit/api/actions/beansModifyActionCallback.php
@@ -18,8 +18,8 @@ require_once __DIR__ . '/includes/class-actions-test-case.php';
  * Class Tests_BeansModifyActionCallback
  *
  * @package Beans\Framework\Tests\Unit\API\Actions
- * @group   unit-tests
  * @group   api
+ * @group   api-actions
  */
 class Tests_BeansModifyActionCallback extends Actions_Test_Case {
 

--- a/tests/phpunit/unit/api/actions/beansModifyActionHook.php
+++ b/tests/phpunit/unit/api/actions/beansModifyActionHook.php
@@ -18,8 +18,8 @@ require_once __DIR__ . '/includes/class-actions-test-case.php';
  * Class Tests_BeansModifyActionHook
  *
  * @package Beans\Framework\Tests\Unit\API\Actions
- * @group   unit-tests
  * @group   api
+ * @group   api-actions
  */
 class Tests_BeansModifyActionHook extends Actions_Test_Case {
 

--- a/tests/phpunit/unit/api/actions/beansModifyActionPriority.php
+++ b/tests/phpunit/unit/api/actions/beansModifyActionPriority.php
@@ -18,8 +18,8 @@ require_once __DIR__ . '/includes/class-actions-test-case.php';
  * Class Tests_BeansModifyActionPriority
  *
  * @package Beans\Framework\Tests\Unit\API\Actions
- * @group   unit-tests
  * @group   api
+ * @group   api-actions
  */
 class Tests_BeansModifyActionPriority extends Actions_Test_Case {
 

--- a/tests/phpunit/unit/api/actions/beansRemoveAction.php
+++ b/tests/phpunit/unit/api/actions/beansRemoveAction.php
@@ -17,8 +17,8 @@ require_once __DIR__ . '/includes/class-replace-action-test-case.php';
  * Class Tests_BeansRemoveAction
  *
  * @package Beans\Framework\Tests\Unit\API\Actions
- * @group   unit-tests
  * @group   api
+ * @group   api-actions
  */
 class Tests_BeansRemoveAction extends Replace_Action_Test_Case {
 

--- a/tests/phpunit/unit/api/actions/beansRenderAction.php
+++ b/tests/phpunit/unit/api/actions/beansRenderAction.php
@@ -16,8 +16,8 @@ use Brain\Monkey\Actions;
  * Class Tests_BeansRenderAction
  *
  * @package Beans\Framework\Tests\Unit\API\Actions
- * @group   unit-tests
  * @group   api
+ * @group   api-actions
  */
 class Tests_BeansRenderAction extends Test_Case {
 

--- a/tests/phpunit/unit/api/actions/beansReplaceAction.php
+++ b/tests/phpunit/unit/api/actions/beansReplaceAction.php
@@ -18,8 +18,8 @@ require_once __DIR__ . '/includes/class-replace-action-test-case.php';
  * Class Tests_BeansReplaceAction
  *
  * @package Beans\Framework\Tests\Unit\API\Actions
- * @group   unit-tests
  * @group   api
+ * @group   api-actions
  */
 class Tests_BeansReplaceAction extends Replace_Action_Test_Case {
 

--- a/tests/phpunit/unit/api/actions/beansReplaceActionArguments.php
+++ b/tests/phpunit/unit/api/actions/beansReplaceActionArguments.php
@@ -18,8 +18,8 @@ require_once __DIR__ . '/includes/class-replace-action-test-case.php';
  * Class Tests_BeansReplaceActionArguments
  *
  * @package Beans\Framework\Tests\Integration\API\Actions
- * @group   unit-tests
  * @group   api
+ * @group   api-actions
  */
 class Tests_BeansReplaceActionArguments extends Replace_Action_Test_Case {
 

--- a/tests/phpunit/unit/api/actions/beansReplaceActionCallback.php
+++ b/tests/phpunit/unit/api/actions/beansReplaceActionCallback.php
@@ -18,8 +18,8 @@ require_once __DIR__ . '/includes/class-replace-action-test-case.php';
  * Class Tests_BeansReplaceActionCallback
  *
  * @package Beans\Framework\Tests\Integration\API\Actions
- * @group   unit-tests
  * @group   api
+ * @group   api-actions
  */
 class Tests_BeansReplaceActionCallback extends Replace_Action_Test_Case {
 

--- a/tests/phpunit/unit/api/actions/beansReplaceActionHook.php
+++ b/tests/phpunit/unit/api/actions/beansReplaceActionHook.php
@@ -18,8 +18,8 @@ require_once __DIR__ . '/includes/class-replace-action-test-case.php';
  * Class Tests_BeansReplaceActionHook
  *
  * @package Beans\Framework\Tests\Integration\API\Actions
- * @group   unit-tests
  * @group   api
+ * @group   api-actions
  */
 class Tests_BeansReplaceActionHook extends Replace_Action_Test_Case {
 

--- a/tests/phpunit/unit/api/actions/beansReplaceActionPriority.php
+++ b/tests/phpunit/unit/api/actions/beansReplaceActionPriority.php
@@ -18,8 +18,8 @@ require_once __DIR__ . '/includes/class-replace-action-test-case.php';
  * Class Tests_BeansReplaceActionPriority
  *
  * @package Beans\Framework\Tests\Unit\API\Actions
- * @group   unit-tests
  * @group   api
+ * @group   api-actions
  */
 class Tests_BeansReplaceActionPriority extends Replace_Action_Test_Case {
 

--- a/tests/phpunit/unit/api/actions/beansResetAction.php
+++ b/tests/phpunit/unit/api/actions/beansResetAction.php
@@ -18,8 +18,8 @@ require_once __DIR__ . '/includes/class-actions-test-case.php';
  * Class Tests_BeansResetAction
  *
  * @package Beans\Framework\Tests\Unit\API\Actions
- * @group   unit-tests
  * @group   api
+ * @group   api-actions
  */
 class Tests_BeansResetAction extends Actions_Test_Case {
 

--- a/tests/phpunit/unit/api/actions/beansSetAction.php
+++ b/tests/phpunit/unit/api/actions/beansSetAction.php
@@ -17,8 +17,8 @@ require_once __DIR__ . '/includes/class-actions-test-case.php';
  * Class Tests_BeansSetAction
  *
  * @package Beans\Framework\Tests\Unit\API\Actions
- * @group   unit-tests
  * @group   api
+ * @group   api-actions
  */
 class Tests_BeansSetAction extends Actions_Test_Case {
 

--- a/tests/phpunit/unit/api/actions/beansUniqueActionId.php
+++ b/tests/phpunit/unit/api/actions/beansUniqueActionId.php
@@ -15,8 +15,8 @@ use Beans\Framework\Tests\Unit\Test_Case;
  * Class Tests_BeansUniqueActionId
  *
  * @package Beans\Framework\Tests\Unit\API\Actions
- * @group   unit-tests
  * @group   api
+ * @group   api-actions
  */
 class Tests_BeansUniqueActionId extends Test_Case {
 

--- a/tests/phpunit/unit/api/actions/beansUnsetAction.php
+++ b/tests/phpunit/unit/api/actions/beansUnsetAction.php
@@ -17,8 +17,8 @@ require_once __DIR__ . '/includes/class-actions-test-case.php';
  * Class Tests_BeansUnsetAction
  *
  * @package Beans\Framework\Tests\Unit\API\Actions
- * @group   unit-tests
  * @group   api
+ * @group   api-actions
  */
 class Tests_BeansUnsetAction extends Actions_Test_Case {
 

--- a/tests/phpunit/unit/api/actions/includes/class-actions-test-case.php
+++ b/tests/phpunit/unit/api/actions/includes/class-actions-test-case.php
@@ -72,8 +72,8 @@ abstract class Actions_Test_Case extends Test_Case {
 	protected function setUp() {
 		parent::setUp();
 
-		require_once BEANS_TESTS_LIB_DIR . 'api/actions/functions.php';
 		$this->load_original_functions( array(
+			'api/actions/functions.php',
 			'api/utilities/functions.php',
 		) );
 

--- a/tests/phpunit/unit/api/actions/includes/class-actions-test-case.php
+++ b/tests/phpunit/unit/api/actions/includes/class-actions-test-case.php
@@ -41,8 +41,6 @@ abstract class Actions_Test_Case extends Test_Case {
 
 		static::$test_actions = require dirname( __DIR__ ) . DIRECTORY_SEPARATOR . 'fixtures/test-actions.php';
 		static::$test_ids     = array_keys( static::$test_actions );
-
-		require_once BEANS_TESTS_LIB_DIR . 'api/actions/functions.php';
 	}
 
 	/**
@@ -74,13 +72,21 @@ abstract class Actions_Test_Case extends Test_Case {
 	protected function setUp() {
 		parent::setUp();
 
+		require_once BEANS_TESTS_LIB_DIR . 'api/actions/functions.php';
 		$this->load_original_functions( array(
 			'api/utilities/functions.php',
 		) );
+
+		Monkey\Functions\when( 'beans_get' )->alias( function ( $needle, $haystack ) {
+
+			if ( isset( $haystack[ $needle ] ) ) {
+				return $haystack[ $needle ];
+			}
+		} );
 	}
 
 	/**
-	 * Reset the test fixture.
+	 * Cleans up the test environment after each test.
 	 */
 	protected function tearDown() {
 		parent::tearDown();
@@ -109,10 +115,11 @@ abstract class Actions_Test_Case extends Test_Case {
 	protected function go_to_post( $expect_added = false ) {
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
+
 			if ( $expect_added ) {
 				Monkey\Actions\expectAdded( $action['hook'] )
 					->once()
-					->whenHappen( function( $callback, $priority, $args ) use ( $action ) {
+					->whenHappen( function ( $callback, $priority, $args ) use ( $action ) {
 						$this->assertSame( $action['callback'], $callback );
 						$this->assertSame( $action['priority'], $priority );
 						$this->assertSame( $action['args'], $args );


### PR DESCRIPTION
1. Mocked `beans_get()` in Actions API's unit tests.
2. Moved API file load to `setUp()`. Why? To ensure that it loads _after_ Patchwork, i.e. for mocking later on in other APIs.
3. Fixed `@group`.
4. Standardized the `setUp()` and `tearDown()` DocBlocks.