### PR TITLE
Optimized beans_get_post_meta

### DIFF
--- a/lib/api/post-meta/functions.php
+++ b/lib/api/post-meta/functions.php
@@ -27,7 +27,7 @@ function beans_get_post_meta( $meta_key, $default = false, $post_id = false ) {
 	}
 
 	if ( ! $post_id ) {
-		$post_id = beans_get( 'post' );
+		$post_id = (int) beans_get( 'post' );
 	}
 
 	if ( ! $post_id ) {

--- a/lib/api/post-meta/functions.php
+++ b/lib/api/post-meta/functions.php
@@ -24,10 +24,10 @@ function beans_get_post_meta( $meta_key, $default = false, $post_id = '' ) {
 
 	if ( ! $post_id ) {
 		$post_id = get_the_ID();
-	}
 
-	if ( ! $post_id ) {
-		$post_id = (int) beans_get( 'post' );
+		if ( ! $post_id ) {
+			$post_id = (int) beans_get( 'post' );
+		}
 	}
 
 	if ( ! $post_id ) {

--- a/lib/api/post-meta/functions.php
+++ b/lib/api/post-meta/functions.php
@@ -23,8 +23,11 @@
 function beans_get_post_meta( $meta_key, $default = false, $post_id = false ) {
 
 	if ( ! $post_id ) {
-		$id      = get_the_ID();
-		$post_id = ! $id ? beans_get( 'post' ) : $id;
+		$post_id = get_the_ID();
+	}
+
+	if ( ! $post_id ) {
+		$post_id = beans_get( 'post' );
 	}
 
 	if ( ! $post_id ) {

--- a/lib/api/post-meta/functions.php
+++ b/lib/api/post-meta/functions.php
@@ -14,13 +14,13 @@
  *
  * @since 1.0.0
  *
- * @param string           $meta_key The post meta id searched.
- * @param mixed            $default  Optional. The default value to return of the post meta value doesn't exist.
- * @param int|string|false $post_id  Optional. Overwrite the current post id.
+ * @param string     $meta_key The post meta id searched.
+ * @param mixed      $default  Optional. The default value to return of the post meta value doesn't exist.
+ * @param int|string $post_id  Optional. Overwrite the current post id.
  *
  * @return mixed Returns the meta value, if it exists; else, the default value is returned.
  */
-function beans_get_post_meta( $meta_key, $default = false, $post_id = false ) {
+function beans_get_post_meta( $meta_key, $default = false, $post_id = '' ) {
 
 	if ( ! $post_id ) {
 		$post_id = get_the_ID();

--- a/lib/api/post-meta/functions.php
+++ b/lib/api/post-meta/functions.php
@@ -18,7 +18,7 @@
  * @param mixed            $default  Optional. The default value to return of the post meta value doesn't exist.
  * @param int|string|false $post_id  Optional. Overwrite the current post id.
  *
- * @return mixed Saved data if exist, otherwise default value set.
+ * @return mixed Returns the meta value, if it exists; else, the default value is returned.
  */
 function beans_get_post_meta( $meta_key, $default = false, $post_id = false ) {
 

--- a/tests/phpunit/unit/api/post-meta/beansGetPostMeta.php
+++ b/tests/phpunit/unit/api/post-meta/beansGetPostMeta.php
@@ -49,7 +49,10 @@ class Tests_BeansGetPostMeta extends Test_Case {
 	 * Test beans_get_post_meta() should return the default when the post meta does not exist.
 	 */
 	public function test_should_return_default_when_post_meta_does_not_exist() {
-		Monkey\Functions\expect( 'get_post_meta' )->with( 1 )->times( 3 )->andReturn( array() );
+		Monkey\Functions\expect( 'get_post_meta' )
+			->with( 1 )
+			->times( 3 )
+			->andReturn( array() );
 
 		$this->assertFalse( beans_get_post_meta( 'beans_layout', false, 1 ) );
 		$this->assertSame( '', beans_get_post_meta( 'beans_layout', '', 1 ) );
@@ -61,12 +64,21 @@ class Tests_BeansGetPostMeta extends Test_Case {
 	 */
 	public function test_should_get_post_id_when_none_is_provided() {
 		Monkey\Functions\expect( 'get_the_ID' )->once()->andReturn( 47 );
-		Monkey\Functions\expect( 'get_post_meta' )->with( 47 )->once()->andReturn( array() );
+		Monkey\Functions\expect( 'get_post_meta' )
+			->with( 47 )
+			->once()
+			->andReturn( array() );
 		$this->assertSame( 'c', beans_get_post_meta( 'beans_layout', 'c' ) );
 
 		Monkey\Functions\expect( 'get_the_ID' )->once()->andReturn( 0 );
-		Monkey\Functions\expect( 'beans_get' )->once()->with( 'post' )->andReturn( 18 );
-		Monkey\Functions\expect( 'get_post_meta' )->with( '18' )->once()->andReturn( array() );
+		Monkey\Functions\expect( 'beans_get' )
+			->once()
+			->with( 'post' )
+			->andReturn( 18 );
+		Monkey\Functions\expect( 'get_post_meta' )
+			->with( '18' )
+			->once()
+			->andReturn( array() );
 		$this->assertSame( 'c', beans_get_post_meta( 'beans_layout', 'c' ) );
 	}
 
@@ -100,7 +112,10 @@ class Tests_BeansGetPostMeta extends Test_Case {
 		$this->assertSame( 'sp_c', beans_get_post_meta( 'beans_layout' ) );
 
 		Monkey\Functions\expect( 'get_the_ID' )->once()->andReturn( 0 );
-		Monkey\Functions\expect( 'beans_get' )->once()->with( 'post' )->andReturn( 18 );
+		Monkey\Functions\expect( 'beans_get' )
+			->once()
+			->with( 'post' )
+			->andReturn( 18 );
 		Monkey\Functions\expect( 'get_post_meta' )
 			->with( '18' )
 			->once()


### PR DESCRIPTION
Optimized `beans_get_post_meta` by eliminating the double assignment when no post ID is passed to the function but it is resolved by `get_the_ID()`.  With this PR, 

1. `get_the_ID()` assigns the value directly to `$post_id`
2. and `beans_get()` only runs IF `get_the_ID()` does not return the ID.

This change speeds up the function by 0.001439ms as noted in the profiler report and saves a single bit of memory:

```
-------------------------
MICRO PROFILER REPORT:
-------------------------

PHP version:        5.6.20
Sample Size:        100,000 (per function)
Time Increments:    milliseconds, where 1 ms equals 0.001 second.

  --------------------------------   -------------   -------------   -------------
| Name                             | Result        |  Avg Time     | v1.4.0
|                                  | (ms)          |  (ms)         | (ms)
| -------------------------------- | ------------- | ------------- | -------------
| beans_get_post_meta              |    -0.001439  |      0.005120 |      0.006559
 --------------------------------   -------------   -------------   -------------

NOTES:

1. The functions were invoked/exercised 100,000 times during this micro profiler process.
2. The 'diff' column = 'time' - 'v1.4.0'.
3. The 'time' column shows the function's average execution time.
4. 'v1.4.0' shows the same micro-profiler run on Beans v1.4.0.
```