### PR TITLE
Tested & Optimized beans_add_attributes.

### DIFF
--- a/lib/api/html/functions.php
+++ b/lib/api/html/functions.php
@@ -459,10 +459,10 @@ function beans_wrap_inner_markup( $id, $new_id, $tag, $attributes = array() ) {
 }
 
 /**
- * Register attributes by ID.
+ * Convert an array of attributes into a properly formatted HTML string.
  *
- * The Beans HTML "attributes" functions make it really easy to modify, replace, extend, remove or hook
- * into registered attributes.
+ * The attributes are registered in Beans via the given ID.  Using this ID, we can hook into the filter, i.e.
+ * "$id_attributes", to modify, replace, extend, or remove one or more of the register attributes.
  *
  * Since this function uses {@see beans_apply_filters()}, the $id argument may contain sub-hook(s).
  *

--- a/lib/api/html/functions.php
+++ b/lib/api/html/functions.php
@@ -484,7 +484,7 @@ function beans_add_attributes( $id, $attributes = array() ) {
 	$args    = func_get_args();
 	$args[0] = $id . '_attributes';
 
-	if ( ! isset( $args[1] ) ) {
+	if ( empty( $args[1] ) ) {
 		$args[1] = array();
 	}
 

--- a/lib/api/html/functions.php
+++ b/lib/api/html/functions.php
@@ -462,7 +462,7 @@ function beans_wrap_inner_markup( $id, $new_id, $tag, $attributes = array() ) {
  * Convert an array of attributes into a properly formatted HTML string.
  *
  * The attributes are registered in Beans via the given ID.  Using this ID, we can hook into the filter, i.e.
- * "$id_attributes", to modify, replace, extend, or remove one or more of the register attributes.
+ * "$id_attributes", to modify, replace, extend, or remove one or more of the registered attributes.
  *
  * Since this function uses {@see beans_apply_filters()}, the $id argument may contain sub-hook(s).
  *

--- a/tests/phpunit/integration/api/html/beansAddAttributes.php
+++ b/tests/phpunit/integration/api/html/beansAddAttributes.php
@@ -2,50 +2,25 @@
 /**
  * Tests for beans_add_attributes().
  *
- * @package Beans\Framework\Tests\Unit\API\HTML
+ * @package Beans\Framework\Tests\Integration\API\HTML
  *
  * @since   1.5.0
  */
 
-namespace Beans\Framework\Tests\Unit\API\HTML;
+namespace Beans\Framework\Tests\Integration\API\HTML;
 
-use Beans\Framework\Tests\Unit\API\HTML\Includes\HTML_Test_Case;
-use Brain\Monkey;
+use Beans\Framework\Tests\Integration\API\HTML\Includes\HTML_Test_Case;
 
 require_once __DIR__ . '/includes/class-html-test-case.php';
 
 /**
  * Class Tests_BeansAddAttributes
  *
- * @package Beans\Framework\Tests\Unit\API\HTML
+ * @package Beans\Framework\Tests\Integration\API\HTML
  * @group   api
  * @group   api-html
  */
 class Tests_BeansAddAttributes extends HTML_Test_Case {
-
-	/**
-	 * Setup dependency function mocks.
-	 */
-	protected function setup_mocks() {
-		parent::setup_mocks();
-
-		Monkey\Functions\when( 'wp_parse_args' )->alias( function ( $args ) {
-
-			if ( is_array( $args ) ) {
-				return $args;
-			}
-
-			if ( is_object( $args ) ) {
-				return get_object_vars( $args );
-			}
-
-			if ( is_string( $args ) ) {
-				parse_str( $args, $result );
-
-				return $result;
-			}
-		} );
-	}
 
 	/**
 	 * Test beans_add_attributes() should return the built attributes string.
@@ -53,11 +28,6 @@ class Tests_BeansAddAttributes extends HTML_Test_Case {
 	public function test_should_return_built_attributes_string() {
 
 		foreach ( static::$test_attributes as $id => $config ) {
-			Monkey\Functions\expect( 'beans_apply_filters' )
-				->with( $id . '_attributes', $config['attributes'] )
-				->once()
-				->andReturn( $config['attributes'] );
-
 			$expected = $this->convert_attributes_into_html( $config['attributes'] );
 			$this->assertSame( $expected, beans_add_attributes( $id, $config['attributes'] ) );
 		}
@@ -67,11 +37,6 @@ class Tests_BeansAddAttributes extends HTML_Test_Case {
 	 * Test beans_add_attributes() should return empty string when no attributes.
 	 */
 	public function test_should_return_empty_string_when_no_attributes() {
-		Monkey\Functions\expect( 'beans_apply_filters' )
-			->with( 'foo_attributes', array() )
-			->times( 4 )
-			->andReturn( array() );
-
 		$this->assertSame( '', beans_add_attributes( 'foo' ) );
 		$this->assertSame( '', beans_add_attributes( 'foo', null ) );
 		$this->assertSame( '', beans_add_attributes( 'foo', '' ) );

--- a/tests/phpunit/integration/api/html/beansAddAttributes.php
+++ b/tests/phpunit/integration/api/html/beansAddAttributes.php
@@ -23,14 +23,23 @@ require_once __DIR__ . '/includes/class-html-test-case.php';
 class Tests_BeansAddAttributes extends HTML_Test_Case {
 
 	/**
-	 * Test beans_add_attributes() should return the built attributes string.
+	 * Test beans_add_attributes() should return the built attributes string when an array of attributes is given.
 	 */
-	public function test_should_return_built_attributes_string() {
+	public function test_should_return_built_attributes_string_when_array_given() {
 
 		foreach ( static::$test_attributes as $id => $config ) {
 			$expected = $this->convert_attributes_into_html( $config['attributes'] );
 			$this->assertSame( $expected, beans_add_attributes( $id, $config['attributes'] ) );
 		}
+	}
+
+	/**
+	 * Test beans_add_attributes() should return the built attributes string when a query string of attributes is given.
+	 */
+	public function test_should_return_built_attributes_string_when_query_string_given() {
+		$this->assertSame( 'id="test"', beans_add_attributes( 'foo', 'id=test' ) );
+		$this->assertSame( 'class="foo" data-foo="test"', beans_add_attributes( 'foo', 'class=foo&data-foo=test' ) );
+		$this->assertSame( 'class="test" style="color:#fff;"', beans_add_attributes( 'beans-test', 'class=test&style=color:#fff;' ) );
 	}
 
 	/**

--- a/tests/phpunit/integration/api/html/beansAddAttributes.php
+++ b/tests/phpunit/integration/api/html/beansAddAttributes.php
@@ -10,6 +10,7 @@
 namespace Beans\Framework\Tests\Integration\API\HTML;
 
 use Beans\Framework\Tests\Integration\API\HTML\Includes\HTML_Test_Case;
+use Brain\Monkey;
 
 require_once __DIR__ . '/includes/class-html-test-case.php';
 
@@ -50,5 +51,27 @@ class Tests_BeansAddAttributes extends HTML_Test_Case {
 		$this->assertSame( '', beans_add_attributes( 'foo', null ) );
 		$this->assertSame( '', beans_add_attributes( 'foo', '' ) );
 		$this->assertSame( '', beans_add_attributes( 'foo', false ) );
+	}
+
+	/**
+	 * Test beans_add_attributes() should return filtered attributes when there is a registered callback.  This test
+	 * ensures the registration component works as expected.
+	 */
+	public function test_should_return_filtered_attributes_when_registered_callback() {
+		// Setup the test.
+		$attributes = array( 'class' => 'foo' );
+		Monkey\Functions\expect( 'foo_attributes_callback' )
+			->with( $attributes )
+			->once()
+			->andReturnUsing( function ( $attributes ) {
+				return array( 'class' => 'changed-me' );
+			} );
+		add_action( 'foo_attributes', 'foo_attributes_callback' );
+
+		// Run the test.
+		$this->assertSame( 'class="changed-me"', beans_add_attributes( 'foo', $attributes ) );
+
+		// Clean up.
+		remove_action( 'foo_attributes', 'foo_attributes_callback' );
 	}
 }

--- a/tests/phpunit/integration/api/html/beansAddAttributes.php
+++ b/tests/phpunit/integration/api/html/beansAddAttributes.php
@@ -44,7 +44,7 @@ class Tests_BeansAddAttributes extends HTML_Test_Case {
 	}
 
 	/**
-	 * Test beans_add_attributes() should return empty string when no attributes.
+	 * Test beans_add_attributes() should return an empty string when no attributes are given.
 	 */
 	public function test_should_return_empty_string_when_no_attributes() {
 		$this->assertSame( '', beans_add_attributes( 'foo' ) );

--- a/tests/phpunit/integration/api/html/includes/class-html-test-case.php
+++ b/tests/phpunit/integration/api/html/includes/class-html-test-case.php
@@ -43,4 +43,23 @@ abstract class HTML_Test_Case extends WP_UnitTestCase {
 			return isset( $markup['attributes'] );
 		} );
 	}
+
+	/**
+	 * Convert an array of attributes into a combined HTML string.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param array $attributes The given attributes to combine.
+	 *
+	 * @return string
+	 */
+	public function convert_attributes_into_html( array $attributes ) {
+		$html = '';
+
+		foreach ( $attributes as $attribute => $value ) {
+			$html .= $attribute . '="' . $value . '" ';
+		}
+
+		return rtrim( $html );
+	}
 }

--- a/tests/phpunit/unit/api/html/beansAddAttributes.php
+++ b/tests/phpunit/unit/api/html/beansAddAttributes.php
@@ -29,7 +29,7 @@ class Tests_BeansAddAttributes extends HTML_Test_Case {
 	protected function setup_mocks() {
 		parent::setup_mocks();
 
-		Monkey\Functions\when( 'wp_parse_args' )->alias( function ( $args ) {
+		Monkey\Functions\when( 'wp_parse_args' )->alias( function( $args ) {
 
 			if ( is_array( $args ) ) {
 				return $args;
@@ -64,7 +64,7 @@ class Tests_BeansAddAttributes extends HTML_Test_Case {
 	}
 
 	/**
-	 * Test beans_add_attributes() should return empty string when no attributes.
+	 * Test beans_add_attributes() should return an empty string when no attributes are given.
 	 */
 	public function test_should_return_empty_string_when_no_attributes() {
 		Monkey\Functions\expect( 'beans_apply_filters' )

--- a/tests/phpunit/unit/api/html/beansAddAttributes.php
+++ b/tests/phpunit/unit/api/html/beansAddAttributes.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Tests for beans_add_attributes().
+ *
+ * @package Beans\Framework\Tests\Unit\API\HTML
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Unit\API\HTML;
+
+use Beans\Framework\Tests\Unit\API\HTML\Includes\HTML_Test_Case;
+use Brain\Monkey;
+
+require_once __DIR__ . '/includes/class-html-test-case.php';
+
+/**
+ * Class Tests_BeansAddAttributes
+ *
+ * @package Beans\Framework\Tests\Unit\API\HTML
+ * @group   api
+ * @group   api-html
+ */
+class Tests_BeansAddAttributes extends HTML_Test_Case {
+
+	/**
+	 * Setup dependency function mocks.
+	 */
+	protected function setup_mocks() {
+		parent::setup_mocks();
+
+		Monkey\Functions\when( 'wp_parse_args' )->alias( function ( $args ) {
+
+			if ( is_array( $args ) ) {
+				return $args;
+			}
+
+			if ( is_object( $args ) ) {
+				return get_object_vars( $args );
+			}
+
+			if ( is_string( $args ) ) {
+				parse_str( $args, $result );
+
+				return $result;
+			}
+		} );
+	}
+
+	/**
+	 * Test beans_add_attributes() should return false when the option does not exist.
+	 */
+	public function test_should_register_attributes() {
+		Monkey\Filters\expectApplied( 'foo_attribute' )->once()->with( array(
+			'foo_attrbutes',
+			array( 'data-foo' => 'beans' ),
+		) );
+
+		$this->assertSame( 'data-foo="beans"', beans_add_attributes( 'foo', array( 'data-foo' => 'beans' ) ) );
+	}
+}

--- a/tests/phpunit/unit/api/html/beansAddAttributes.php
+++ b/tests/phpunit/unit/api/html/beansAddAttributes.php
@@ -77,4 +77,17 @@ class Tests_BeansAddAttributes extends HTML_Test_Case {
 		$this->assertSame( '', beans_add_attributes( 'foo', '' ) );
 		$this->assertSame( '', beans_add_attributes( 'foo', false ) );
 	}
+
+	/**
+	 * Test beans_add_attributes() should pass additional arguments when given.
+	 */
+	public function test_should_pass_additional_arguments_when_given() {
+		$attributes = array( 'class' => 'foo' );
+		Monkey\Functions\expect( 'beans_apply_filters' )
+			->with( 'foo_attributes', $attributes, 14, 'hi' )
+			->once()
+			->andReturn( $attributes );
+
+		$this->assertSame( 'class="foo"', beans_add_attributes( 'foo', $attributes, 14, 'hi' ) );
+	}
 }

--- a/tests/phpunit/unit/api/html/includes/class-html-test-case.php
+++ b/tests/phpunit/unit/api/html/includes/class-html-test-case.php
@@ -10,6 +10,7 @@
 namespace Beans\Framework\Tests\Unit\API\HTML\Includes;
 
 use Beans\Framework\Tests\Unit\Test_Case;
+use Brain\Monkey;
 
 /**
  * Abstract Class HTML_Test_Case
@@ -55,5 +56,27 @@ abstract class HTML_Test_Case extends Test_Case {
 			'api/html/functions.php',
 			'api/filters/functions.php',
 		) );
+
+		$this->setup_mocks();
+	}
+
+	/**
+	 * Setup dependency function mocks.
+	 */
+	protected function setup_mocks() {
+		Monkey\Functions\when( 'beans_esc_attributes' )->alias( function( array $attributes ) {
+			$string = '';
+
+			foreach ( (array) $attributes as $attribute => $value ) {
+
+				if ( null === $value ) {
+					continue;
+				}
+
+				$string .= $attribute . '="' . $value . '" ';
+			}
+
+			return trim( $string );
+		} );
 	}
 }

--- a/tests/phpunit/unit/api/html/includes/class-html-test-case.php
+++ b/tests/phpunit/unit/api/html/includes/class-html-test-case.php
@@ -40,7 +40,7 @@ abstract class HTML_Test_Case extends Test_Case {
 		parent::setUpBeforeClass();
 
 		static::$test_markup     = require dirname( __DIR__ ) . DIRECTORY_SEPARATOR . 'fixtures/test-markup.php';
-		static::$test_attributes = array_filter( static::$test_markup, function ( $markup ) {
+		static::$test_attributes = array_filter( static::$test_markup, function( $markup ) {
 			return isset( $markup['attributes'] );
 		} );
 	}

--- a/tests/phpunit/unit/api/html/includes/class-html-test-case.php
+++ b/tests/phpunit/unit/api/html/includes/class-html-test-case.php
@@ -40,7 +40,7 @@ abstract class HTML_Test_Case extends Test_Case {
 		parent::setUpBeforeClass();
 
 		static::$test_markup     = require dirname( __DIR__ ) . DIRECTORY_SEPARATOR . 'fixtures/test-markup.php';
-		static::$test_attributes = array_filter( static::$test_markup, function( $markup ) {
+		static::$test_attributes = array_filter( static::$test_markup, function ( $markup ) {
 			return isset( $markup['attributes'] );
 		} );
 	}
@@ -64,19 +64,25 @@ abstract class HTML_Test_Case extends Test_Case {
 	 * Setup dependency function mocks.
 	 */
 	protected function setup_mocks() {
-		Monkey\Functions\when( 'beans_esc_attributes' )->alias( function( array $attributes ) {
-			$string = '';
+		Monkey\Functions\when( 'beans_esc_attributes' )->alias( array( $this, 'convert_attributes_into_html' ) );
+	}
 
-			foreach ( (array) $attributes as $attribute => $value ) {
+	/**
+	 * Convert an array of attributes into a combined HTML string.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param array $attributes The given attributes to combine.
+	 *
+	 * @return string
+	 */
+	public function convert_attributes_into_html( array $attributes ) {
+		$html = '';
 
-				if ( null === $value ) {
-					continue;
-				}
+		foreach ( $attributes as $attribute => $value ) {
+			$html .= $attribute . '="' . $value . '" ';
+		}
 
-				$string .= $attribute . '="' . $value . '" ';
-			}
-
-			return trim( $string );
-		} );
+		return rtrim( $html );
 	}
 }


### PR DESCRIPTION
1. Added unit tests.
2. Added integration tests.
3. Removed the `isset()` and replaced with `empty()` to further optimize the function.

## Optimization Results

The overall function improved by 0.002303 ms.

```
-------------------------
MICRO PROFILER REPORT:
-------------------------

PHP version:        5.6.20
Sample Size:        100,000 (per function)
Time Increments:    milliseconds, where 1 ms equals 0.001 second.

  --------------------------------   -------------   -------------   -------------
| Name                             | Result        |  Avg Time     | v1.4.0
|                                  | (ms)          |  (ms)         | (ms)
| -------------------------------- | ------------- | ------------- | -------------
| beans_add_attributes             |    -0.002303  |      0.017420 |      0.019723
 --------------------------------   -------------   -------------   -------------

NOTES:

1. The functions were invoked/exercised 100,000 times during this micro profiler process.
2. The 'diff' column = 'time' - 'v1.4.0'.
3. The 'time' column shows the function's average execution time.
4. 'v1.4.0' shows the same micro-profiler run on Beans v1.4.0.
```