### PR TITLE
Tested beans_wrap_inner_markup.

### DIFF
--- a/lib/api/html/functions.php
+++ b/lib/api/html/functions.php
@@ -456,6 +456,11 @@ function beans_wrap_markup( $id, $new_id, $tag, $attributes = array() ) {
  * @return bool Will always return true.
  */
 function beans_wrap_inner_markup( $id, $new_id, $tag, $attributes = array() ) {
+
+	if ( ! $tag ) {
+		return false;
+	}
+
 	$args = func_get_args();
 	unset( $args[0] );
 

--- a/lib/api/html/functions.php
+++ b/lib/api/html/functions.php
@@ -434,18 +434,23 @@ function beans_wrap_markup( $id, $new_id, $tag, $attributes = array() ) {
 }
 
 /**
- * Wrap markup inner content.
+ * Register the wrap inner content's markup with Beans using the given markup ID.
  *
- * This function calls {@see beans_open_markup()} after the opening markup and {@see beans_close_markup()}
- * before the closing markup.
+ * This function registers an anonymous callback to the following action hooks:
+ *
+ *    1. `$id_prepend_markup`:  When this hook fires, {@see beans_open_markup()} is called to build the wrap inner
+ *        content's HTML markup just after the wrap's opening tag.
+ *    2. `$id_append_markup`: When this hook fires, {@see beans_close_markup()} is called to build the wrap inner
+ *        content's HTML markup just before the wrap's closing tag.
  *
  * Note: You can pass additional arguments to the functions that are hooked to <tt>$id</tt>.
  *
  * @since 1.0.0
+ * @since 1.5.0 Bails out if an empty $tag is given.
  *
- * @param string       $id         The markup ID.
+ * @param string       $id         The wrap markup's ID.
  * @param string       $new_id     A unique string used as a reference. The $id argument may contain sub-hook(s).
- * @param string       $tag        The HTML wrap tag.
+ * @param string       $tag        The wrap inner content's HTML tag.
  * @param string|array $attributes Optional. Query string or array of attributes. The array key defines the
  *                                 attribute name and the array value define the attribute value. Setting
  *                                 the array value to '' will display the attribute value as empty
@@ -453,7 +458,7 @@ function beans_wrap_markup( $id, $new_id, $tag, $attributes = array() ) {
  *                                 the attribute name (e.g. data-example). Setting it to 'null' will not
  *                                 display anything.
  *
- * @return bool Will always return true.
+ * @return bool
  */
 function beans_wrap_inner_markup( $id, $new_id, $tag, $attributes = array() ) {
 

--- a/tests/phpunit/integration/api/html/beansWrapInnerMarkup.php
+++ b/tests/phpunit/integration/api/html/beansWrapInnerMarkup.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Tests for beans_wrap_inner_markup().
+ *
+ * @package Beans\Framework\Tests\Integration\API\HTML
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Integration\API\HTML;
+
+use Beans\Framework\Tests\Integration\API\HTML\Includes\HTML_Test_Case;
+use Brain\Monkey;
+
+require_once __DIR__ . '/includes/class-html-test-case.php';
+
+/**
+ * Class Tests_BeansWrapInnerMarkup
+ *
+ * @package Beans\Framework\Tests\Integration\API\HTML
+ * @group   api
+ * @group   api-html
+ */
+class Tests_BeansWrapInnerMarkup extends HTML_Test_Case {
+
+	/**
+	 * Since we do not have direct access to the instance, we need to get it from WordPress.
+	 *
+	 * @since 1.5.0
+	 *
+	 * @param string $hook     To given hook's event name.
+	 * @param int    $priority The priority number for the callback.
+	 *
+	 * @return \_Beans_Anonymous_Actions
+	 */
+	protected function get_instance_from_wp( $hook, $priority ) {
+		global $wp_filter;
+
+		return end( $wp_filter[ $hook ]->callbacks[ $priority ] )['function'][0];
+	}
+
+	/**
+	 * Test beans_wrap_inner_markup() should register beans_open_markup() to the given ID's '_prepend_markup' hook.
+	 */
+	public function test_should_register_beans_open_markup_to_given_id_prepend_markup_hook() {
+		$this->assertTrue( beans_wrap_inner_markup( 'foo', 'new_foo', 'div', array( 'class' => 'test-wrap' ) ) );
+
+		// Check that it did register a callback to the hook.
+		$this->assertTrue( has_action( 'foo_prepend_markup' ) );
+		global $wp_filter;
+		$this->assertArrayHasKey( 'foo_prepend_markup', $wp_filter );
+		$this->assertArrayHasKey( 1, $wp_filter['foo_prepend_markup'] );
+
+		// Check that the correct arguments were stored in the instance.
+		$anonomyous_action = $this->get_instance_from_wp( 'foo_prepend_markup', 1 );
+		$this->assertSame(
+			array(
+				'beans_open_markup',
+				array(
+					1 => 'new_foo',
+					2 => 'div',
+					3 => array( 'class' => 'test-wrap' ),
+				),
+			),
+			$anonomyous_action->callback
+		);
+
+		// Clean up.
+		remove_action( 'foo_prepend_markup', array( $anonomyous_action, 'callback' ), 1 );
+	}
+
+	/**
+	 * Test beans_wrap_inner_markup() should register beans_close_markup() to the given ID's '_append_markup' hook.
+	 */
+	public function test_should_register_beans_close_markup_to_given_id_append_markup_hook() {
+		$this->assertTrue( beans_wrap_inner_markup( 'foo', 'new_foo', 'div', array( 'class' => 'test-wrap' ) ) );
+
+		// Check that it did register a callback to the hook.
+		$this->assertTrue( has_action( 'foo_append_markup' ) );
+		global $wp_filter;
+		$this->assertArrayHasKey( 'foo_append_markup', $wp_filter );
+		$this->assertArrayHasKey( 9999, $wp_filter['foo_append_markup'] );
+
+		// Check that the correct arguments were stored in the instance.
+		$anonomyous_action = $this->get_instance_from_wp( 'foo_append_markup', 9999 );
+		$this->assertSame(
+			array(
+				'beans_close_markup',
+				array(
+					1 => 'new_foo',
+					2 => 'div',
+				),
+			),
+			$anonomyous_action->callback
+		);
+
+		// Clean up.
+		remove_action( 'foo_append_markup', array( $anonomyous_action, 'callback' ), 9999 );
+	}
+
+	/**
+	 * Test beans_wrap_inner_markup() should not pass the given attributes to anonymous action.
+	 */
+	public function test_should_not_pass_attributes_for_append_markup_hook() {
+		beans_wrap_inner_markup( 'no_atts', '', 'div', array( 'class' => 'test-wrap' ) );
+
+		// Check that the attributes do not exist.
+		$anonomyous_action = $this->get_instance_from_wp( 'no_atts_append_markup', 9999 );
+		$this->assertNotContains( array( 'class' => 'test-wrap' ), $anonomyous_action->callback[1] );
+
+		// Clean up.
+		remove_action( 'no_atts_append_markup', array( $anonomyous_action, 'callback' ), 9999 );
+	}
+
+	/**
+	 * Test beans_wrap_inner_markup() should pass the extra arguments to the anonymous action for the given ID's
+	 * '_prepend_markup' hook.
+	 */
+	public function test_should_pass_extra_arguments_for_prepend_markup_hook() {
+		beans_wrap_inner_markup( 'extra_args', 'new_extra_args', 'div', array( 'class' => 'test-wrap' ), 47, 'Beans Rocks!' );
+
+		// Check that the correct arguments were stored in the instance.
+		$anonomyous_action = $this->get_instance_from_wp( 'extra_args_prepend_markup', 1 );
+		$this->assertSame(
+			array(
+				'beans_open_markup',
+				array(
+					1 => 'new_extra_args',
+					2 => 'div',
+					3 => array( 'class' => 'test-wrap' ),
+					4 => 47,
+					5 => 'Beans Rocks!',
+				),
+			),
+			$anonomyous_action->callback
+		);
+
+		// Clean up.
+		remove_action( 'extra_args_prepend_markup', array( $anonomyous_action, 'callback' ), 1 );
+	}
+
+	/**
+	 * Test beans_wrap_inner_markup() should pass the extra arguments to the anonymous action for the given ID's
+	 * '_append_markup' hook.
+	 */
+	public function test_should_pass_extra_arguments_for_append_markup_hook() {
+		beans_wrap_inner_markup( 'extra_args', 'new_extra_args', 'div', array( 'class' => 'test-wrap' ), 'Beans Rocks!', 'and so does WordPress!' );
+
+		// Check that the correct arguments were stored in the instance.
+		$anonomyous_action = $this->get_instance_from_wp( 'extra_args_append_markup', 9999 );
+		$this->assertSame(
+			array(
+				'beans_close_markup',
+				array(
+					1 => 'new_extra_args',
+					2 => 'div',
+					4 => 'Beans Rocks!',
+					5 => 'and so does WordPress!',
+				),
+			),
+			$anonomyous_action->callback
+		);
+
+		// Clean up.
+		remove_action( 'extra_args_append_markup', array( $anonomyous_action, 'callback' ), 9999 );
+	}
+}

--- a/tests/phpunit/unit/api/html/beansWrapInnerMarkup.php
+++ b/tests/phpunit/unit/api/html/beansWrapInnerMarkup.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Tests for beans_wrap_inner_markup().
+ *
+ * @package Beans\Framework\Tests\Unit\API\HTML
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Unit\API\HTML;
+
+use Beans\Framework\Tests\Unit\API\HTML\Fixtures\Anonymous_Action_Stub;
+use Beans\Framework\Tests\Unit\API\HTML\Includes\HTML_Test_Case;
+use Brain\Monkey;
+
+require_once __DIR__ . '/includes/class-html-test-case.php';
+
+/**
+ * Class Tests_BeansWrapInnerMarkup
+ *
+ * @package Beans\Framework\Tests\Unit\API\HTML
+ * @group   api
+ * @group   api-html
+ */
+class Tests_BeansWrapInnerMarkup extends HTML_Test_Case {
+
+	/**
+	 * Prepares the test environment before each test.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		require_once __DIR__ . '/fixtures/class-anonymous-action-stub.php';
+	}
+
+	/**
+	 * Test beans_wrap_inner_markup() should return false when an empty tag is given.
+	 */
+	public function test_should_return_false_when_empty_tag_is_given() {
+		$this->assertFalse( beans_wrap_inner_markup( 'foo', 'new_foo', null ) );
+		$this->assertFalse( beans_wrap_inner_markup( 'bar', 'new_bar', '' ) );
+		$this->assertFalse( beans_wrap_inner_markup( 'baz', 'new_baz', false, array( 'class' => 'test-wrap' ) ) );
+	}
+
+	/**
+	 * Test beans_wrap_inner_markup() should register beans_open_markup() to the given ID's '_prepend_markup' hook.
+	 */
+	public function test_should_register_beans_open_markup_to_given_id_prepend_markup_hook() {
+		// Setup the tests.
+		$args                  = array(
+			'beans_open_markup',
+			array(
+				1 => 'new_foo',
+				2 => 'div',
+				3 => array( 'class' => 'test-wrap' ),
+			),
+		);
+		$anonymous_action_mock = new Anonymous_Action_Stub( 'foo_prepend_markup', $args, 1 );
+		Monkey\Functions\expect( '_beans_add_anonymous_action' )
+			->once()
+			->with( 'foo_prepend_markup', $args, 1 )
+			->andReturn( $anonymous_action_mock );
+
+		// Run the tests.
+		$this->assertTrue( beans_wrap_inner_markup( 'foo', 'new_foo', 'div', array( 'class' => 'test-wrap' ) ) );
+		$this->assertTrue( has_action( 'foo_prepend_markup', array( $anonymous_action_mock, 'callback' ) ) );
+
+		// Clean up.
+		remove_action( 'foo_prepend_markup', array( $anonymous_action_mock, 'callback' ), 1 );
+	}
+
+	/**
+	 * Test beans_wrap_inner_markup() should register beans_close_markup() to the given ID's '_append_markup' hook.
+	 */
+	public function test_should_register_beans_close_markup_to_given_id_append_markup_hook() {
+		// Setup the tests.
+		$args                  = array(
+			'beans_close_markup',
+			array(
+				1 => 'new_foo',
+				2 => 'div',
+			),
+		);
+		$anonymous_action_mock = new Anonymous_Action_Stub( 'foo_append_markup', $args, 9999 );
+		Monkey\Functions\expect( '_beans_add_anonymous_action' )
+			->once()
+			->with( 'foo_append_markup', $args, 9999 )
+			->andReturn( $anonymous_action_mock );
+
+		// Run the tests.
+		$this->assertTrue( beans_wrap_inner_markup( 'foo', 'new_foo', 'div', array( 'class' => 'test-wrap' ) ) );
+		$this->assertTrue( has_action( 'foo_append_markup', array( $anonymous_action_mock, 'callback' ) ) );
+
+		// Clean up.
+		remove_action( 'foo_append_markup', array( $anonymous_action_mock, 'callback' ), 9999 );
+	}
+
+	/**
+	 * Test beans_wrap_inner_markup() should not pass the given attributes to anonymous action.
+	 */
+	public function test_should_not_pass_attributes_for_append_markup_hook() {
+		// Setup the tests.
+		$args                  = array(
+			'beans_close_markup',
+			array(
+				1 => 'new_no_atts',
+				2 => 'div',
+			),
+		);
+		$anonymous_action_mock = new Anonymous_Action_Stub( 'no_atts_append_markup', $args, 9999 );
+		Monkey\Functions\expect( '_beans_add_anonymous_action' )
+			->once()
+			->with( 'no_atts_append_markup', $args, 9999 )
+			->andReturn( $anonymous_action_mock );
+
+		// Run the tests.
+		$this->assertTrue( beans_wrap_inner_markup( 'no_atts', 'new_no_atts', 'div', array( 'class' => 'test-wrap' ) ) );
+		$this->assertSame( $args, $anonymous_action_mock->callback );
+
+		// Clean up.
+		remove_action( 'no_atts_append_markup', array( $anonymous_action_mock, 'callback' ), 9999 );
+	}
+
+	/**
+	 * Test beans_wrap_inner_markup() should pass the extra arguments to the anonymous action for the given ID's '_prepend_markup' hook.
+	 */
+	public function test_should_pass_extra_arguments_for_prepend_markup_hook() {
+		// Setup the tests.
+		$args                  = array(
+			'beans_open_markup',
+			array(
+				1 => 'new_extra_args',
+				2 => 'div',
+				3 => array( 'class' => 'test-wrap' ),
+				4 => 47,
+				5 => 'Beans Rocks!',
+			),
+		);
+		$anonymous_action_mock = new Anonymous_Action_Stub( 'extra_args_prepend_markup', $args, 1 );
+		Monkey\Functions\expect( '_beans_add_anonymous_action' )
+			->once()
+			->with( 'extra_args_prepend_markup', $args, 1 )
+			->andReturn( $anonymous_action_mock );
+
+		// Run the tests.
+		$this->assertTrue( beans_wrap_inner_markup( 'extra_args', 'new_extra_args', 'div', array( 'class' => 'test-wrap' ), 47, 'Beans Rocks!' ) );
+		$this->assertSame( $args, $anonymous_action_mock->callback );
+
+		// Clean up.
+		remove_action( 'extra_args_prepend_markup', array( $anonymous_action_mock, 'callback' ), 1 );
+	}
+
+	/**
+	 * Test beans_wrap_inner_markup() should pass the extra arguments to the anonymous action for the given ID's '_append_markup' hook.
+	 */
+	public function test_should_pass_extra_arguments_for_append_markup_hook() {
+		// Setup the tests.
+		$args                  = array(
+			'beans_close_markup',
+			array(
+				1 => 'new_extra_args',
+				2 => 'div',
+				4 => 'Beans Rocks!',
+				5 => 47,
+			),
+		);
+		$anonymous_action_mock = new Anonymous_Action_Stub( 'extra_args_append_markup', $args, 9999 );
+		Monkey\Functions\expect( '_beans_add_anonymous_action' )
+			->once()
+			->with( 'extra_args_append_markup', $args, 9999 )
+			->andReturn( $anonymous_action_mock );
+
+		// Run the tests.
+		$this->assertTrue( beans_wrap_inner_markup( 'extra_args', 'new_extra_args', 'div', array( 'class' => 'test-wrap' ), 'Beans Rocks!', 47 ) );
+		$this->assertSame( $args, $anonymous_action_mock->callback );
+
+		// Clean up.
+		remove_action( 'extra_args_append_markup', array( $anonymous_action_mock, 'callback' ), 9999 );
+	}
+}


### PR DESCRIPTION
1. Added unit tests.
2. Added integration tests.
3. Bailing out if the `$tag` is empty, as there is no work to be done.
4. Improved function's documentation.