### PR TITLE
Added full integration tests for Fields API

### DIFF
--- a/tests/phpunit/integration/api/fields/beansField.php
+++ b/tests/phpunit/integration/api/fields/beansField.php
@@ -274,9 +274,6 @@ EOB;
 		foreach ( $test_data['fields'][0]['fields'] as $field ) {
 			add_action( 'beans_field_' . $field['type'], 'beans_field_' . $field['type'] );
 		}
-		add_action( 'beans_field_group_label', 'beans_field_label' );
-		add_action( 'beans_field_wrap_prepend_markup', 'beans_field_label' );
-		add_action( 'beans_field_wrap_append_markup', 'beans_field_description' );
 
 		// Run the function and grab the HTML out of the buffer.
 		ob_start();
@@ -313,8 +310,5 @@ EOB;
 		foreach ( $test_data['fields'][0]['fields'] as $field ) {
 			remove_action( 'beans_field_' . $field['type'], 'beans_field_' . $field['type'] );
 		}
-		remove_action( 'beans_field_group_label', 'beans_field_label' );
-		remove_action( 'beans_field_wrap_prepend_markup', 'beans_field_label' );
-		remove_action( 'beans_field_wrap_append_markup', 'beans_field_description' );
 	}
 }

--- a/tests/phpunit/integration/api/fields/beansField.php
+++ b/tests/phpunit/integration/api/fields/beansField.php
@@ -217,4 +217,104 @@ EOB;
 		beans_remove_action( 'beans_field_activation', 'beans_field_activation' );
 		beans_remove_action( 'beans_field_select', 'beans_field_select' );
 	}
+
+	/**
+	 * Test should render the single field. This is a full integration test for the Fields API.
+	 */
+	public function test_full_integration_should_render_single_field() {
+		$test_data = static::$test_data['single_fields'];
+
+		// Register the fields.
+		beans_register_fields( $test_data['fields'], 'beans_tests', $test_data['section'] );
+		$fields = beans_get_fields( 'beans_tests', $test_data['section'] );
+
+		// Register the checkbox, label, and description callbacks (as they've been unregistered in previous tests).
+		add_action( 'beans_field_checkbox', 'beans_field_checkbox' );
+		add_action( 'beans_field_group_label', 'beans_field_label' );
+		add_action( 'beans_field_wrap_prepend_markup', 'beans_field_label' );
+		add_action( 'beans_field_wrap_append_markup', 'beans_field_description' );
+
+		// Run the function and grab the HTML out of the buffer.
+		ob_start();
+		beans_field( $fields[1] );
+		$html = ob_get_clean();
+
+		$expected = <<<EOB
+<div class="bs-field-wrap bs-checkbox beans_tests">
+	<div class="bs-field-inside">
+		<div class="bs-field bs-checkbox">
+			<input type="hidden" value="0" name="beans_fields[beans_checkbox_test]" />
+			<input id="beans_checkbox_test" type="checkbox" name="beans_fields[beans_checkbox_test]" value="1" />
+			<span class="bs-checkbox-label">Enable the checkbox test</span>
+		</div>
+	</div>
+</div>
+EOB;
+		// Check the HTML.
+		$this->assertSame( $this->format_the_html( $expected ), $this->format_the_html( $html ) );
+
+		// Clean up.
+		remove_action( 'beans_field_checkbox', 'beans_field_checkbox' );
+		remove_action( 'beans_field_group_label', 'beans_field_label' );
+		remove_action( 'beans_field_wrap_prepend_markup', 'beans_field_label' );
+		remove_action( 'beans_field_wrap_append_markup', 'beans_field_description' );
+	}
+
+	/**
+	 * Test should render the single field. This is a full integration test for the Fields API.
+	 */
+	public function test_full_integration_should_render_group_of_fields() {
+		$test_data = static::$test_data['group'];
+
+		// Register the fields.
+		beans_register_fields( $test_data['fields'], 'beans_tests', $test_data['section'] );
+		$fields = beans_get_fields( 'beans_tests', $test_data['section'] );
+
+		// Register each field's callback (as it's been unregistered in previous tests).
+		foreach ( $test_data['fields'][0]['fields'] as $field ) {
+			add_action( 'beans_field_' . $field['type'], 'beans_field_' . $field['type'] );
+		}
+		add_action( 'beans_field_group_label', 'beans_field_label' );
+		add_action( 'beans_field_wrap_prepend_markup', 'beans_field_label' );
+		add_action( 'beans_field_wrap_append_markup', 'beans_field_description' );
+
+		// Run the function and grab the HTML out of the buffer.
+		ob_start();
+		beans_field( $fields[0] );
+		$html = ob_get_clean();
+
+		$expected = <<<EOB
+<div class="bs-field-wrap bs-group beans_tests">
+	<h3 class="bs-fields-header hndle">Group of fields</h3>
+	<div class="bs-field-inside">
+		<div class="bs-field bs-activation">
+			<input type="hidden" value="0" name="beans_fields[beans_compile_all_scripts]" />
+			<input id="beans_compile_all_scripts" type="checkbox" name="beans_fields[beans_compile_all_scripts]" value="1" />
+		</div>
+		<div class="bs-field bs-select">
+			<select id="beans_compile_all_scripts_mode" name="beans_fields[beans_compile_all_scripts_mode]" style="margin: -3px 0 0 -8px;">
+				<option value="aggressive" selected='selected'>Aggressive</option>
+				<option value="standard">Standard</option>
+			</select>
+		</div>
+		<div class="bs-field bs-checkbox">
+			<input type="hidden" value="0" name="beans_fields[beans_checkbox_test]" />
+			<input id="beans_checkbox_test" type="checkbox" name="beans_fields[beans_checkbox_test]" value="1" />
+			<span class="bs-checkbox-label">Enable the checkbox test</span>
+		</div>
+	</div>
+	<div class="bs-field-description">This is a group of fields.</div>
+</div>
+EOB;
+		// Check the HTML.
+		$this->assertSame( $this->format_the_html( $expected ), $this->format_the_html( $html ) );
+
+		// Clean up.
+		foreach ( $test_data['fields'][0]['fields'] as $field ) {
+			remove_action( 'beans_field_' . $field['type'], 'beans_field_' . $field['type'] );
+		}
+		remove_action( 'beans_field_group_label', 'beans_field_label' );
+		remove_action( 'beans_field_wrap_prepend_markup', 'beans_field_label' );
+		remove_action( 'beans_field_wrap_append_markup', 'beans_field_description' );
+	}
 }

--- a/tests/phpunit/integration/api/fields/beansField.php
+++ b/tests/phpunit/integration/api/fields/beansField.php
@@ -261,7 +261,7 @@ EOB;
 	}
 
 	/**
-	 * Test should render the single field. This is a full integration test for the Fields API.
+	 * Test should render a group of fields. This is a full integration test for the Fields API.
 	 */
 	public function test_full_integration_should_render_group_of_fields() {
 		$test_data = static::$test_data['group'];

--- a/tests/phpunit/integration/api/fields/beansGetFields.php
+++ b/tests/phpunit/integration/api/fields/beansGetFields.php
@@ -35,7 +35,7 @@ class Tests_BeansGetFields extends Fields_Test_Case {
 			);
 
 			// Register the fields first.
-			$registered = $this->get_reflective_property( 'registered' );
+			$registered = $this->get_reflective_property( 'registered', '_Beans_Fields' );
 			$registered->setValue( new \_Beans_Fields(), $data_set );
 
 			$this->assertSame( $data_set['beans_tests'][ $test_data['section'] ], beans_get_fields( 'beans_tests', $test_data['section'] ) );

--- a/tests/phpunit/integration/api/fields/includes/class-fields-test-case.php
+++ b/tests/phpunit/integration/api/fields/includes/class-fields-test-case.php
@@ -45,6 +45,10 @@ abstract class Fields_Test_Case extends Test_Case {
 		$this->reset_fields_container();
 
 		$this->reset_actions_container();
+
+		add_action( 'beans_field_group_label', 'beans_field_label' );
+		add_action( 'beans_field_wrap_prepend_markup', 'beans_field_label' );
+		add_action( 'beans_field_wrap_append_markup', 'beans_field_description' );
 	}
 
 	/**
@@ -56,6 +60,10 @@ abstract class Fields_Test_Case extends Test_Case {
 		$this->reset_fields_container();
 
 		$this->reset_actions_container();
+
+		remove_action( 'beans_field_group_label', 'beans_field_label' );
+		remove_action( 'beans_field_wrap_prepend_markup', 'beans_field_label' );
+		remove_action( 'beans_field_wrap_append_markup', 'beans_field_description' );
 	}
 
 	/**

--- a/tests/phpunit/integration/api/fields/includes/class-fields-test-case.php
+++ b/tests/phpunit/integration/api/fields/includes/class-fields-test-case.php
@@ -49,20 +49,9 @@ abstract class Fields_Test_Case extends Test_Case {
 	public function tearDown() {
 		parent::tearDown();
 
-		// Reset the "registered" container.
-		$registered = $this->get_reflective_property( 'registered' );
-		$registered->setValue( new \_Beans_Fields(), array(
-			'option'       => array(),
-			'post_meta'    => array(),
-			'term_meta'    => array(),
-			'wp_customize' => array(),
-		) );
+		$this->reset_fields_container();
 
-		// Reset the other static properties.
-		foreach ( array( 'field_types_loaded', 'field_assets_hook_loaded' ) as $property_name ) {
-			$property = $this->get_reflective_property( $property_name );
-			$property->setValue( new \_Beans_Fields(), array() );
-		}
+		$this->reset_actions_container();
 	}
 
 	/**

--- a/tests/phpunit/integration/api/fields/includes/class-fields-test-case.php
+++ b/tests/phpunit/integration/api/fields/includes/class-fields-test-case.php
@@ -41,6 +41,10 @@ abstract class Fields_Test_Case extends Test_Case {
 		parent::setUp();
 
 		require_once BEANS_THEME_DIR . '/lib/api/fields/class-beans-fields.php';
+
+		$this->reset_fields_container();
+
+		$this->reset_actions_container();
 	}
 
 	/**

--- a/tests/phpunit/integration/api/fields/includes/class-fields-test-case.php
+++ b/tests/phpunit/integration/api/fields/includes/class-fields-test-case.php
@@ -67,40 +67,6 @@ abstract class Fields_Test_Case extends Test_Case {
 	}
 
 	/**
-	 * Get reflective access to the private method.
-	 *
-	 * @since 1.5.0
-	 *
-	 * @param string $method_name Method name for which to gain access.
-	 *
-	 * @return \ReflectionMethod
-	 */
-	protected function get_reflective_method( $method_name ) {
-		$class  = new \ReflectionClass( '_Beans_Fields' );
-		$method = $class->getMethod( $method_name );
-		$method->setAccessible( true );
-
-		return $method;
-	}
-
-	/**
-	 * Get reflective access to the private property.
-	 *
-	 * @since 1.5.0
-	 *
-	 * @param string $property Property name for which to gain access.
-	 *
-	 * @return \ReflectionProperty|string
-	 */
-	protected function get_reflective_property( $property ) {
-		$class    = new \ReflectionClass( '_Beans_Fields' );
-		$property = $class->getProperty( $property );
-		$property->setAccessible( true );
-
-		return $property;
-	}
-
-	/**
 	 * Get the value of the private or protected property.
 	 *
 	 * @since 1.5.0
@@ -108,9 +74,10 @@ abstract class Fields_Test_Case extends Test_Case {
 	 * @param string $property Property name for which to gain access.
 	 *
 	 * @return mixed
+	 * @throws \ReflectionException Throws an exception if property does not exist.
 	 */
 	protected function get_reflective_property_value( $property ) {
-		$reflective = $this->get_reflective_property( $property );
+		$reflective = $this->get_reflective_property( $property, '_Beans_Fields' );
 		return $reflective->getValue( new \_Beans_Fields() );
 	}
 

--- a/tests/phpunit/integration/api/fields/includes/class-fields-test-case.php
+++ b/tests/phpunit/integration/api/fields/includes/class-fields-test-case.php
@@ -42,10 +42,6 @@ abstract class Fields_Test_Case extends Test_Case {
 
 		require_once BEANS_THEME_DIR . '/lib/api/fields/class-beans-fields.php';
 
-		$this->reset_fields_container();
-
-		$this->reset_actions_container();
-
 		add_action( 'beans_field_group_label', 'beans_field_label' );
 		add_action( 'beans_field_wrap_prepend_markup', 'beans_field_label' );
 		add_action( 'beans_field_wrap_append_markup', 'beans_field_description' );
@@ -56,10 +52,6 @@ abstract class Fields_Test_Case extends Test_Case {
 	 */
 	public function tearDown() {
 		parent::tearDown();
-
-		$this->reset_fields_container();
-
-		$this->reset_actions_container();
 
 		remove_action( 'beans_field_group_label', 'beans_field_label' );
 		remove_action( 'beans_field_wrap_prepend_markup', 'beans_field_label' );

--- a/tests/phpunit/integration/class-test-case.php
+++ b/tests/phpunit/integration/class-test-case.php
@@ -114,4 +114,42 @@ abstract class Test_Case extends WP_UnitTestCase {
 			$property->setValue( new \_Beans_Fields(), array() );
 		}
 	}
+
+	/**
+	 * Get reflective access to the private method.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param string $method_name Method name for which to gain access.
+	 * @param string $class_name  Name of the target class.
+	 *
+	 * @return \ReflectionMethod
+	 * @throws \ReflectionException Throws an exception if method does not exist.
+	 */
+	protected function get_reflective_method( $method_name, $class_name ) {
+		$class  = new \ReflectionClass( $class_name );
+		$method = $class->getMethod( $method_name );
+		$method->setAccessible( true );
+
+		return $method;
+	}
+
+	/**
+	 * Get reflective access to the private property.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param string $property   Property name for which to gain access.
+	 * @param string $class_name Name of the target class.
+	 *
+	 * @return \ReflectionProperty|string
+	 * @throws \ReflectionException Throws an exception if property does not exist.
+	 */
+	protected function get_reflective_property( $property, $class_name ) {
+		$class    = new \ReflectionClass( $class_name );
+		$property = $class->getProperty( $property );
+		$property->setAccessible( true );
+
+		return $property;
+	}
 }

--- a/tests/phpunit/integration/class-test-case.php
+++ b/tests/phpunit/integration/class-test-case.php
@@ -81,4 +81,37 @@ abstract class Test_Case extends WP_UnitTestCase {
 
 		return str_replace( '>', ">\n", $html );
 	}
+
+	/**
+	 * Reset the Actions API container.
+	 */
+	protected function reset_actions_container() {
+		global $_beans_registered_actions;
+		$_beans_registered_actions = array(
+			'added'    => array(),
+			'modified' => array(),
+			'removed'  => array(),
+			'replaced' => array(),
+		);
+	}
+
+	/**
+	 * Reset the Fields API container, i.e. static memories.
+	 */
+	protected function reset_fields_container() {
+		// Reset the "registered" container.
+		$registered = $this->get_reflective_property( 'registered', '_Beans_Fields' );
+		$registered->setValue( new \_Beans_Fields(), array(
+			'option'       => array(),
+			'post_meta'    => array(),
+			'term_meta'    => array(),
+			'wp_customize' => array(),
+		) );
+
+		// Reset the other static properties.
+		foreach ( array( 'field_types_loaded', 'field_assets_hook_loaded' ) as $property_name ) {
+			$property = $this->get_reflective_property( $property_name, '_Beans_Fields' );
+			$property->setValue( new \_Beans_Fields(), array() );
+		}
+	}
 }

--- a/tests/phpunit/integration/class-test-case.php
+++ b/tests/phpunit/integration/class-test-case.php
@@ -20,11 +20,24 @@ use WP_UnitTestCase;
 abstract class Test_Case extends WP_UnitTestCase {
 
 	/**
+	 * Reset flag.
+	 *
+	 * @var bool
+	 */
+	protected $was_reset = false;
+
+	/**
 	 * Prepares the test environment before each test.
 	 */
 	public function setUp() {
 		parent::setUp();
 		Monkey\setUp();
+
+		if ( $this->was_reset ) {
+			$this->reset_fields_container();
+			$this->reset_actions_container();
+			$this->was_reset = true;
+		}
 	}
 
 	/**
@@ -33,6 +46,9 @@ abstract class Test_Case extends WP_UnitTestCase {
 	public function tearDown() {
 		Monkey\tearDown();
 		parent::tearDown();
+
+		$this->reset_fields_container();
+		$this->reset_actions_container();
 	}
 
 	/**
@@ -99,6 +115,11 @@ abstract class Test_Case extends WP_UnitTestCase {
 	 * Reset the Fields API container, i.e. static memories.
 	 */
 	protected function reset_fields_container() {
+
+		if ( ! class_exists( '_Beans_Fields' ) ) {
+			return;
+		}
+
 		// Reset the "registered" container.
 		$registered = $this->get_reflective_property( 'registered', '_Beans_Fields' );
 		$registered->setValue( new \_Beans_Fields(), array(

--- a/tests/phpunit/integration/class-test-case.php
+++ b/tests/phpunit/integration/class-test-case.php
@@ -33,7 +33,7 @@ abstract class Test_Case extends WP_UnitTestCase {
 		parent::setUp();
 		Monkey\setUp();
 
-		if ( $this->was_reset ) {
+		if ( ! $this->was_reset ) {
 			$this->reset_fields_container();
 			$this->reset_actions_container();
 			$this->was_reset = true;


### PR DESCRIPTION
To ensure that everything works in the Fields API, this PR adds 2 full integration tests that register the fields and then render them.

This PR also improves the test suite by:

1. Adding Actions API Container resets in the Integration Test Case.
2. Adding Fields API Container resets in the Integration Test Case.
3. Moving the reflective methods to the Integration Test Case.
4. Adding label and description set up and tear down.

The resets ensure we start at a known state for each test.