### PR TITLE
Optimized _beans_when_has_action_do_render()

### DIFF
--- a/lib/api/actions/functions.php
+++ b/lib/api/actions/functions.php
@@ -134,6 +134,7 @@ function beans_modify_action( $id, $hook = null, $callback = null, $priority = n
 
 	// Overwrite the modified parameters.
 	$action = array_merge( $current_action, $action );
+
 	return add_action( $action['hook'], $action['callback'], $action['priority'], $action['args'] );
 }
 
@@ -712,7 +713,8 @@ function _beans_render_action( $hook ) {
 }
 
 /**
- * Calls beans_render_function when the hook is registered.
+ * Render all hooked action callbacks by firing {@see do_action()}.  The output is captured in the buffer and then
+ * returned.
  *
  * @since  1.5.0
  * @ignore
@@ -721,7 +723,7 @@ function _beans_render_action( $hook ) {
  * @param array  $args   Array of arguments.
  * @param string $output The output to be updated.
  *
- * @return string
+ * @return string|bool
  */
 function _beans_when_has_action_do_render( array $args, &$output = '' ) {
 
@@ -732,6 +734,7 @@ function _beans_when_has_action_do_render( array $args, &$output = '' ) {
 	ob_start();
 	call_user_func_array( 'do_action', $args );
 	$output .= ob_get_clean();
+
 	return $output;
 }
 

--- a/lib/api/actions/functions.php
+++ b/lib/api/actions/functions.php
@@ -721,16 +721,18 @@ function _beans_render_action( $hook ) {
  * @param array  $args   Array of arguments.
  * @param string $output The output to be updated.
  *
- * @return string|bool
+ * @return string
  */
 function _beans_when_has_action_do_render( array $args, &$output = '' ) {
 
-	if ( has_action( $args[0] ) ) {
-		$output .= call_user_func_array( 'beans_render_function', array_merge( array( 'do_action' ), $args ) );
-		return $output;
+	if ( ! has_action( $args[0] ) ) {
+		return false;
 	}
 
-	return false;
+	ob_start();
+	call_user_func_array( 'do_action', $args );
+	$output .= ob_get_clean();
+	return $output;
 }
 
 /**


### PR DESCRIPTION
Optimized `_beans_when_has_action_do_render`, which made `_beans_render_action()`, `beans_open_markup()`, `beans_close_markup()` and other functions run faster:

- `_beans_render_action()` runs 0.002281ms faster
- `beans_open_markup()` runs 0.002855ms faster

## Details:

Invoking `beans_render_function` has a performance hit as we have to:

1. We assemble arguments using `array_merge()` to invoke `beans_render_function`.
2. get all the arguments via `func_get_args()`.
3. Prep the args using `array_slice()`.
4. Then invoke `do_action()` using `call_user_func_array()`.

This PR removes all of that overhead.  Though it's a little less DRY, as the output buffering is repeated in this function, it is more performant as it runs 0.004033ms faster.

This change impacts all functions that use `_beans_render_action()`, such as the `beans_open_markup()` and `beans_close_markup()` functions in the HTML API.  This PR improves the execution time, as `beans_open_markup()` now runs 0.002855ms faster.

## Micro-Profiler Reports

To profile the impact of this PR, I ran both `_beans_render_action` and `beans_open_markup` through the micro profiler.  Let's compare the results:

- before this PR, `_beans_render_action()` ran an average of 0.023142ms. 
- after this PR, it ran an average of 0.019109ms

### Before this PR

```
-------------------------
MICRO PROFILER REPORT:
-------------------------

PHP version:        5.6.20
Sample Size:        100,000 (per function)
Time Increments:    milliseconds, where 1 ms equals 0.001 second.

  --------------------------------   -------------   -------------   -------------
| Name                             | Result        |  Avg Time     | v1.4.0
|                                  | (ms)          |  (ms)         | (ms)
| -------------------------------- | ------------- | ------------- | -------------
| _beans_render_action             |     0.001753  |      0.023142 |      0.021389
| beans_open_markup                |     0.003826  |      0.083117 |      0.079291
 --------------------------------   -------------   -------------   -------------
```

### After this PR

Both `_beans_render_action` and `beans_open_markup` now run faster than v1.4.0 and the current version in Beans 1.5.0.

```
  --------------------------------   -------------   -------------   -------------
| Name                             | Result        |  Avg Time     | v1.4.0
|                                  | (ms)          |  (ms)         | (ms)
| -------------------------------- | ------------- | ------------- | -------------
| _beans_render_action             |    -0.002281  |      0.019109 |      0.021389
| beans_open_markup                |    -0.002855  |      0.076436 |      0.079291
```