### PR TITLE
Added .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Default behaviour
+* text=auto
+
+# Text files
+*.php eol=lf
+
+# Binary files
+*.png binary
+*.jpg binary
+*.gif binary
+*.ico binary


### PR DESCRIPTION
This only sets the line endings for `.php` files to `lf`.  
(see https://git-scm.com/docs/gitattributes#gitattributes-Settostringvaluelf)

Other file formats (e.g. `.js` or `.css`) could also be configured but right now only PHPCS is running a sniff for `lf` line endings on local / checked out files. 

It also excludes common image formats from line ending conversions. 
(see https://git-scm.com/docs/gitattributes#_using_macro_attributes)

Closes #162 