### PR TITLE
Refactored common WP stubs.

### DIFF
--- a/tests/phpunit/unit/api/fields/includes/class-fields-test-case.php
+++ b/tests/phpunit/unit/api/fields/includes/class-fields-test-case.php
@@ -153,39 +153,35 @@ abstract class Fields_Test_Case extends Test_Case {
 	 */
 	protected function setup_function_mocks() {
 
-		foreach ( array( 'esc_attr', 'esc_html', 'esc_textarea', 'esc_url', 'wp_kses_post', '__' ) as $wp_function ) {
-			Monkey\Functions\when( $wp_function )->returnArg();
-		}
-
 		foreach ( array( 'esc_attr_e', 'esc_html_e', '_e' ) as $wp_function ) {
 			Monkey\Functions\when( $wp_function )->echoArg();
 		}
 
-		Monkey\Functions\when( 'checked' )->alias( function ( $actual, $value ) {
+		Monkey\Functions\when( 'checked' )->alias( function( $actual, $value ) {
 
 			if ( $actual === $value ) {
 				echo " checked='checked'";
 			}
 		} );
 
-		Monkey\Functions\when( 'selected' )->alias( function ( $actual, $value ) {
+		Monkey\Functions\when( 'selected' )->alias( function( $actual, $value ) {
 
 			if ( $actual === $value ) {
 				echo " selected='selected'";
 			}
 		} );
 
-		Monkey\Functions\when( '_n' )->alias( function ( $single, $plural, $number ) {
+		Monkey\Functions\when( '_n' )->alias( function( $single, $plural, $number ) {
 			return $number > 1 ? $plural : $single;
 		} );
 
-		Monkey\Functions\when( 'beans_get' )->alias( function ( $needle, $haystack = false, $default = null ) {
+		Monkey\Functions\when( 'beans_get' )->alias( function( $needle, $haystack = false, $default = null ) {
 			$haystack = (array) $haystack;
 
 			return isset( $haystack[ $needle ] ) ? $haystack[ $needle ] : $default;
 		} );
 
-		Monkey\Functions\when( 'beans_esc_attributes' )->alias( function ( $attributes ) {
+		Monkey\Functions\when( 'beans_esc_attributes' )->alias( function( $attributes ) {
 			$string = '';
 
 			foreach ( (array) $attributes as $attribute => $value ) {

--- a/tests/phpunit/unit/api/fields/includes/class-fields-test-case.php
+++ b/tests/phpunit/unit/api/fields/includes/class-fields-test-case.php
@@ -50,6 +50,7 @@ abstract class Fields_Test_Case extends Test_Case {
 		) );
 
 		$this->setup_function_mocks();
+		$this->setup_common_wp_stubs();
 	}
 
 	/**
@@ -152,11 +153,6 @@ abstract class Fields_Test_Case extends Test_Case {
 	 * Set up function mocks.
 	 */
 	protected function setup_function_mocks() {
-
-		foreach ( array( 'esc_attr_e', 'esc_html_e', '_e' ) as $wp_function ) {
-			Monkey\Functions\when( $wp_function )->echoArg();
-		}
-
 		Monkey\Functions\when( 'checked' )->alias( function( $actual, $value ) {
 
 			if ( $actual === $value ) {

--- a/tests/phpunit/unit/api/html/beansAddAttributes.php
+++ b/tests/phpunit/unit/api/html/beansAddAttributes.php
@@ -24,10 +24,10 @@ require_once __DIR__ . '/includes/class-html-test-case.php';
 class Tests_BeansAddAttributes extends HTML_Test_Case {
 
 	/**
-	 * Setup dependency function mocks.
+	 * Prepares the test environment before each test.
 	 */
-	protected function setup_mocks() {
-		parent::setup_mocks();
+	protected function setup() {
+		parent::setUp();
 
 		Monkey\Functions\when( 'wp_parse_args' )->alias( function( $args ) {
 

--- a/tests/phpunit/unit/api/html/includes/class-html-test-case.php
+++ b/tests/phpunit/unit/api/html/includes/class-html-test-case.php
@@ -57,13 +57,14 @@ abstract class HTML_Test_Case extends Test_Case {
 			'api/filters/functions.php',
 		) );
 
-		$this->setup_mocks();
+		$this->setup_function_mocks();
+		$this->setup_common_wp_stubs();
 	}
 
 	/**
 	 * Setup dependency function mocks.
 	 */
-	protected function setup_mocks() {
+	protected function setup_function_mocks() {
 		Monkey\Functions\when( 'beans_esc_attributes' )->alias( array( $this, 'convert_attributes_into_html' ) );
 	}
 

--- a/tests/phpunit/unit/api/image/includes/class-image-test-case.php
+++ b/tests/phpunit/unit/api/image/includes/class-image-test-case.php
@@ -100,7 +100,7 @@ abstract class Image_Test_Case extends Test_Case {
 
 		$this->set_up_virtual_filesystem();
 
-		$this->setup_mocks();
+		$this->setup_function_mocks();
 
 		$this->images = array(
 			$this->images_dir . '/image1.jpg' => static::$fixtures_dir . '/image1.jpg',
@@ -231,7 +231,7 @@ abstract class Image_Test_Case extends Test_Case {
 	 *
 	 * @return void
 	 */
-	protected function setup_mocks() {
+	protected function setup_function_mocks() {
 		Monkey\Functions\when( 'beans_url_to_path' )->returnArg();
 		Monkey\Functions\when( 'beans_path_to_url' )->returnArg();
 

--- a/tests/phpunit/unit/api/options/includes/class-options-test-case.php
+++ b/tests/phpunit/unit/api/options/includes/class-options-test-case.php
@@ -49,6 +49,7 @@ abstract class Options_Test_Case extends Test_Case {
 		) );
 
 		$this->setup_function_mocks();
+		$this->setup_common_wp_stubs();
 	}
 
 	/**
@@ -62,10 +63,10 @@ abstract class Options_Test_Case extends Test_Case {
 	}
 
 	/**
-	 * Set up function mocks.
+	 * Setup dependency function mocks.
 	 */
 	protected function setup_function_mocks() {
-		Monkey\Functions\when( 'add_meta_box' )->alias( function ( $id, $title, $callback, $screen = null, $context = 'advanced', $priority = 'default', $callback_args = null ) {
+		Monkey\Functions\when( 'add_meta_box' )->alias( function( $id, $title, $callback, $screen = null, $context = 'advanced', $priority = 'default', $callback_args = null ) {
 			global $wp_meta_boxes;
 
 			if ( empty( $screen ) ) {
@@ -88,13 +89,5 @@ abstract class Options_Test_Case extends Test_Case {
 				),
 			);
 		} );
-
-		foreach ( array( 'esc_attr', 'esc_html', '__' ) as $wp_function ) {
-			Monkey\Functions\when( $wp_function )->returnArg();
-		}
-
-		foreach ( array( 'esc_attr_e', 'esc_html_e' ) as $wp_function ) {
-			Monkey\Functions\when( $wp_function )->echoArg();
-		}
 	}
 }

--- a/tests/phpunit/unit/class-test-case.php
+++ b/tests/phpunit/unit/class-test-case.php
@@ -47,12 +47,17 @@ abstract class Test_Case extends TestCase {
 	 * Setup the stubs for the common WordPress escaping and internationalization functions.
 	 */
 	protected function setup_common_wp_stubs() {
+		// Common escaping functions.
 		Monkey\Functions\stubs( array(
 			'esc_attr',
 			'esc_html',
 			'esc_textarea',
 			'esc_url',
 			'wp_kses_post',
+		) );
+
+		// Common internationalization functions.
+		Monkey\Functions\stubs( array(
 			'__',
 			'esc_html__',
 			'esc_html_x',

--- a/tests/phpunit/unit/class-test-case.php
+++ b/tests/phpunit/unit/class-test-case.php
@@ -27,7 +27,7 @@ abstract class Test_Case extends TestCase {
 		parent::setUp();
 		Monkey\setUp();
 
-		Functions\when( 'wp_normalize_path' )->alias( function ( $path ) {
+		Functions\when( 'wp_normalize_path' )->alias( function( $path ) {
 			$path = str_replace( '\\', '/', $path );
 			$path = preg_replace( '|(?<=.)/+|', '/', $path );
 
@@ -38,9 +38,30 @@ abstract class Test_Case extends TestCase {
 			return $path;
 		} );
 
-		Functions\when( 'wp_json_encode' )->alias( function ( $array ) {
+		Functions\when( 'wp_json_encode' )->alias( function( $array ) {
 			return json_encode( $array ); // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode -- Required as part of our mock.
 		} );
+	}
+
+	/**
+	 * Setup the stubs for the common WordPress escaping and internationalization functions.
+	 */
+	protected function setup_common_wp_stubs() {
+		Monkey\Functions\stubs( array(
+			'esc_attr',
+			'esc_html',
+			'esc_textarea',
+			'esc_url',
+			'wp_kses_post',
+			'__',
+			'esc_html__',
+			'esc_html_x',
+			'esc_attr_x',
+		) );
+
+		foreach ( array( 'esc_attr_e', 'esc_html_e', '_e' ) as $wp_function ) {
+			Monkey\Functions\when( $wp_function )->echoArg();
+		}
 	}
 
 	/**


### PR DESCRIPTION
Refactored the stubs for the common WordPress escaping and internationalization functions by moving them into the Test Case with a new `setup_common_wp_stubs` method.

This change allows tests suites to invoke `$this-setup_common_wp_stubs()` instead of redefining each of the WP functions again.

Reason: DRY.