### PR TITLE
Tested beans_open_markup and beans_open_markup_e

### DIFF
--- a/lib/api/html/functions.php
+++ b/lib/api/html/functions.php
@@ -109,20 +109,16 @@ function beans_remove_output( $id ) {
  * @return string|void
  */
 function beans_open_markup( $id, $tag, $attributes = array() ) {
-	global $_temp_beans_selfclose_markup;
-
 	$args            = func_get_args();
 	$attributes_args = $args;
 
 	// Set markup tag filter id.
 	$args[0] = $id . '_markup';
 
-	if ( isset( $args[2] ) ) {
+	// If there are attributes, remove them from $args.
+	if ( $attributes ) {
 		unset( $args[2] );
 	}
-
-	// Remove function $tag argument.
-	unset( $attributes_args[1] );
 
 	// Filter the tag.
 	$tag = call_user_func_array( 'beans_apply_filters', $args );
@@ -132,23 +128,24 @@ function beans_open_markup( $id, $tag, $attributes = array() ) {
 		return;
 	}
 
-	// Remove function $tag argument.
+	global $_temp_beans_selfclose_markup;
+
+	// Remove function $tag arguments.
 	unset( $args[1] );
+	unset( $attributes_args[1] );
 
-	// Set before action hook.
+	// Set and then do the before action hook.
 	$args[0] = $id . '_before_markup';
-
-	$output = call_user_func_array( '_beans_render_action', $args );
+	$output  = call_user_func_array( '_beans_render_action', $args );
 
 	// Don't output the tag if empty, the before and after actions still run.
 	if ( $tag ) {
 		$output .= '<' . $tag . ' ' . call_user_func_array( 'beans_add_attributes', $attributes_args ) . ( _beans_is_html_dev_mode() ? ' data-markup-id="' . $id . '"' : null ) . ( $_temp_beans_selfclose_markup ? '/' : '' ) . '>';
 	}
 
-	// Set after action hook.
+	// Set and then fire the after action hook.
 	$args[0] = $id . ( $_temp_beans_selfclose_markup ? '_after_markup' : '_prepend_markup' );
-
-	$output .= call_user_func_array( '_beans_render_action', $args );
+	$output  .= call_user_func_array( '_beans_render_action', $args );
 
 	// Reset the global variable to reduce memory usage.
 	unset( $GLOBALS['_temp_beans_selfclose_markup'] );

--- a/lib/api/html/functions.php
+++ b/lib/api/html/functions.php
@@ -120,9 +120,10 @@ function beans_open_markup( $id, $tag, $attributes = array() ) {
 	// Remove function $tag argument.
 	unset( $attributes_args[1] );
 
-	// Stop here if the tag is set to false, the before and after actions won't run in this case.
+	// Filter the tag.
 	$tag = call_user_func_array( 'beans_apply_filters', $args );
 
+	// Stop here if the tag is set to null, the before and after actions won't run in this case.
 	if ( null === $tag ) {
 		return;
 	}

--- a/lib/api/html/functions.php
+++ b/lib/api/html/functions.php
@@ -77,7 +77,7 @@ function beans_remove_output( $id ) {
 }
 
 /**
- * Build the opening HTML's element markup.  This function fires 3 separate hooks:
+ * Build the opening HTML element's markup.  This function fires 3 separate hooks:
  *
  *      1. "{id}_before_markup" - which fires first before the element.
  *      2. "{$id}_prepend_markup" - which fires after the element when the element is not self-closing.
@@ -134,7 +134,7 @@ function beans_open_markup( $id, $tag, $attributes = array() ) {
 	unset( $args[1] );
 	unset( $attributes_args[1] );
 
-	// Set and then do the before action hook.
+	// Set and then fire the before action hook.
 	$args[0] = $id . '_before_markup';
 	$output  = call_user_func_array( '_beans_render_action', $args );
 
@@ -154,7 +154,7 @@ function beans_open_markup( $id, $tag, $attributes = array() ) {
 }
 
 /**
- * Echo the opening HTML's element markup.  This function is a wrapper for {@see beans_open_markup()}.  See
+ * Echo the opening HTML element's markup.  This function is a wrapper for {@see beans_open_markup()}.  See
  * {@see beans_open_markup()} for more details.
  *
  * @since 1.4.0

--- a/lib/api/html/functions.php
+++ b/lib/api/html/functions.php
@@ -77,17 +77,21 @@ function beans_remove_output( $id ) {
 }
 
 /**
- * Register open markup and attributes by ID.
+ * Build the opening HTML's element markup.  This function fires 3 separate hooks:
  *
- * The Beans HTML "markups" and "attributes" functions make it really easy to modify, replace, extend,
- * remove or hook into registered markup or attributes.
+ *      1. "{id}_before_markup" - which fires first before the element.
+ *      2. "{$id}_prepend_markup" - which fires after the element when the element is not self-closing.
+ *      3. "{$id}_after_markup" - which fires after the element when the element is self-closing.
  *
- * The "data-markup-id" is added as a HTML attribute if the development mode is enabled. This makes it very
- * easy to find the content ID when inspecting an element in a web browser.
+ * These 3 hooks along with the attributes make it really easy to modify, replace, extend, remove or hook the
+ * markup and/or attributes.
  *
- * Since this function uses {@see beans_apply_filters()}, the $id argument may contain sub-hook(s).
+ * When in development mode, the "data-markup-id" attribute is added to the element, i.e. making it
+ * easier to identify the content ID when inspecting an element in your web browser.
  *
- * Note: You can pass additional arguments to the functions that are hooked to <tt>$id</tt>.
+ * Notes:
+ *      1. Since this function uses {@see beans_apply_filters()}, the $id argument may contain sub-hook(s).
+ *      2. You can pass additional arguments to the functions that are hooked to <tt>$id</tt>.
  *
  * @since 1.0.0
  *
@@ -102,7 +106,7 @@ function beans_remove_output( $id ) {
  *                                 the attribute name (e.g. data-example). Setting it to 'null' will not
  *                                 display anything.
  *
- * @return string The output.
+ * @return string|void
  */
 function beans_open_markup( $id, $tag, $attributes = array() ) {
 	global $_temp_beans_selfclose_markup;
@@ -131,7 +135,7 @@ function beans_open_markup( $id, $tag, $attributes = array() ) {
 	// Remove function $tag argument.
 	unset( $args[1] );
 
-	// Set before action id.
+	// Set before action hook.
 	$args[0] = $id . '_before_markup';
 
 	$output = call_user_func_array( '_beans_render_action', $args );
@@ -141,29 +145,20 @@ function beans_open_markup( $id, $tag, $attributes = array() ) {
 		$output .= '<' . $tag . ' ' . call_user_func_array( 'beans_add_attributes', $attributes_args ) . ( _beans_is_html_dev_mode() ? ' data-markup-id="' . $id . '"' : null ) . ( $_temp_beans_selfclose_markup ? '/' : '' ) . '>';
 	}
 
-	// Set after action id.
+	// Set after action hook.
 	$args[0] = $id . ( $_temp_beans_selfclose_markup ? '_after_markup' : '_prepend_markup' );
 
 	$output .= call_user_func_array( '_beans_render_action', $args );
 
-	// Reset temp selfclose global to reduce memory usage.
+	// Reset the global variable to reduce memory usage.
 	unset( $GLOBALS['_temp_beans_selfclose_markup'] );
 
 	return $output;
 }
 
 /**
- * Echo open markup and attributes registered by ID.
- *
- * The Beans HTML "markups" and "attributes" functions make it really easy to modify, replace, extend,
- * remove or hook into registered markup or attributes.
- *
- * The "data-markup-id" is added as a HTML attribute if the development mode is enabled. This makes it very
- * easy to find the content ID when inspecting an element in a web browser.
- *
- * Since this function uses {@see beans_apply_filters()}, the $id argument may contain sub-hook(s).
- *
- * Note: You can pass additional arguments to the functions that are hooked to <tt>$id</tt>.
+ * Echo the opening HTML's element markup.  This function is a wrapper for {@see beans_open_markup()}.  See
+ * {@see beans_open_markup()} for more details.
  *
  * @since 1.4.0
  *

--- a/lib/api/html/functions.php
+++ b/lib/api/html/functions.php
@@ -145,7 +145,7 @@ function beans_open_markup( $id, $tag, $attributes = array() ) {
 
 	// Set and then fire the after action hook.
 	$args[0] = $id . ( $_temp_beans_selfclose_markup ? '_after_markup' : '_prepend_markup' );
-	$output  .= call_user_func_array( '_beans_render_action', $args );
+	$output .= call_user_func_array( '_beans_render_action', $args );
 
 	// Reset the global variable to reduce memory usage.
 	unset( $GLOBALS['_temp_beans_selfclose_markup'] );

--- a/tests/phpunit/integration/api/html/beansOpenMarkup.php
+++ b/tests/phpunit/integration/api/html/beansOpenMarkup.php
@@ -2,14 +2,14 @@
 /**
  * Tests for beans_open_markup().
  *
- * @package Beans\Framework\Tests\Unit\API\HTML
+ * @package Beans\Framework\Tests\Integration\API\HTML
  *
  * @since   1.5.0
  */
 
-namespace Beans\Framework\Tests\Unit\API\HTML;
+namespace Beans\Framework\Tests\Integration\API\HTML;
 
-use Beans\Framework\Tests\Unit\API\HTML\Includes\HTML_Test_Case;
+use Beans\Framework\Tests\Integration\API\HTML\Includes\HTML_Test_Case;
 use Brain\Monkey;
 
 require_once __DIR__ . '/includes/class-html-test-case.php';
@@ -17,7 +17,7 @@ require_once __DIR__ . '/includes/class-html-test-case.php';
 /**
  * Class Tests_BeansOpenMarkup
  *
- * @package Beans\Framework\Tests\Unit\API\HTML
+ * @package Beans\Framework\Tests\Integration\API\HTML
  * @group   api
  * @group   api-html
  */
@@ -27,11 +27,6 @@ class Tests_BeansOpenMarkup extends HTML_Test_Case {
 	 * Test beans_open_markup() should return null when the tag is set to null.
 	 */
 	public function test_should_return_null_when_tag_set_to_false() {
-		Monkey\Functions\expect( 'beans_apply_filters' )
-			->once()
-			->with( 'beans_archive_title_markup', null )
-			->andReturnNull();
-
 		$this->assertNull( beans_open_markup( 'beans_archive_title', null, array( 'class' => 'uk-article-title' ) ) );
 	}
 
@@ -39,14 +34,17 @@ class Tests_BeansOpenMarkup extends HTML_Test_Case {
 	 * Test beans_open_markup() should fire "{$id}_before_markup" hooks and include the content in the returned HTML.
 	 */
 	public function test_should_fire_before_markup_hooks_and_include_content_in_returned_html() {
-		Monkey\Functions\when( 'beans_add_attributes' )->justReturn( 'class="uk-article-title"' );
-		Monkey\Functions\when( '_beans_is_html_dev_mode' )->justReturn( false );
-		Monkey\Functions\expect( '_beans_render_action' )
+		Monkey\Functions\expect( '__beans_render_title_before_markup' )
 			->once()
-			->with( 'beans_archive_title_before_markup' )
-			->andReturn( '<!-- _before_markup fired -->' );
+			->with( '' )
+			->andReturnUsing( function() {
+				echo '<!-- _before_markup fired -->';
+			} );
+		add_action( 'beans_archive_title_before_markup', '__beans_render_title_before_markup' );
 
+		// Run the tests.
 		$actual = beans_open_markup( 'beans_archive_title', 'h1', array( 'class' => 'uk-article-title' ) );
+		$this->assertEquals( 1, did_action( 'beans_archive_title_before_markup' ) );
 		$this->assertStringStartsWith( '<!-- _before_markup fired -->', $actual );
 	}
 
@@ -54,14 +52,17 @@ class Tests_BeansOpenMarkup extends HTML_Test_Case {
 	 * Test beans_open_markup() should fire "{$id}_prepend_markup" hooks and include the content in the returned HTML.
 	 */
 	public function test_should_fire_prepend_markup_hooks_and_include_content_in_returned_html() {
-		Monkey\Functions\when( 'beans_add_attributes' )->justReturn( 'class="uk-article-title"' );
-		Monkey\Functions\when( '_beans_is_html_dev_mode' )->justReturn( false );
-		Monkey\Functions\expect( '_beans_render_action' )
+		Monkey\Functions\expect( '__beans_render_title_prepend_markup' )
 			->once()
-			->with( 'beans_archive_title_prepend_markup' )
-			->andReturn( '<!-- _prepend_markup fired -->' );
+			->with( '' )
+			->andReturnUsing( function() {
+				echo '<!-- _prepend_markup fired -->';
+			} );
+		add_action( 'beans_archive_title_prepend_markup', '__beans_render_title_prepend_markup' );
 
+		// Run the tests.
 		$actual = beans_open_markup( 'beans_archive_title', 'h1', array( 'class' => 'uk-article-title' ) );
+		$this->assertEquals( 1, did_action( 'beans_archive_title_prepend_markup' ) );
 		$this->assertStringEndsWith( '<!-- _prepend_markup fired -->', $actual );
 	}
 
@@ -70,17 +71,21 @@ class Tests_BeansOpenMarkup extends HTML_Test_Case {
 	 * $_temp_beans_selfclose_markup is set to true.
 	 */
 	public function test_should_fire_after_markup_hooks_when_selfclose_is_true() {
-		Monkey\Functions\when( 'beans_add_attributes' )->justReturn( 'class="uk-article-title"' );
-		Monkey\Functions\when( '_beans_is_html_dev_mode' )->justReturn( false );
-		Monkey\Functions\expect( '_beans_render_action' )
+		Monkey\Functions\expect( '__beans_render_title_after_markup' )
 			->once()
-			->with( 'beans_archive_title_after_markup' )
-			->andReturn( 'Worked!' );
+			->with( '' )
+			->andReturnUsing( function() {
+				echo '<!-- _after_markup fired -->';
+			} );
+		add_action( 'beans_archive_title_after_markup', '__beans_render_title_after_markup' );
 
 		global $_temp_beans_selfclose_markup;
 		$_temp_beans_selfclose_markup = true; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Used in function scope.
 
-		$this->assertContains( 'Worked!', beans_open_markup( 'beans_archive_title', 'h1', array( 'class' => 'uk-article-title' ) ) );
+		// Run the tests.
+		$actual = beans_open_markup( 'beans_archive_title', 'h1', array( 'class' => 'uk-article-title' ) );
+		$this->assertEquals( 1, did_action( 'beans_archive_title_after_markup' ) );
+		$this->assertStringEndsWith( '<!-- _after_markup fired -->', $actual );
 
 		// Check that the global was unset.
 		$this->assertArrayNotHasKey( '_temp_beans_selfclose_markup', $GLOBALS );
@@ -90,55 +95,45 @@ class Tests_BeansOpenMarkup extends HTML_Test_Case {
 	 * Test beans_open_markup() should return built HTML when no before or prepend hooks are registered.
 	 */
 	public function test_should_return_built_html_when_before_or_prepend_hooks_registered() {
-		Monkey\Functions\when( '_beans_render_action' )->justReturn( '' );
-		Monkey\Functions\expect( 'beans_add_attributes' )
-			->once()
-			->with( 'beans_archive_title', array( 'class' => 'uk-article-title' ) )
-			->andReturn( 'class="uk-article-title"' );
-		Monkey\Functions\expect( '_beans_is_html_dev_mode' )->once()->andReturn( false );
-
 		$actual = beans_open_markup( 'beans_archive_title', 'h1', array( 'class' => 'uk-article-title' ) );
 		$this->assertSame( '<h1 class="uk-article-title">', $actual );
+		$this->assertEquals( 0, did_action( 'beans_archive_title_before_markup' ) );
+		$this->assertEquals( 0, did_action( 'beans_archive_title_prepend_markup' ) );
+		$this->assertEquals( 0, did_action( 'beans_archive_title_after_markup' ) );
 	}
 
 	/**
 	 * Test beans_open_markup() should return built HTML with the "data-markup-id" when in development mode.
 	 */
 	public function test_should_return_built_html_with_data_markup_id_when_in_dev_mode() {
-		Monkey\Functions\when( '_beans_render_action' )->justReturn( '' );
-		Monkey\Functions\expect( 'beans_add_attributes' )
-			->once()
-			->with( 'beans_archive_title', array( 'class' => 'uk-article-title' ) )
-			->andReturn( 'class="uk-article-title"' );
-		Monkey\Functions\expect( '_beans_is_html_dev_mode' )->once()->andReturn( true );
+		add_option( 'beans_dev_mode', 1 );
 
 		$actual = beans_open_markup( 'beans_archive_title', 'h1', array( 'class' => 'uk-article-title' ) );
 		$this->assertSame( '<h1 class="uk-article-title" data-markup-id="beans_archive_title">', $actual );
 	}
 
 	/**
-	 * Test beans_open_markup() should return a built HTML element when no before or prepend hooks are registered.
+	 * Test beans_open_markup() should return a built HTML element when there are before and prepend hooks are
+	 * registered.
 	 */
 	public function test_should_return_built_html_when_before_or_prepend_hooks() {
-		Monkey\Functions\expect( 'beans_add_attributes' )
-			->once()
-			->with( 'beans_archive_title', array( 'class' => 'uk-article-title' ) )
-			->andReturn( 'class="uk-article-title"' );
-		Monkey\Functions\expect( '_beans_is_html_dev_mode' )->once()->andReturn( false );
-		Monkey\Functions\expect( '_beans_render_action' )
-			->once()
-			->with( 'beans_archive_title_before_markup' )
-			->andReturn( '<!-- _before_markup fired -->' )
-			->andAlsoExpectIt()
-			->once()
-			->with( 'beans_archive_title_prepend_markup' )
-			->andReturn( '<!-- _prepend_markup fired -->' );
+		add_action( 'beans_archive_title_before_markup', function() {
+			echo '<!-- _before_markup fired -->';
+		} );
+		add_action( 'beans_archive_title_prepend_markup', function() {
+			echo '<!-- _prepend_markup fired -->';
+		} );
 
+		// Run the tests.
 		$actual   = beans_open_markup( 'beans_archive_title', 'h1', array( 'class' => 'uk-article-title' ) );
 		$expected = <<<EOB
 <!-- _before_markup fired --><h1 class="uk-article-title"><!-- _prepend_markup fired -->
 EOB;
+
 		$this->assertSame( $expected, $actual );
+		$this->assertEquals( 1, did_action( 'beans_archive_title_before_markup' ) );
+		$this->assertEquals( 1, did_action( 'beans_archive_title_prepend_markup' ) );
+		$this->assertEquals( 0, did_action( 'beans_archive_title_after_markup' ) );
 	}
 
 	/**
@@ -154,16 +149,7 @@ EOB;
 			'itemprop' => 'image',
 		);
 
-		Monkey\Functions\when( '_beans_render_action' )->justReturn( '' );
-		Monkey\Functions\expect( 'beans_add_attributes' )
-			->twice()
-			->with( 'beans_post_image_item', $args, 'http://example.com/image.png' )
-			->andReturnUsing( function( $id, $attributes ) {
-				return $this->convert_attributes_into_html( $attributes );
-			} );
-
 		// Run it with development mode off.
-		Monkey\Functions\expect( '_beans_is_html_dev_mode' )->once()->andReturn( false );
 		global $_temp_beans_selfclose_markup;
 		$_temp_beans_selfclose_markup = true; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Used in function scope.
 
@@ -174,7 +160,7 @@ EOB;
 		$this->assertSame( $expected, $actual );
 
 		// Run it with development mode on.
-		Monkey\Functions\expect( '_beans_is_html_dev_mode' )->once()->andReturn( true );
+		add_option( 'beans_dev_mode', 1 );
 		global $_temp_beans_selfclose_markup;
 		$_temp_beans_selfclose_markup = true; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Used in function scope.
 
@@ -183,5 +169,8 @@ EOB;
 <img width="800" height="500" src="http://example.com/image.png" alt="Some image" itemprop="image" data-markup-id="beans_post_image_item"/>
 EOB;
 		$this->assertSame( $expected, $actual );
+		$this->assertEquals( 0, did_action( 'beans_post_image_item_before_markup' ) );
+		$this->assertEquals( 0, did_action( 'beans_post_image_item_prepend_markup' ) );
+		$this->assertEquals( 0, did_action( 'beans_post_image_item_after_markup' ) );
 	}
 }

--- a/tests/phpunit/integration/api/html/beansOpenMarkup.php
+++ b/tests/phpunit/integration/api/html/beansOpenMarkup.php
@@ -92,9 +92,9 @@ class Tests_BeansOpenMarkup extends HTML_Test_Case {
 	}
 
 	/**
-	 * Test beans_open_markup() should return built HTML when no before or prepend hooks are registered.
+	 * Test beans_open_markup() should return the built HTML element when before or prepend hooks are not registered.
 	 */
-	public function test_should_return_built_html_when_before_or_prepend_hooks_registered() {
+	public function test_should_return_built_html_when_before_or_prepend_hooks_not_registered() {
 		$actual = beans_open_markup( 'beans_archive_title', 'h1', array( 'class' => 'uk-article-title' ) );
 		$this->assertSame( '<h1 class="uk-article-title">', $actual );
 		$this->assertEquals( 0, did_action( 'beans_archive_title_before_markup' ) );
@@ -103,7 +103,7 @@ class Tests_BeansOpenMarkup extends HTML_Test_Case {
 	}
 
 	/**
-	 * Test beans_open_markup() should return built HTML with the "data-markup-id" when in development mode.
+	 * Test beans_open_markup() should return the built HTML element with the "data-markup-id" when in development mode.
 	 */
 	public function test_should_return_built_html_with_data_markup_id_when_in_dev_mode() {
 		add_option( 'beans_dev_mode', 1 );
@@ -113,8 +113,7 @@ class Tests_BeansOpenMarkup extends HTML_Test_Case {
 	}
 
 	/**
-	 * Test beans_open_markup() should return a built HTML element when there are before and prepend hooks are
-	 * registered.
+	 * Test beans_open_markup() should return the built HTML when before and prepend hooks are registered.
 	 */
 	public function test_should_return_built_html_when_before_or_prepend_hooks() {
 		add_action( 'beans_archive_title_before_markup', function() {

--- a/tests/phpunit/integration/api/html/beansOpenMarkup.php
+++ b/tests/phpunit/integration/api/html/beansOpenMarkup.php
@@ -173,4 +173,30 @@ EOB;
 		$this->assertEquals( 0, did_action( 'beans_post_image_item_prepend_markup' ) );
 		$this->assertEquals( 0, did_action( 'beans_post_image_item_after_markup' ) );
 	}
+
+	/**
+	 * Test beans_open_markup() should return only the output from the hooked callbacks and not the HTML element when
+	 * the tag is empty.
+	 */
+	public function test_should_return_only_hooked_callbacks_output_and_no_html_element_when_tag_is_empty() {
+		add_action( 'beans_archive_title_before_markup', function() {
+			echo '<!-- _before_markup fired -->';
+		} );
+		add_action( 'beans_archive_title_prepend_markup', function() {
+			echo '<!-- _prepend_markup fired -->';
+		} );
+
+		// Check with an empty string.
+		$actual = beans_open_markup( 'beans_archive_title', '', array( 'class' => 'uk-article-title' ) );
+		$this->assertSame( '<!-- _before_markup fired --><!-- _prepend_markup fired -->', $actual );
+
+		// Check with false.
+		$actual = beans_open_markup( 'beans_archive_title', false, array( 'class' => 'uk-article-title' ) );
+		$this->assertSame( '<!-- _before_markup fired --><!-- _prepend_markup fired -->', $actual );
+
+		// Check the hooks.
+		$this->assertEquals( 2, did_action( 'beans_archive_title_before_markup' ) );
+		$this->assertEquals( 2, did_action( 'beans_archive_title_prepend_markup' ) );
+		$this->assertEquals( 0, did_action( 'beans_archive_title_after_markup' ) );
+	}
 }

--- a/tests/phpunit/integration/api/html/beansOpenMarkupE.php
+++ b/tests/phpunit/integration/api/html/beansOpenMarkupE.php
@@ -25,16 +25,16 @@ class Tests_BeansOpenMarkupE extends HTML_Test_Case {
 	/**
 	 * Test beans_open_markup_e() should echo empty when the tag is set to null.
 	 */
-	public function test_should_echo_empty_when_tag_set_to_false() {
+	public function test_should_echo_empty_when_tag_set_to_null() {
 		ob_start();
 		beans_open_markup_e( 'beans_archive_title', null, array( 'class' => 'uk-article-title' ) );
 		$this->assertEquals( '', ob_get_clean() );
 	}
 
 	/**
-	 * Test beans_open_markup_e() should echo the HTML element only when no before or prepend hooks are registered.
+	 * Test beans_open_markup_e() should echo the HTML element only when before or prepend hooks are not registered.
 	 */
-	public function test_should_echo_html_element_when_no_hooks_are_registered() {
+	public function test_should_echo_html_element_when_hooks_not_registered() {
 		ob_start();
 		beans_open_markup_e( 'beans_archive_title', 'h1', array( 'class' => 'uk-article-title' ) );
 		$actual = ob_get_clean();

--- a/tests/phpunit/integration/api/html/beansOpenMarkupE.php
+++ b/tests/phpunit/integration/api/html/beansOpenMarkupE.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Tests for beans_open_markup_e().
+ *
+ * @package Beans\Framework\Tests\Integration\API\HTML
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Integration\API\HTML;
+
+use Beans\Framework\Tests\Integration\API\HTML\Includes\HTML_Test_Case;
+
+require_once __DIR__ . '/includes/class-html-test-case.php';
+
+/**
+ * Class Tests_BeansOpenMarkupE
+ *
+ * @package Beans\Framework\Tests\Integration\API\HTML
+ * @group   api
+ * @group   api-html
+ */
+class Tests_BeansOpenMarkupE extends HTML_Test_Case {
+
+	/**
+	 * Test beans_open_markup_e() should echo empty when the tag is set to null.
+	 */
+	public function test_should_echo_empty_when_tag_set_to_false() {
+		ob_start();
+		beans_open_markup_e( 'beans_archive_title', null, array( 'class' => 'uk-article-title' ) );
+		$this->assertEquals( '', ob_get_clean() );
+	}
+
+	/**
+	 * Test beans_open_markup_e() should echo the HTML element only when no before or prepend hooks are registered.
+	 */
+	public function test_should_echo_html_element_when_no_hooks_are_registered() {
+		ob_start();
+		beans_open_markup_e( 'beans_archive_title', 'h1', array( 'class' => 'uk-article-title' ) );
+		$actual = ob_get_clean();
+
+		$this->assertSame( '<h1 class="uk-article-title">', $actual );
+		$this->assertEquals( 0, did_action( 'beans_archive_title_before_markup' ) );
+		$this->assertEquals( 0, did_action( 'beans_archive_title_prepend_markup' ) );
+		$this->assertEquals( 0, did_action( 'beans_archive_title_after_markup' ) );
+	}
+
+	/**
+	 * Test beans_open_markup_e() should echo the HTML element with the "data-markup-id" when in development mode.
+	 */
+	public function test_should_echo_html_element_with_data_markup_id_when_in_dev_mode() {
+		add_option( 'beans_dev_mode', 1 );
+
+		ob_start();
+		beans_open_markup_e( 'beans_archive_title', 'h1', array( 'class' => 'uk-article-title' ) );
+		$this->assertSame( '<h1 class="uk-article-title" data-markup-id="beans_archive_title">', ob_get_clean() );
+	}
+
+	/**
+	 * Test beans_open_markup_e() should echo the before, element, and prepend HTML when callbacks are registered to
+	 * the "_before_markup" and "_prepend_markup" hooks.
+	 */
+	public function test_should_echo_before_element_prepend_html_when_before_or_prepend_hooks() {
+		add_action( 'beans_archive_title_before_markup', function() {
+			echo '<!-- _before_markup fired -->';
+		} );
+		add_action( 'beans_archive_title_prepend_markup', function() {
+			echo '<!-- _prepend_markup fired -->';
+		} );
+
+		ob_start();
+		beans_open_markup_e( 'beans_archive_title', 'h1', array( 'class' => 'uk-article-title' ) );
+		$actual = ob_get_clean();
+
+		$expected = <<<EOB
+<!-- _before_markup fired --><h1 class="uk-article-title"><!-- _prepend_markup fired -->
+EOB;
+
+		// Run the tests.
+		$this->assertSame( $expected, $actual );
+		$this->assertEquals( 1, did_action( 'beans_archive_title_before_markup' ) );
+		$this->assertEquals( 1, did_action( 'beans_archive_title_prepend_markup' ) );
+		$this->assertEquals( 0, did_action( 'beans_archive_title_after_markup' ) );
+	}
+}

--- a/tests/phpunit/unit/api/html/beansOpenMarkup.php
+++ b/tests/phpunit/unit/api/html/beansOpenMarkup.php
@@ -26,7 +26,7 @@ class Tests_BeansOpenMarkup extends HTML_Test_Case {
 	/**
 	 * Test beans_open_markup() should return null when the tag is set to null.
 	 */
-	public function test_should_return_null_when_tag_set_to_false() {
+	public function test_should_return_null_when_tag_set_to_null() {
 		Monkey\Functions\expect( 'beans_apply_filters' )
 			->once()
 			->with( 'beans_archive_title_markup', null )
@@ -87,9 +87,9 @@ class Tests_BeansOpenMarkup extends HTML_Test_Case {
 	}
 
 	/**
-	 * Test beans_open_markup() should return built HTML when no before or prepend hooks are registered.
+	 * Test beans_open_markup() should return the built HTML element when before or prepend hooks are not registered.
 	 */
-	public function test_should_return_built_html_when_before_or_prepend_hooks_registered() {
+	public function test_should_return_built_html_when_before_or_prepend_hooks_not_registered() {
 		Monkey\Functions\when( '_beans_render_action' )->justReturn( '' );
 		Monkey\Functions\expect( 'beans_add_attributes' )
 			->once()
@@ -102,7 +102,7 @@ class Tests_BeansOpenMarkup extends HTML_Test_Case {
 	}
 
 	/**
-	 * Test beans_open_markup() should return built HTML with the "data-markup-id" when in development mode.
+	 * Test beans_open_markup() should return the built HTML element with the "data-markup-id" when in development mode.
 	 */
 	public function test_should_return_built_html_with_data_markup_id_when_in_dev_mode() {
 		Monkey\Functions\when( '_beans_render_action' )->justReturn( '' );
@@ -117,7 +117,7 @@ class Tests_BeansOpenMarkup extends HTML_Test_Case {
 	}
 
 	/**
-	 * Test beans_open_markup() should return a built HTML element when no before or prepend hooks are registered.
+	 * Test beans_open_markup() should return a built HTML when before or prepend hooks are registered.
 	 */
 	public function test_should_return_built_html_when_before_or_prepend_hooks() {
 		Monkey\Functions\expect( 'beans_add_attributes' )

--- a/tests/phpunit/unit/api/html/beansOpenMarkup.php
+++ b/tests/phpunit/unit/api/html/beansOpenMarkup.php
@@ -184,4 +184,29 @@ EOB;
 EOB;
 		$this->assertSame( $expected, $actual );
 	}
+
+	/**
+	 * Test beans_open_markup() should return only the output from the hooked callbacks and not the HTML element when
+	 * the tag is empty.
+	 */
+	public function test_should_return_only_hooked_callbacks_output_and_no_html_element_when_tag_is_empty() {
+		Monkey\Functions\expect( 'beans_add_attributes' )->never();
+		Monkey\Functions\expect( '_beans_is_html_dev_mode' )->never();
+		Monkey\Functions\expect( '_beans_render_action' )
+			->twice()
+			->with( 'beans_archive_title_before_markup' )
+			->andReturn( '<!-- _before_markup fired -->' )
+			->andAlsoExpectIt()
+			->twice()
+			->with( 'beans_archive_title_prepend_markup' )
+			->andReturn( '<!-- _prepend_markup fired -->' );
+
+		// Check with an empty string.
+		$actual = beans_open_markup( 'beans_archive_title', '', array( 'class' => 'uk-article-title' ) );
+		$this->assertSame( '<!-- _before_markup fired --><!-- _prepend_markup fired -->', $actual );
+
+		// Check with false.
+		$actual = beans_open_markup( 'beans_archive_title', false, array( 'class' => 'uk-article-title' ) );
+		$this->assertSame( '<!-- _before_markup fired --><!-- _prepend_markup fired -->', $actual );
+	}
 }

--- a/tests/phpunit/unit/api/html/beansOpenMarkup.php
+++ b/tests/phpunit/unit/api/html/beansOpenMarkup.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Tests for beans_open_markup().
+ *
+ * @package Beans\Framework\Tests\Unit\API\HTML
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Unit\API\HTML;
+
+use Beans\Framework\Tests\Unit\API\HTML\Includes\HTML_Test_Case;
+use Brain\Monkey;
+
+require_once __DIR__ . '/includes/class-html-test-case.php';
+
+/**
+ * Class Tests_BeansOpenMarkup
+ *
+ * @package Beans\Framework\Tests\Unit\API\HTML
+ * @group   api
+ * @group   api-html
+ */
+class Tests_BeansOpenMarkup extends HTML_Test_Case {
+
+	/**
+	 * Test beans_open_markup() should return null when the tag is set to null.
+	 */
+	public function test_should_return_null_when_tag_set_to_false() {
+		Monkey\Functions\expect( 'beans_apply_filters' )
+			->once()
+			->with( 'beans_archive_title_markup', null )
+			->andReturnNull();
+
+		$this->assertNull( beans_open_markup( 'beans_archive_title', null, array( 'class' => 'uk-article-title' ) ) );
+	}
+
+	/**
+	 * Test beans_open_markup() should fire _beans_render_action() for the "_before_markup" and "_prepend_markup" hooks.
+	 */
+	public function test_should_fire_beans_render_action_for_before_and_prepend_markup_hooks() {
+		Monkey\Functions\when( 'beans_add_attributes' )->justReturn( 'class="uk-article-title"' );
+		Monkey\Functions\when( '_beans_is_html_dev_mode' )->justReturn( false );
+		Monkey\Functions\expect( '_beans_render_action' )
+			->once()
+			->with( 'beans_archive_title_before_markup' )
+			->andReturn( 'Fired "_before_markup" hooks' )
+			->andAlsoExpectIt()
+			->once()
+			->with( 'beans_archive_title_prepend_markup' )
+			->andReturn( 'Fired "_prepend_markup" hooks' );
+
+		$actual = beans_open_markup( 'beans_archive_title', 'h1', array( 'class' => 'uk-article-title' ) );
+		$this->assertContains( 'Fired "_before_markup" hooks', $actual );
+		$this->assertContains( 'Fired "_prepend_markup" hooks', $actual );
+	}
+
+	/**
+	 * Test beans_open_markup() should fire _beans_render_action() for the "_after_markup" hooks when the global
+	 * $_temp_beans_selfclose_markup is set to true.
+	 */
+	public function test_should_fire_after_markup_hooks_when_selfclose_is_true() {
+		Monkey\Functions\when( 'beans_add_attributes' )->justReturn( 'class="uk-article-title"' );
+		Monkey\Functions\when( '_beans_is_html_dev_mode' )->justReturn( false );
+		Monkey\Functions\expect( '_beans_render_action' )
+			->once()
+			->with( 'beans_archive_title_after_markup' )
+			->andReturn( 'Worked!' );
+
+		global $_temp_beans_selfclose_markup;
+		$_temp_beans_selfclose_markup = true; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Used in function scope.
+
+		$this->assertContains( 'Worked!', beans_open_markup( 'beans_archive_title', 'h1', array( 'class' => 'uk-article-title' ) ) );
+
+		// Check that the global was unset.
+		$this->assertArrayNotHasKey( '_temp_beans_selfclose_markup', $GLOBALS );
+	}
+
+	/**
+	 * Test beans_open_markup() should return built HTML when no before or prepend hooks are registered.
+	 */
+	public function test_should_return_built_html_when_before_or_prepend_hooks_registered() {
+		Monkey\Functions\when( '_beans_render_action' )->justReturn( '' );
+		Monkey\Functions\expect( 'beans_add_attributes' )
+			->once()
+			->with( 'beans_archive_title', array( 'class' => 'uk-article-title' ) )
+			->andReturn( 'class="uk-article-title"' );
+		Monkey\Functions\expect( '_beans_is_html_dev_mode' )->once()->andReturn( false );
+
+		$actual = beans_open_markup( 'beans_archive_title', 'h1', array( 'class' => 'uk-article-title' ) );
+		$this->assertSame( '<h1 class="uk-article-title">', $actual );
+	}
+
+	/**
+	 * Test beans_open_markup() should return built HTML with the "data-markup-id" when in development mode.
+	 */
+	public function test_should_return_built_html_with_data_markup_id_when_in_dev_mode() {
+		Monkey\Functions\when( '_beans_render_action' )->justReturn( '' );
+		Monkey\Functions\expect( 'beans_add_attributes' )
+			->once()
+			->with( 'beans_archive_title', array( 'class' => 'uk-article-title' ) )
+			->andReturn( 'class="uk-article-title"' );
+		Monkey\Functions\expect( '_beans_is_html_dev_mode' )->once()->andReturn( true );
+
+		$actual = beans_open_markup( 'beans_archive_title', 'h1', array( 'class' => 'uk-article-title' ) );
+		$this->assertSame( '<h1 class="uk-article-title" data-markup-id="beans_archive_title">', $actual );
+	}
+
+	/**
+	 * Test beans_open_markup() should return a built HTML element when no before or prepend hooks are registered.
+	 */
+	public function test_should_return_built_html_when_before_or_prepend_hooks() {
+		Monkey\Functions\expect( 'beans_add_attributes' )
+			->once()
+			->with( 'beans_archive_title', array( 'class' => 'uk-article-title' ) )
+			->andReturn( 'class="uk-article-title"' );
+		Monkey\Functions\expect( '_beans_is_html_dev_mode' )->once()->andReturn( false );
+		Monkey\Functions\expect( '_beans_render_action' )
+			->once()
+			->with( 'beans_archive_title_before_markup' )
+			->andReturn( '<!-- _before_markup hook fired -->' )
+			->andAlsoExpectIt()
+			->once()
+			->with( 'beans_archive_title_prepend_markup' )
+			->andReturn( '<!--_prepend_markup hook fired -->' );
+
+		$actual   = beans_open_markup( 'beans_archive_title', 'h1', array( 'class' => 'uk-article-title' ) );
+		$expected = <<<EOB
+<!-- _before_markup hook fired --><h1 class="uk-article-title"><!--_prepend_markup hook fired -->
+EOB;
+		$this->assertSame( $expected, $actual );
+	}
+
+	/**
+	 * Test beans_open_markup() should return a built self-closing HTML element when the global
+	 * $_temp_beans_selfclose_markup is set to true.
+	 */
+	public function test_should_return_built_self_closing_html_when_selfclose_markup_is_true() {
+		$args = array(
+			'width'    => 800,
+			'height'   => 500,
+			'src'      => 'http://example.com/image.png',
+			'alt'      => 'Some image',
+			'itemprop' => 'image',
+		);
+
+		Monkey\Functions\when( '_beans_render_action' )->justReturn( '' );
+		Monkey\Functions\expect( 'beans_add_attributes' )
+			->twice()
+			->with( 'beans_post_image_item', $args, 'http://example.com/image.png' )
+			->andReturnUsing( function( $id, $attributes ) {
+				return $this->convert_attributes_into_html( $attributes );
+			} );
+
+		// Run it with development mode off.
+		Monkey\Functions\expect( '_beans_is_html_dev_mode' )->once()->andReturn( false );
+		global $_temp_beans_selfclose_markup;
+		$_temp_beans_selfclose_markup = true; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Used in function scope.
+
+		$actual   = beans_open_markup( 'beans_post_image_item', 'img', $args, 'http://example.com/image.png' );
+		$expected = <<<EOB
+<img width="800" height="500" src="http://example.com/image.png" alt="Some image" itemprop="image"/>
+EOB;
+		$this->assertSame( $expected, $actual );
+
+		// Run it with development mode on.
+		Monkey\Functions\expect( '_beans_is_html_dev_mode' )->once()->andReturn( true );
+		global $_temp_beans_selfclose_markup;
+		$_temp_beans_selfclose_markup = true; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Used in function scope.
+
+		$actual   = beans_open_markup( 'beans_post_image_item', 'img', $args, 'http://example.com/image.png' );
+		$expected = <<<EOB
+<img width="800" height="500" src="http://example.com/image.png" alt="Some image" itemprop="image" data-markup-id="beans_post_image_item"/>
+EOB;
+		$this->assertSame( $expected, $actual );
+	}
+}

--- a/tests/phpunit/unit/api/html/beansOpenMarkupE.php
+++ b/tests/phpunit/unit/api/html/beansOpenMarkupE.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Tests for beans_open_markup_e().
+ *
+ * @package Beans\Framework\Tests\Unit\API\HTML
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Unit\API\HTML;
+
+use Beans\Framework\Tests\Unit\API\HTML\Includes\HTML_Test_Case;
+use Brain\Monkey;
+
+require_once __DIR__ . '/includes/class-html-test-case.php';
+
+/**
+ * Class Tests_BeansOpenMarkupE
+ *
+ * @package Beans\Framework\Tests\Unit\API\HTML
+ * @group   api
+ * @group   api-html
+ */
+class Tests_BeansOpenMarkupE extends HTML_Test_Case {
+
+	/**
+	 * Test beans_open_markup_e() should echo empty when the tag is set to null.
+	 */
+	public function test_should_echo_empty_when_tag_set_to_false() {
+		Monkey\Functions\expect( 'beans_open_markup' )
+			->once()
+			->with( 'beans_archive_title', null, array( 'class' => 'uk-article-title' ) )
+			->andReturn( null );
+
+		ob_start();
+		beans_open_markup_e( 'beans_archive_title', null, array( 'class' => 'uk-article-title' ) );
+		$this->assertEquals( '', ob_get_clean() );
+	}
+
+	/**
+	 * Test beans_open_markup_e() should echo the HTML element only when no before or prepend hooks are registered.
+	 */
+	public function test_should_echo_html_element_when_no_hooks_are_registered() {
+		Monkey\Functions\expect( 'beans_open_markup' )
+			->once()
+			->with( 'beans_archive_title', null, array( 'class' => 'uk-article-title' ) )
+			->andReturn( '<h1 class="uk-article-title">' );
+
+		// Run the tests.
+		ob_start();
+		beans_open_markup_e( 'beans_archive_title', null, array( 'class' => 'uk-article-title' ) );
+		$this->assertEquals( '<h1 class="uk-article-title">', ob_get_clean() );
+	}
+}

--- a/tests/phpunit/unit/api/html/beansOpenMarkupE.php
+++ b/tests/phpunit/unit/api/html/beansOpenMarkupE.php
@@ -26,7 +26,7 @@ class Tests_BeansOpenMarkupE extends HTML_Test_Case {
 	/**
 	 * Test beans_open_markup_e() should echo empty when the tag is set to null.
 	 */
-	public function test_should_echo_empty_when_tag_set_to_false() {
+	public function test_should_echo_empty_when_tag_set_to_null() {
 		Monkey\Functions\expect( 'beans_open_markup' )
 			->once()
 			->with( 'beans_archive_title', null, array( 'class' => 'uk-article-title' ) )
@@ -38,9 +38,9 @@ class Tests_BeansOpenMarkupE extends HTML_Test_Case {
 	}
 
 	/**
-	 * Test beans_open_markup_e() should echo the HTML element only when no before or prepend hooks are registered.
+	 * Test beans_open_markup_e() should echo the HTML element only when before or prepend hooks are not registered.
 	 */
-	public function test_should_echo_html_element_when_no_hooks_are_registered() {
+	public function test_should_echo_html_element_when_hooks_not_registered() {
 		Monkey\Functions\expect( 'beans_open_markup' )
 			->once()
 			->with( 'beans_archive_title', null, array( 'class' => 'uk-article-title' ) )


### PR DESCRIPTION
1. Added unit and integration tests.
2. Refactored `beans_open_markup`, re-arranging tasks to occur only where/when needed.
3. Improved documentation.