### PR TITLE
Improved Fields API Tests

### DIFF
--- a/lib/api/fields/types/field.php
+++ b/lib/api/fields/types/field.php
@@ -71,7 +71,7 @@ function beans_field_description( array $field ) {
 
 	beans_open_markup_e( 'beans_field_description[_' . $field['id'] . ']', 'div', array( 'class' => 'bs-field-description' ) );
 
-		echo $description;  // @codingStandardsIgnoreLine - WordPress.XSS.EscapeOutput.OutputNotEscaped - To optimize, escaping is handled above.
+		echo $description;  // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- To optimize, escaping is handled above.
 
 	if ( isset( $extended ) ) {
 		include dirname( __FILE__ ) . '/views/field-description.php';

--- a/tests/phpunit/integration/api/fields/_beansPreStandardizeFields.php
+++ b/tests/phpunit/integration/api/fields/_beansPreStandardizeFields.php
@@ -17,8 +17,8 @@ require_once __DIR__ . '/includes/class-fields-test-case.php';
  * Class Tests_BeansPreStandardizeFields
  *
  * @package Beans\Framework\Tests\Integration\API\Fields
- * @group   integration-tests
  * @group   api
+ * @group   api-fields
  */
 class Tests_BeansPreStandardizeFields extends Fields_Test_Case {
 

--- a/tests/phpunit/integration/api/fields/beansField.php
+++ b/tests/phpunit/integration/api/fields/beansField.php
@@ -17,8 +17,8 @@ require_once __DIR__ . '/includes/class-fields-test-case.php';
  * Class Tests_BeansField
  *
  * @package Beans\Framework\Tests\Integration\API\Fields
- * @group   integration-tests
  * @group   api
+ * @group   api-fields
  */
 class Tests_BeansField extends Fields_Test_Case {
 

--- a/tests/phpunit/integration/api/fields/beansField.php
+++ b/tests/phpunit/integration/api/fields/beansField.php
@@ -10,7 +10,6 @@
 namespace Beans\Framework\Tests\Integration\API\Fields;
 
 use Beans\Framework\Tests\Integration\API\Fields\Includes\Fields_Test_Case;
-use Brain\Monkey;
 
 require_once __DIR__ . '/includes/class-fields-test-case.php';
 
@@ -67,8 +66,6 @@ class Tests_BeansField extends Fields_Test_Case {
 			'type'           => 'checkbox',
 			'default'        => false,
 		) );
-		Monkey\Actions\expectDone( 'beans_field_checkbox' )->once()->with( $field );
-		Monkey\Actions\expectDone( 'beans_field_group_label' )->once();
 
 		// Run the function and grab the HTML out of the buffer.
 		ob_start();
@@ -86,8 +83,10 @@ class Tests_BeansField extends Fields_Test_Case {
 	</div>
 </div>
 EOB;
-		// Run the test.
+		// Run the tests.
 		$this->assertSame( $this->format_the_html( $expected ), $this->format_the_html( $html ) );
+		$this->assertEquals( 1, did_action( 'beans_field_checkbox' ) );
+		$this->assertEquals( 0, did_action( 'beans_field_group_label' ) );
 
 		// Clean up.
 		beans_remove_action( 'beans_field_checkbox', 'beans_field_checkbox' );
@@ -111,7 +110,6 @@ EOB;
 				'yes' => 'Yes',
 			),
 		) );
-		Monkey\Actions\expectDone( 'beans_field_radio' )->once()->with( $field );
 
 		// Run the function and grab the HTML out of the buffer.
 		ob_start();
@@ -139,6 +137,8 @@ EOB;
 EOB;
 		// Run the test.
 		$this->assertSame( $this->format_the_html( $expected ), $this->format_the_html( $html ) );
+		$this->assertEquals( 1, did_action( 'beans_field_radio' ) );
+		$this->assertEquals( 0, did_action( 'beans_field_group_label' ) );
 
 		// Clean up.
 		beans_remove_action( 'beans_field_radio', 'beans_field_radio' );
@@ -182,11 +182,6 @@ EOB;
 			),
 		) );
 
-		Monkey\Actions\expectDone( 'beans_field_group_label' )->once();
-		Monkey\Actions\expectDone( 'beans_field_activate' )->once()->with( $group['fields'][0] );
-		Monkey\Actions\expectDone( 'beans_field_activate' )->once()->with( $group['fields'][0] );
-		Monkey\Actions\expectDone( 'beans_field_select' )->once()->with( $group['fields'][1] );
-
 		// Run the function and grab the HTML out of the buffer.
 		ob_start();
 		beans_field( $group );
@@ -212,8 +207,11 @@ EOB;
 	<div class="bs-field-description">This is a group of fields.</div>
 </div>
 EOB;
-		// Run the test.
+		// Run the tests.
 		$this->assertSame( $this->format_the_html( $expected ), $this->format_the_html( $html ) );
+		$this->assertEquals( 2, did_action( 'beans_field_group_label' ) );
+		$this->assertEquals( 1, did_action( 'beans_field_activation' ) );
+		$this->assertEquals( 1, did_action( 'beans_field_select' ) );
 
 		// Clean up.
 		beans_remove_action( 'beans_field_activation', 'beans_field_activation' );

--- a/tests/phpunit/integration/api/fields/beansGetFields.php
+++ b/tests/phpunit/integration/api/fields/beansGetFields.php
@@ -17,8 +17,8 @@ require_once __DIR__ . '/includes/class-fields-test-case.php';
  * Class Tests_BeansGetFields
  *
  * @package Beans\Framework\Tests\Integration\API\Fields
- * @group   integration-tests
  * @group   api
+ * @group   api-fields
  */
 class Tests_BeansGetFields extends Fields_Test_Case {
 

--- a/tests/phpunit/integration/api/fields/beansRegisterFields.php
+++ b/tests/phpunit/integration/api/fields/beansRegisterFields.php
@@ -17,8 +17,8 @@ require_once __DIR__ . '/includes/class-fields-test-case.php';
  * Class Tests_BeansRegisterFields
  *
  * @package Beans\Framework\Tests\Integration\API\Fields
- * @group   integration-tests
  * @group   api
+ * @group   api-fields
  */
 class Tests_BeansRegisterFields extends Fields_Test_Case {
 

--- a/tests/phpunit/integration/api/fields/includes/class-fields-test-case.php
+++ b/tests/phpunit/integration/api/fields/includes/class-fields-test-case.php
@@ -32,6 +32,14 @@ abstract class Fields_Test_Case extends Test_Case {
 		parent::setUpBeforeClass();
 
 		static::$test_data = require dirname( __DIR__ ) . DIRECTORY_SEPARATOR . 'fixtures/test-fields.php';
+	}
+
+	/**
+	 * Prepares the test environment before each test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
 		require_once BEANS_THEME_DIR . '/lib/api/fields/class-beans-fields.php';
 	}
 

--- a/tests/phpunit/integration/api/fields/includes/class-fields-test-case.php
+++ b/tests/phpunit/integration/api/fields/includes/class-fields-test-case.php
@@ -9,14 +9,14 @@
 
 namespace Beans\Framework\Tests\Integration\API\Fields\Includes;
 
-use WP_UnitTestCase;
+use Beans\Framework\Tests\Integration\Test_Case;
 
 /**
  * Abstract Class Fields_Test_Case
  *
  * @package Beans\Framework\Tests\Integration\API\Fields\Includes
  */
-abstract class Fields_Test_Case extends WP_UnitTestCase {
+abstract class Fields_Test_Case extends Test_Case {
 
 	/**
 	 * An array of test data.
@@ -136,33 +136,5 @@ abstract class Fields_Test_Case extends WP_UnitTestCase {
 		}
 
 		return $field;
-	}
-
-	/**
-	 * Format the HTML by stripping out the whitespace between the HTML tags and then putting each tag on a separate
-	 * line.
-	 *
-	 * Why? We can then compare the actual vs. expected HTML patterns without worrying about tabs, new lines, and extra
-	 * spaces.
-	 *
-	 * @since 1.5.0
-	 *
-	 * @param string $html HTML to strip.
-	 *
-	 * @return string
-	 */
-	protected function format_the_html( $html ) {
-		$html = trim( $html );
-
-		// Strip whitespace between the tags.
-		$html = preg_replace( '/(\>)\s*(\<)/m', '$1$2', $html );
-
-		// Strip whitespace at the end of a tag.
-		$html = preg_replace( '/(\>)\s*/m', '$1$2', $html );
-
-		// Strip whitespace at the start of a tag.
-		$html = preg_replace( '/\s*(\<)/m', '$1$2', $html );
-
-		return str_replace( '>', ">\n", $html );
 	}
 }

--- a/tests/phpunit/integration/api/fields/types/_BeansGetImageAlt.php
+++ b/tests/phpunit/integration/api/fields/types/_BeansGetImageAlt.php
@@ -23,10 +23,10 @@ require_once dirname( __DIR__ ) . '/includes/class-fields-test-case.php';
 class Tests_BeansGetImageAlt extends Fields_Test_Case {
 
 	/**
-	 * Prepares the test environment before loading the tests.
+	 * Prepares the test environment before each test.
 	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public function setUp() {
+		parent::setUp();
 
 		// Load the field type.
 		require_once BEANS_THEME_DIR . '/lib/api/fields/types/image.php';

--- a/tests/phpunit/integration/api/fields/types/_BeansGetImageAlt.php
+++ b/tests/phpunit/integration/api/fields/types/_BeansGetImageAlt.php
@@ -17,8 +17,8 @@ require_once dirname( __DIR__ ) . '/includes/class-fields-test-case.php';
  * Class Tests_BeansGetImageAlt
  *
  * @package Beans\Framework\Tests\Integration\API\Fields\Types
- * @group   integration-tests
  * @group   api
+ * @group   api-fields
  */
 class Tests_BeansGetImageAlt extends Fields_Test_Case {
 

--- a/tests/phpunit/integration/api/fields/types/_BeansGetImageUrl.php
+++ b/tests/phpunit/integration/api/fields/types/_BeansGetImageUrl.php
@@ -23,10 +23,10 @@ require_once dirname( __DIR__ ) . '/includes/class-fields-test-case.php';
 class Tests_BeansGetImageUrl extends Fields_Test_Case {
 
 	/**
-	 * Prepares the test environment before loading the tests.
+	 * Prepares the test environment before each test.
 	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public function setUp() {
+		parent::setUp();
 
 		// Load the field type.
 		require_once BEANS_THEME_DIR . '/lib/api/fields/types/image.php';

--- a/tests/phpunit/integration/api/fields/types/_BeansGetImageUrl.php
+++ b/tests/phpunit/integration/api/fields/types/_BeansGetImageUrl.php
@@ -17,8 +17,8 @@ require_once dirname( __DIR__ ) . '/includes/class-fields-test-case.php';
  * Class Tests_BeansGetImageUrl
  *
  * @package Beans\Framework\Tests\Integration\API\Fields\Types
- * @group   integration-tests
  * @group   api
+ * @group   api-fields
  */
 class Tests_BeansGetImageUrl extends Fields_Test_Case {
 

--- a/tests/phpunit/integration/api/fields/types/_beansIsRadioImage.php
+++ b/tests/phpunit/integration/api/fields/types/_beansIsRadioImage.php
@@ -17,8 +17,8 @@ require_once dirname( __DIR__ ) . '/includes/class-fields-test-case.php';
  * Class Tests_BeansIsRadioImage
  *
  * @package Beans\Framework\Tests\Integration\API\Fields\Types
- * @group   integration-tests
  * @group   api
+ * @group   api-fields
  */
 class Tests_BeansIsRadioImage extends Fields_Test_Case {
 

--- a/tests/phpunit/integration/api/fields/types/_beansIsRadioImage.php
+++ b/tests/phpunit/integration/api/fields/types/_beansIsRadioImage.php
@@ -23,10 +23,10 @@ require_once dirname( __DIR__ ) . '/includes/class-fields-test-case.php';
 class Tests_BeansIsRadioImage extends Fields_Test_Case {
 
 	/**
-	 * Prepares the test environment before loading the tests.
+	 * Prepares the test environment before each test.
 	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public function setUp() {
+		parent::setUp();
 
 		// Load the field type.
 		require_once BEANS_THEME_DIR . '/lib/api/fields/types/radio.php';

--- a/tests/phpunit/integration/api/fields/types/_beansStandardizeRadioImage.php
+++ b/tests/phpunit/integration/api/fields/types/_beansStandardizeRadioImage.php
@@ -23,10 +23,10 @@ require_once dirname( __DIR__ ) . '/includes/class-fields-test-case.php';
 class Tests_BeansStandardizeRadioImage extends Fields_Test_Case {
 
 	/**
-	 * Prepares the test environment before loading the tests.
+	 * Prepares the test environment before each test.
 	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public function setUp() {
+		parent::setUp();
 
 		// Load the field type.
 		require_once BEANS_THEME_DIR . '/lib/api/fields/types/radio.php';

--- a/tests/phpunit/integration/api/fields/types/_beansStandardizeRadioImage.php
+++ b/tests/phpunit/integration/api/fields/types/_beansStandardizeRadioImage.php
@@ -17,8 +17,8 @@ require_once dirname( __DIR__ ) . '/includes/class-fields-test-case.php';
  * Class Tests_BeansStandardizeRadioImage
  *
  * @package Beans\Framework\Tests\Integration\API\Fields\Types
- * @group   integration-tests
  * @group   api
+ * @group   api-fields
  */
 class Tests_BeansStandardizeRadioImage extends Fields_Test_Case {
 

--- a/tests/phpunit/integration/api/fields/types/beansFieldActivation.php
+++ b/tests/phpunit/integration/api/fields/types/beansFieldActivation.php
@@ -17,8 +17,8 @@ require_once dirname( __DIR__ ) . '/includes/class-fields-test-case.php';
  * Class Tests_BeansFieldActivation
  *
  * @package Beans\Framework\Tests\Integration\API\Fields\Types
- * @group   integration-tests
  * @group   api
+ * @group   api-fields
  */
 class Tests_BeansFieldActivation extends Fields_Test_Case {
 

--- a/tests/phpunit/integration/api/fields/types/beansFieldCheckbox.php
+++ b/tests/phpunit/integration/api/fields/types/beansFieldCheckbox.php
@@ -17,8 +17,8 @@ require_once dirname( __DIR__ ) . '/includes/class-fields-test-case.php';
  * Class Tests_BeansFieldCheckbox
  *
  * @package Beans\Framework\Tests\Integration\API\Fields\Types
- * @group   integration-tests
  * @group   api
+ * @group   api-fields
  */
 class Tests_BeansFieldCheckbox extends Fields_Test_Case {
 

--- a/tests/phpunit/integration/api/fields/types/beansFieldDescription.php
+++ b/tests/phpunit/integration/api/fields/types/beansFieldDescription.php
@@ -17,8 +17,8 @@ require_once dirname( __DIR__ ) . '/includes/class-fields-test-case.php';
  * Class Tests_BeansFieldDescription
  *
  * @package Beans\Framework\Tests\Integration\API\Fields\Types
- * @group   integration-tests
  * @group   api
+ * @group   api-fields
  */
 class Tests_BeansFieldDescription extends Fields_Test_Case {
 

--- a/tests/phpunit/integration/api/fields/types/beansFieldImage.php
+++ b/tests/phpunit/integration/api/fields/types/beansFieldImage.php
@@ -17,8 +17,8 @@ require_once dirname( __DIR__ ) . '/includes/class-fields-test-case.php';
  * Class Tests_BeansFieldImage
  *
  * @package Beans\Framework\Tests\Integration\API\Fields\Types
- * @group   integration-tests
  * @group   api
+ * @group   api-fields
  */
 class Tests_BeansFieldImage extends Fields_Test_Case {
 

--- a/tests/phpunit/integration/api/fields/types/beansFieldLabel.php
+++ b/tests/phpunit/integration/api/fields/types/beansFieldLabel.php
@@ -17,8 +17,8 @@ require_once dirname( __DIR__ ) . '/includes/class-fields-test-case.php';
  * Class Tests_BeansFieldLabel
  *
  * @package Beans\Framework\Tests\Integration\API\Fields\Types
- * @group   integration-tests
  * @group   api
+ * @group   api-fields
  */
 class Tests_BeansFieldLabel extends Fields_Test_Case {
 

--- a/tests/phpunit/integration/api/fields/types/beansFieldRadio.php
+++ b/tests/phpunit/integration/api/fields/types/beansFieldRadio.php
@@ -17,8 +17,8 @@ require_once dirname( __DIR__ ) . '/includes/class-fields-test-case.php';
  * Class Tests_BeansFieldRadio
  *
  * @package Beans\Framework\Tests\Integration\API\Fields\Types
- * @group   integration-tests
  * @group   api
+ * @group   api-fields
  */
 class Tests_BeansFieldRadio extends Fields_Test_Case {
 

--- a/tests/phpunit/integration/api/fields/types/beansFieldSelect.php
+++ b/tests/phpunit/integration/api/fields/types/beansFieldSelect.php
@@ -17,8 +17,8 @@ require_once dirname( __DIR__ ) . '/includes/class-fields-test-case.php';
  * Class Tests_BeansFieldSelect
  *
  * @package Beans\Framework\Tests\Integration\API\Fields\Types
- * @group   integration-tests
  * @group   api
+ * @group   api-fields
  */
 class Tests_BeansFieldSelect extends Fields_Test_Case {
 

--- a/tests/phpunit/integration/api/fields/types/beansFieldSlider.php
+++ b/tests/phpunit/integration/api/fields/types/beansFieldSlider.php
@@ -17,8 +17,8 @@ require_once dirname( __DIR__ ) . '/includes/class-fields-test-case.php';
  * Class Tests_BeansFieldSlider
  *
  * @package Beans\Framework\Tests\Integration\API\Fields\Types
- * @group   integration-tests
  * @group   api
+ * @group   api-fields
  */
 class Tests_BeansFieldSlider extends Fields_Test_Case {
 

--- a/tests/phpunit/integration/api/fields/types/beansFieldText.php
+++ b/tests/phpunit/integration/api/fields/types/beansFieldText.php
@@ -17,8 +17,8 @@ require_once dirname( __DIR__ ) . '/includes/class-fields-test-case.php';
  * Class Tests_BeansFieldText
  *
  * @package Beans\Framework\Tests\Integration\API\Fields\Types
- * @group   integration-tests
  * @group   api
+ * @group   api-fields
  */
 class Tests_BeansFieldText extends Fields_Test_Case {
 

--- a/tests/phpunit/integration/api/fields/types/beansFieldTextarea.php
+++ b/tests/phpunit/integration/api/fields/types/beansFieldTextarea.php
@@ -17,8 +17,8 @@ require_once dirname( __DIR__ ) . '/includes/class-fields-test-case.php';
  * Class Tests_BeansFieldTextarea
  *
  * @package Beans\Framework\Tests\Integration\API\Fields\Types
- * @group   integration-tests
  * @group   api
+ * @group   api-fields
  */
 class Tests_BeansFieldTextarea extends Fields_Test_Case {
 

--- a/tests/phpunit/integration/bootstrap.php
+++ b/tests/phpunit/integration/bootstrap.php
@@ -68,3 +68,6 @@ tests_add_filter( 'setup_theme', function() {
 
 // Start up the WP testing environment.
 require_once $beans_tests_dir . '/includes/bootstrap.php';
+
+// Load the Integration Test Case.
+require_once BEANS_TESTS_DIR . '/class-test-case.php';

--- a/tests/phpunit/integration/class-test-case.php
+++ b/tests/phpunit/integration/class-test-case.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Test Case for the integration tests.
+ *
+ * @package Beans\Framework\Tests\Integration
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Integration;
+
+use Brain\Monkey;
+use WP_UnitTestCase;
+
+/**
+ * Abstract Class Test_Case
+ *
+ * @package Beans\Framework\Tests\Integration
+ */
+abstract class Test_Case extends WP_UnitTestCase {
+
+	/**
+	 * Prepares the test environment before each test.
+	 */
+	public function setUp() {
+		parent::setUp();
+		Monkey\setUp();
+	}
+
+	/**
+	 * Cleans up the test environment after each test.
+	 */
+	public function tearDown() {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Load the original Beans' functions into memory before we start.
+	 *
+	 * Then in our tests, we monkey patch via Brain Monkey, which redefines the original function.
+	 * At tear down, the original function is restored in Brain Monkey, by calling Patchwork\restoreAll().
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param array $files Array of files to load into memory.
+	 *
+	 * @return void
+	 */
+	protected function load_original_functions( array $files ) {
+
+		foreach ( $files as $file ) {
+			require_once BEANS_TESTS_LIB_DIR . $file;
+		}
+	}
+
+	/**
+	 * Format the HTML by stripping out the whitespace between the HTML tags and then putting each tag on a separate
+	 * line.
+	 *
+	 * Why? We can then compare the actual vs. expected HTML patterns without worrying about tabs, new lines, and extra
+	 * spaces.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param string $html HTML to strip.
+	 *
+	 * @return string
+	 */
+	protected function format_the_html( $html ) {
+		$html = trim( $html );
+
+		// Strip whitespace between the tags.
+		$html = preg_replace( '/(\>)\s*(\<)/m', '$1$2', $html );
+
+		// Strip whitespace at the end of a tag.
+		$html = preg_replace( '/(\>)\s*/m', '$1$2', $html );
+
+		// Strip whitespace at the start of a tag.
+		$html = preg_replace( '/\s*(\<)/m', '$1$2', $html );
+
+		return str_replace( '>', ">\n", $html );
+	}
+}

--- a/tests/phpunit/unit/api/fields/_beansPreStandardizeFields.php
+++ b/tests/phpunit/unit/api/fields/_beansPreStandardizeFields.php
@@ -17,8 +17,8 @@ require_once __DIR__ . '/includes/class-fields-test-case.php';
  * Class Tests_BeansPreStandardizeFields
  *
  * @package Beans\Framework\Tests\Unit\API\Fields
- * @group   unit-tests
  * @group   api
+ * @group   api-fields
  */
 class Tests_BeansPreStandardizeFields extends Fields_Test_Case {
 

--- a/tests/phpunit/unit/api/fields/beansGetFields.php
+++ b/tests/phpunit/unit/api/fields/beansGetFields.php
@@ -17,8 +17,8 @@ require_once __DIR__ . '/includes/class-fields-test-case.php';
  * Class Tests_BeansGetFields
  *
  * @package Beans\Framework\Tests\Unit\API\Fields
- * @group   unit-tests
  * @group   api
+ * @group   api-fields
  */
 class Tests_BeansGetFields extends Fields_Test_Case {
 

--- a/tests/phpunit/unit/api/fields/beansRegisterFields.php
+++ b/tests/phpunit/unit/api/fields/beansRegisterFields.php
@@ -17,8 +17,8 @@ require_once __DIR__ . '/includes/class-fields-test-case.php';
  * Class Tests_BeansRegisterFields
  *
  * @package Beans\Framework\Tests\Unit\API\Fields
- * @group   unit-tests
  * @group   api
+ * @group   api-fields
  */
 class Tests_BeansRegisterFields extends Fields_Test_Case {
 

--- a/tests/phpunit/unit/api/fields/includes/class-fields-test-case.php
+++ b/tests/phpunit/unit/api/fields/includes/class-fields-test-case.php
@@ -48,31 +48,7 @@ abstract class Fields_Test_Case extends Test_Case {
 			'api/utilities/functions.php',
 		) );
 
-		foreach ( array( 'esc_attr', 'esc_html', 'esc_textarea', 'esc_url', 'wp_kses_post', '__' ) as $wp_function ) {
-			Monkey\Functions\when( $wp_function )->returnArg();
-		}
-
-		foreach ( array( 'esc_attr_e', 'esc_html_e', '_e' ) as $wp_function ) {
-			Monkey\Functions\when( $wp_function )->echoArg();
-		}
-
-		Monkey\Functions\when( 'checked' )->alias( function( $actual, $value ) {
-			if ( $actual !== $value ) {
-				return;
-			}
-
-			echo " checked='checked'";
-		} );
-		Monkey\Functions\when( 'selected' )->alias( function( $actual, $value ) {
-			if ( $actual !== $value ) {
-				return;
-			}
-
-			echo " selected='selected'";
-		} );
-		Monkey\Functions\when( '_n' )->alias( function( $single, $plural, $number ) {
-			return $number > 1 ? $plural : $single;
-		} );
+		$this->setup_function_mocks();
 	}
 
 	/**
@@ -199,5 +175,39 @@ abstract class Fields_Test_Case extends Test_Case {
 		$html = preg_replace( '/\s*(\<)/m', '$1$2', $html );
 
 		return str_replace( '>', ">\n", $html );
+	}
+
+	/**
+	 * Set up function mocks.
+	 */
+	protected function setup_function_mocks() {
+
+		foreach ( array( 'esc_attr', 'esc_html', 'esc_textarea', 'esc_url', 'wp_kses_post', '__' ) as $wp_function ) {
+			Monkey\Functions\when( $wp_function )->returnArg();
+		}
+
+		foreach ( array( 'esc_attr_e', 'esc_html_e', '_e' ) as $wp_function ) {
+			Monkey\Functions\when( $wp_function )->echoArg();
+		}
+
+		Monkey\Functions\when( 'checked' )->alias( function ( $actual, $value ) {
+			if ( $actual !== $value ) {
+				return;
+			}
+
+			echo " checked='checked'";
+		} );
+
+		Monkey\Functions\when( 'selected' )->alias( function ( $actual, $value ) {
+			if ( $actual !== $value ) {
+				return;
+			}
+
+			echo " selected='selected'";
+		} );
+
+		Monkey\Functions\when( '_n' )->alias( function ( $single, $plural, $number ) {
+			return $number > 1 ? $plural : $single;
+		} );
 	}
 }

--- a/tests/phpunit/unit/api/fields/includes/class-fields-test-case.php
+++ b/tests/phpunit/unit/api/fields/includes/class-fields-test-case.php
@@ -151,34 +151,6 @@ abstract class Fields_Test_Case extends Test_Case {
 	}
 
 	/**
-	 * Format the HTML by stripping out the whitespace between the HTML tags and then putting each tag on a separate
-	 * line.
-	 *
-	 * Why? We can then compare the actual vs. expected HTML patterns without worrying about tabs, new lines, and extra
-	 * spaces.
-	 *
-	 * @since 1.5.0
-	 *
-	 * @param string $html HTML to strip.
-	 *
-	 * @return string
-	 */
-	protected function format_the_html( $html ) {
-		$html = trim( $html );
-
-		// Strip whitespace between the tags.
-		$html = preg_replace( '/(\>)\s*(\<)/m', '$1$2', $html );
-
-		// Strip whitespace at the end of a tag.
-		$html = preg_replace( '/(\>)\s*/m', '$1$2', $html );
-
-		// Strip whitespace at the start of a tag.
-		$html = preg_replace( '/\s*(\<)/m', '$1$2', $html );
-
-		return str_replace( '>', ">\n", $html );
-	}
-
-	/**
 	 * Set up function mocks.
 	 */
 	protected function setup_function_mocks() {

--- a/tests/phpunit/unit/api/fields/includes/class-fields-test-case.php
+++ b/tests/phpunit/unit/api/fields/includes/class-fields-test-case.php
@@ -214,5 +214,20 @@ abstract class Fields_Test_Case extends Test_Case {
 
 			return isset( $haystack[ $needle ] ) ? $haystack[ $needle ] : $default;
 		} );
+
+		Monkey\Functions\when( 'beans_esc_attributes' )->alias( function ( $attributes ) {
+			$string = '';
+
+			foreach ( (array) $attributes as $attribute => $value ) {
+
+				if ( null === $value ) {
+					continue;
+				}
+
+				$string .= $attribute . '="' . $value . '" ';
+			}
+
+			return trim( $string );
+		} );
 	}
 }

--- a/tests/phpunit/unit/api/fields/includes/class-fields-test-case.php
+++ b/tests/phpunit/unit/api/fields/includes/class-fields-test-case.php
@@ -209,5 +209,15 @@ abstract class Fields_Test_Case extends Test_Case {
 		Monkey\Functions\when( '_n' )->alias( function ( $single, $plural, $number ) {
 			return $number > 1 ? $plural : $single;
 		} );
+
+		Monkey\Functions\when( 'beans_get' )->alias( function ( $needle, $haystack = false, $default = null ) {
+			$haystack = (array) $haystack;
+
+			if ( isset( $haystack[ $needle ] ) ) {
+				return $haystack[ $needle ];
+			}
+
+			return $default;
+		} );
 	}
 }

--- a/tests/phpunit/unit/api/fields/includes/class-fields-test-case.php
+++ b/tests/phpunit/unit/api/fields/includes/class-fields-test-case.php
@@ -118,6 +118,7 @@ abstract class Fields_Test_Case extends Test_Case {
 	 */
 	protected function get_reflective_property_value( $property ) {
 		$reflective = $this->get_reflective_property( $property );
+
 		return $reflective->getValue( new \_Beans_Fields() );
 	}
 
@@ -191,19 +192,17 @@ abstract class Fields_Test_Case extends Test_Case {
 		}
 
 		Monkey\Functions\when( 'checked' )->alias( function ( $actual, $value ) {
-			if ( $actual !== $value ) {
-				return;
-			}
 
-			echo " checked='checked'";
+			if ( $actual === $value ) {
+				echo " checked='checked'";
+			}
 		} );
 
 		Monkey\Functions\when( 'selected' )->alias( function ( $actual, $value ) {
-			if ( $actual !== $value ) {
-				return;
-			}
 
-			echo " selected='selected'";
+			if ( $actual === $value ) {
+				echo " selected='selected'";
+			}
 		} );
 
 		Monkey\Functions\when( '_n' )->alias( function ( $single, $plural, $number ) {
@@ -213,11 +212,7 @@ abstract class Fields_Test_Case extends Test_Case {
 		Monkey\Functions\when( 'beans_get' )->alias( function ( $needle, $haystack = false, $default = null ) {
 			$haystack = (array) $haystack;
 
-			if ( isset( $haystack[ $needle ] ) ) {
-				return $haystack[ $needle ];
-			}
-
-			return $default;
+			return isset( $haystack[ $needle ] ) ? $haystack[ $needle ] : $default;
 		} );
 	}
 }

--- a/tests/phpunit/unit/api/fields/types/_BeansGetImageAlt.php
+++ b/tests/phpunit/unit/api/fields/types/_BeansGetImageAlt.php
@@ -24,10 +24,10 @@ require_once dirname( __DIR__ ) . '/includes/class-fields-test-case.php';
 class Tests_BeansGetImageAlt extends Fields_Test_Case {
 
 	/**
-	 * Prepares the test environment before loading the tests.
+	 * Prepares the test environment before each test.
 	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public function setUp() {
+		parent::setUp();
 
 		// Load the field type.
 		require_once BEANS_THEME_DIR . '/lib/api/fields/types/image.php';

--- a/tests/phpunit/unit/api/fields/types/_BeansGetImageAlt.php
+++ b/tests/phpunit/unit/api/fields/types/_BeansGetImageAlt.php
@@ -18,8 +18,8 @@ require_once dirname( __DIR__ ) . '/includes/class-fields-test-case.php';
  * Class Tests_BeansGetImageAlt
  *
  * @package Beans\Framework\Tests\Unit\API\Fields\Types
- * @group   integration-tests
  * @group   api
+ * @group   api-fields
  */
 class Tests_BeansGetImageAlt extends Fields_Test_Case {
 

--- a/tests/phpunit/unit/api/fields/types/_BeansGetImageUrl.php
+++ b/tests/phpunit/unit/api/fields/types/_BeansGetImageUrl.php
@@ -18,8 +18,8 @@ require_once dirname( __DIR__ ) . '/includes/class-fields-test-case.php';
  * Class Tests_BeansGetImageUrl
  *
  * @package Beans\Framework\Tests\Unit\API\Fields\Types
- * @group   integration-tests
  * @group   api
+ * @group   api-fields
  */
 class Tests_BeansGetImageUrl extends Fields_Test_Case {
 

--- a/tests/phpunit/unit/api/fields/types/_BeansGetImageUrl.php
+++ b/tests/phpunit/unit/api/fields/types/_BeansGetImageUrl.php
@@ -24,10 +24,10 @@ require_once dirname( __DIR__ ) . '/includes/class-fields-test-case.php';
 class Tests_BeansGetImageUrl extends Fields_Test_Case {
 
 	/**
-	 * Prepares the test environment before loading the tests.
+	 * Prepares the test environment before each test.
 	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public function setUp() {
+		parent::setUp();
 
 		// Load the field type.
 		require_once BEANS_THEME_DIR . '/lib/api/fields/types/image.php';

--- a/tests/phpunit/unit/api/fields/types/_beansIsRadioImage.php
+++ b/tests/phpunit/unit/api/fields/types/_beansIsRadioImage.php
@@ -17,8 +17,8 @@ require_once dirname( __DIR__ ) . '/includes/class-fields-test-case.php';
  * Class Tests_BeansIsRadioImage
  *
  * @package Beans\Framework\Tests\Unit\API\Fields\Types
- * @group   unit-tests
  * @group   api
+ * @group   api-fields
  */
 class Tests_BeansIsRadioImage extends Fields_Test_Case {
 

--- a/tests/phpunit/unit/api/fields/types/_beansIsRadioImage.php
+++ b/tests/phpunit/unit/api/fields/types/_beansIsRadioImage.php
@@ -23,10 +23,10 @@ require_once dirname( __DIR__ ) . '/includes/class-fields-test-case.php';
 class Tests_BeansIsRadioImage extends Fields_Test_Case {
 
 	/**
-	 * Prepares the test environment before loading the tests.
+	 * Prepares the test environment before each test.
 	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public function setUp() {
+		parent::setUp();
 
 		// Load the field type.
 		require_once BEANS_THEME_DIR . '/lib/api/fields/types/radio.php';

--- a/tests/phpunit/unit/api/fields/types/_beansStandardizeRadioImage.php
+++ b/tests/phpunit/unit/api/fields/types/_beansStandardizeRadioImage.php
@@ -23,10 +23,10 @@ require_once dirname( __DIR__ ) . '/includes/class-fields-test-case.php';
 class Tests_BeansStandardizeRadioImage extends Fields_Test_Case {
 
 	/**
-	 * Prepares the test environment before loading the tests.
+	 * Prepares the test environment before each test.
 	 */
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
+	public function setUp() {
+		parent::setUp();
 
 		// Load the field type.
 		require_once BEANS_THEME_DIR . '/lib/api/fields/types/radio.php';

--- a/tests/phpunit/unit/api/fields/types/_beansStandardizeRadioImage.php
+++ b/tests/phpunit/unit/api/fields/types/_beansStandardizeRadioImage.php
@@ -17,8 +17,8 @@ require_once dirname( __DIR__ ) . '/includes/class-fields-test-case.php';
  * Class Tests_BeansStandardizeRadioImage
  *
  * @package Beans\Framework\Tests\Unit\API\Fields\Types
- * @group   unit-tests
  * @group   api
+ * @group   api-fields
  */
 class Tests_BeansStandardizeRadioImage extends Fields_Test_Case {
 

--- a/tests/phpunit/unit/api/fields/types/beansFieldActivation.php
+++ b/tests/phpunit/unit/api/fields/types/beansFieldActivation.php
@@ -17,8 +17,8 @@ require_once dirname( __DIR__ ) . '/includes/class-fields-test-case.php';
  * Class Tests_BeansFieldActivation
  *
  * @package Beans\Framework\Tests\Unit\API\Fields\Types
- * @group   unit-tests
  * @group   api
+ * @group   api-fields
  */
 class Tests_BeansFieldActivation extends Fields_Test_Case {
 

--- a/tests/phpunit/unit/api/fields/types/beansFieldCheckbox.php
+++ b/tests/phpunit/unit/api/fields/types/beansFieldCheckbox.php
@@ -17,8 +17,8 @@ require_once dirname( __DIR__ ) . '/includes/class-fields-test-case.php';
  * Class Tests_BeansFieldCheckbox
  *
  * @package Beans\Framework\Tests\Unit\API\Fields\Types
- * @group   unit-tests
  * @group   api
+ * @group   api-fields
  */
 class Tests_BeansFieldCheckbox extends Fields_Test_Case {
 

--- a/tests/phpunit/unit/api/fields/types/beansFieldImage.php
+++ b/tests/phpunit/unit/api/fields/types/beansFieldImage.php
@@ -18,8 +18,8 @@ require_once dirname( __DIR__ ) . '/includes/class-fields-test-case.php';
  * Class Tests_BeansFieldImage
  *
  * @package Beans\Framework\Tests\Unit\API\Fields\Types
- * @group   unit-tests
  * @group   api
+ * @group   api-fields
  */
 class Tests_BeansFieldImage extends Fields_Test_Case {
 

--- a/tests/phpunit/unit/api/fields/types/beansFieldImage.php
+++ b/tests/phpunit/unit/api/fields/types/beansFieldImage.php
@@ -100,10 +100,11 @@ EOB;
 	public function test_should_render_multiple_images_field() {
 		Monkey\Functions\expect( 'wp_get_attachment_image_src' )
 			->times( 2 )
-			->andReturnUsing( function( $image_id ) {
+			->andReturnUsing( function ( $image_id ) {
 				if ( 'placeholder' === $image_id ) {
 					return '';
 				}
+
 				return "image-{$image_id}.png";
 			} );
 		Monkey\Functions\expect( 'get_post_meta' )

--- a/tests/phpunit/unit/api/fields/types/beansFieldRadio.php
+++ b/tests/phpunit/unit/api/fields/types/beansFieldRadio.php
@@ -17,8 +17,8 @@ require_once dirname( __DIR__ ) . '/includes/class-fields-test-case.php';
  * Class Tests_BeansFieldRadio
  *
  * @package Beans\Framework\Tests\Unit\API\Fields\Types
- * @group   unit-tests
  * @group   api
+ * @group   api-fields
  */
 class Tests_BeansFieldRadio extends Fields_Test_Case {
 

--- a/tests/phpunit/unit/api/fields/types/beansFieldSelect.php
+++ b/tests/phpunit/unit/api/fields/types/beansFieldSelect.php
@@ -17,8 +17,8 @@ require_once dirname( __DIR__ ) . '/includes/class-fields-test-case.php';
  * Class Tests_BeansFieldSelect
  *
  * @package Beans\Framework\Tests\Unit\API\Fields\Types
- * @group   unit-tests
  * @group   api
+ * @group   api-fields
  */
 class Tests_BeansFieldSelect extends Fields_Test_Case {
 

--- a/tests/phpunit/unit/api/fields/types/beansFieldSlider.php
+++ b/tests/phpunit/unit/api/fields/types/beansFieldSlider.php
@@ -17,8 +17,8 @@ require_once dirname( __DIR__ ) . '/includes/class-fields-test-case.php';
  * Class Tests_BeansFieldSlider
  *
  * @package Beans\Framework\Tests\Unit\API\Fields\Types
- * @group   unit-tests
  * @group   api
+ * @group   api-fields
  */
 class Tests_BeansFieldSlider extends Fields_Test_Case {
 

--- a/tests/phpunit/unit/api/fields/types/beansFieldText.php
+++ b/tests/phpunit/unit/api/fields/types/beansFieldText.php
@@ -17,8 +17,8 @@ require_once dirname( __DIR__ ) . '/includes/class-fields-test-case.php';
  * Class Tests_BeansFieldText
  *
  * @package Beans\Framework\Tests\Unit\API\Fields\Types
- * @group   unit-tests
  * @group   api
+ * @group   api-fields
  */
 class Tests_BeansFieldText extends Fields_Test_Case {
 

--- a/tests/phpunit/unit/api/fields/types/beansFieldTextarea.php
+++ b/tests/phpunit/unit/api/fields/types/beansFieldTextarea.php
@@ -17,8 +17,8 @@ require_once dirname( __DIR__ ) . '/includes/class-fields-test-case.php';
  * Class Tests_BeansFieldTextarea
  *
  * @package Beans\Framework\Tests\Unit\API\Fields\Types
- * @group   unit-tests
  * @group   api
+ * @group   api-fields
  */
 class Tests_BeansFieldTextarea extends Fields_Test_Case {
 

--- a/tests/phpunit/unit/class-test-case.php
+++ b/tests/phpunit/unit/class-test-case.php
@@ -27,7 +27,7 @@ abstract class Test_Case extends TestCase {
 		parent::setUp();
 		Monkey\setUp();
 
-		Functions\when( 'wp_normalize_path' )->alias( function( $path ) {
+		Functions\when( 'wp_normalize_path' )->alias( function ( $path ) {
 			$path = str_replace( '\\', '/', $path );
 			$path = preg_replace( '|(?<=.)/+|', '/', $path );
 
@@ -38,7 +38,7 @@ abstract class Test_Case extends TestCase {
 			return $path;
 		} );
 
-		Functions\when( 'wp_json_encode' )->alias( function( $array ) {
+		Functions\when( 'wp_json_encode' )->alias( function ( $array ) {
 			return json_encode( $array ); // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- Required as part of our mock.
 		} );
 	}
@@ -68,5 +68,33 @@ abstract class Test_Case extends TestCase {
 		foreach ( $files as $file ) {
 			require_once BEANS_TESTS_LIB_DIR . $file;
 		}
+	}
+
+	/**
+	 * Format the HTML by stripping out the whitespace between the HTML tags and then putting each tag on a separate
+	 * line.
+	 *
+	 * Why? We can then compare the actual vs. expected HTML patterns without worrying about tabs, new lines, and extra
+	 * spaces.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param string $html HTML to strip.
+	 *
+	 * @return string
+	 */
+	protected function format_the_html( $html ) {
+		$html = trim( $html );
+
+		// Strip whitespace between the tags.
+		$html = preg_replace( '/(\>)\s*(\<)/m', '$1$2', $html );
+
+		// Strip whitespace at the end of a tag.
+		$html = preg_replace( '/(\>)\s*/m', '$1$2', $html );
+
+		// Strip whitespace at the start of a tag.
+		$html = preg_replace( '/\s*(\<)/m', '$1$2', $html );
+
+		return str_replace( '>', ">\n", $html );
 	}
 }


### PR DESCRIPTION
1. Added an Integration Test Case to ensure Brain Monkey, Mockery, and Patchwork are properly set up and torn down.
2. Moved the HTML formatter method to each Test Case, making it available for all tests.
3. Replaced the action expects with `did_action` tests in the integration suite.
4. Replaced the `@group`.