### PR TITLE
Tests & improvements for beans_selfclose_markup and _e

### DIFF
--- a/lib/api/html/functions.php
+++ b/lib/api/html/functions.php
@@ -236,8 +236,7 @@ function beans_selfclose_markup( $id, $tag, $attributes = array() ) {
  * @return void
  */
 function beans_selfclose_markup_e( $id, $tag, $attributes = array() ) {
-	$args = func_get_args();
-	echo call_user_func_array( 'beans_selfclose_markup', $args ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Pending security audit.
+	echo call_user_func_array( 'beans_selfclose_markup', func_get_args() ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Pending security audit.
 }
 
 /**

--- a/lib/api/html/functions.php
+++ b/lib/api/html/functions.php
@@ -201,9 +201,8 @@ function beans_selfclose_markup( $id, $tag, $attributes = array() ) {
 	global $_temp_beans_selfclose_markup;
 
 	$_temp_beans_selfclose_markup = true; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Used in function scope.
-	$args                         = func_get_args();
 
-	$html = call_user_func_array( 'beans_open_markup', $args );
+	$html = call_user_func_array( 'beans_open_markup', func_get_args() );
 
 	// Reset the global variable to reduce memory usage.
 	unset( $GLOBALS['_temp_beans_selfclose_markup'] );

--- a/lib/api/html/functions.php
+++ b/lib/api/html/functions.php
@@ -142,7 +142,7 @@ function beans_open_markup( $id, $tag, $attributes = array() ) {
 
 	// Set and then fire the after action hook.
 	$args[0] = $id . ( $_temp_beans_selfclose_markup ? '_after_markup' : '_prepend_markup' );
-	$output .= call_user_func_array( '_beans_render_action', $args );
+	$output  .= call_user_func_array( '_beans_render_action', $args );
 
 	// Reset the global variable to reduce memory usage.
 	unset( $GLOBALS['_temp_beans_selfclose_markup'] );
@@ -175,7 +175,7 @@ function beans_open_markup_e( $id, $tag, $attributes = array() ) {
 }
 
 /**
- * Register self-close markup and attributes by ID.
+ * Build the self-closing HTML element's markup.
  *
  * This function is shortcut of {@see beans_open_markup()}. It should be used for self-closing HTML markup such as
  * images or inputs.
@@ -184,10 +184,12 @@ function beans_open_markup_e( $id, $tag, $attributes = array() ) {
  *
  * @since 1.0.0
  *
+ * @global bool $_temp_beans_selfclose_markup When true, indicates a self-closing element should be built.
+ *
  * @param string       $id         A unique string used as a reference. The $id argument may contain sub-hook(s).
- * @param string|bool  $tag        The HTML self-close tag.If set to False or empty, the markup HTML tag will
- *                                 be removed but the actions hook will be called. If set the Null, both
- *                                 markup HTML tag and actions hooks will be removed.
+ * @param string       $tag        The self-closing HTML tag. When set to false or an empty string, the markup HTML tag
+ *                                 will not be built, but both action hooks will fire. If set to null, the function
+ *                                 bails out, i.e. the markup HTML tag will not be built and neither action hook fires.
  * @param string|array $attributes Optional. Query string or array of attributes. The array key defines the
  *                                 attribute name and the array value defines the attribute value. Setting
  *                                 the array value to '' will display the attribute value as empty
@@ -195,7 +197,7 @@ function beans_open_markup_e( $id, $tag, $attributes = array() ) {
  *                                 the attribute name (e.g. data-example). Setting it to 'null' will not
  *                                 display anything.
  *
- * @return string The output.
+ * @return string|void
  */
 function beans_selfclose_markup( $id, $tag, $attributes = array() ) {
 	global $_temp_beans_selfclose_markup;
@@ -280,7 +282,7 @@ function beans_close_markup( $id, $tag ) {
 
 	// Set and then fire the after action hook.
 	$args[0] = $id . '_after_markup';
-	$output .= call_user_func_array( '_beans_render_action', $args );
+	$output  .= call_user_func_array( '_beans_render_action', $args );
 
 	return $output;
 }

--- a/lib/api/html/functions.php
+++ b/lib/api/html/functions.php
@@ -125,7 +125,7 @@ function beans_open_markup( $id, $tag, $attributes = array() ) {
 		return;
 	}
 
-	global $_temp_beans_selfclose_markup;
+	global $_beans_is_selfclose_markup;
 
 	// Remove the $tag argument.
 	unset( $args[1] );
@@ -137,15 +137,15 @@ function beans_open_markup( $id, $tag, $attributes = array() ) {
 
 	// Skip the opening tag when it's empty.
 	if ( $tag ) {
-		$output .= '<' . $tag . ' ' . call_user_func_array( 'beans_add_attributes', $attributes_args ) . ( _beans_is_html_dev_mode() ? ' data-markup-id="' . $id . '"' : null ) . ( $_temp_beans_selfclose_markup ? '/' : '' ) . '>';
+		$output .= '<' . $tag . ' ' . call_user_func_array( 'beans_add_attributes', $attributes_args ) . ( _beans_is_html_dev_mode() ? ' data-markup-id="' . $id . '"' : null ) . ( $_beans_is_selfclose_markup ? '/' : '' ) . '>';
 	}
 
 	// Set and then fire the after action hook.
-	$args[0] = $id . ( $_temp_beans_selfclose_markup ? '_after_markup' : '_prepend_markup' );
+	$args[0] = $id . ( $_beans_is_selfclose_markup ? '_after_markup' : '_prepend_markup' );
 	$output  .= call_user_func_array( '_beans_render_action', $args );
 
 	// Reset the global variable to reduce memory usage.
-	unset( $GLOBALS['_temp_beans_selfclose_markup'] );
+	unset( $GLOBALS['_beans_is_selfclose_markup'] );
 
 	return $output;
 }
@@ -184,7 +184,7 @@ function beans_open_markup_e( $id, $tag, $attributes = array() ) {
  *
  * @since 1.0.0
  *
- * @global bool $_temp_beans_selfclose_markup When true, indicates a self-closing element should be built.
+ * @global bool $_beans_is_selfclose_markup When true, indicates a self-closing element should be built.
  *
  * @param string       $id         A unique string used as a reference. The $id argument may contain sub-hook(s).
  * @param string       $tag        The self-closing HTML tag. When set to false or an empty string, the markup HTML tag
@@ -200,14 +200,14 @@ function beans_open_markup_e( $id, $tag, $attributes = array() ) {
  * @return string|void
  */
 function beans_selfclose_markup( $id, $tag, $attributes = array() ) {
-	global $_temp_beans_selfclose_markup;
+	global $_beans_is_selfclose_markup;
 
-	$_temp_beans_selfclose_markup = true; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Used in function scope.
+	$_beans_is_selfclose_markup = true; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Used in function scope.
 
 	$html = call_user_func_array( 'beans_open_markup', func_get_args() );
 
 	// Reset the global variable to reduce memory usage.
-	unset( $GLOBALS['_temp_beans_selfclose_markup'] );
+	unset( $GLOBALS['_beans_is_selfclose_markup'] );
 
 	return $html;
 }

--- a/lib/api/html/functions.php
+++ b/lib/api/html/functions.php
@@ -203,7 +203,12 @@ function beans_selfclose_markup( $id, $tag, $attributes = array() ) {
 	$_temp_beans_selfclose_markup = true; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Used in function scope.
 	$args                         = func_get_args();
 
-	return call_user_func_array( 'beans_open_markup', $args );
+	$html = call_user_func_array( 'beans_open_markup', $args );
+
+	// Reset the global variable to reduce memory usage.
+	unset( $GLOBALS['_temp_beans_selfclose_markup'] );
+
+	return $html;
 }
 
 /**

--- a/lib/api/html/functions.php
+++ b/lib/api/html/functions.php
@@ -184,25 +184,29 @@ function beans_open_markup_e( $id, $tag, $attributes = array() ) {
  *
  * @since 1.0.0
  *
- * @global bool $_beans_is_selfclose_markup When true, indicates a self-closing element should be built.
+ * @global bool        $_beans_is_selfclose_markup When true, indicates a self-closing element should be built.
  *
- * @param string       $id         A unique string used as a reference. The $id argument may contain sub-hook(s).
- * @param string       $tag        The self-closing HTML tag. When set to false or an empty string, the markup HTML tag
- *                                 will not be built, but both action hooks will fire. If set to null, the function
- *                                 bails out, i.e. the markup HTML tag will not be built and neither action hook fires.
- * @param string|array $attributes Optional. Query string or array of attributes. The array key defines the
- *                                 attribute name and the array value defines the attribute value. Setting
- *                                 the array value to '' will display the attribute value as empty
- *                                 (e.g. class=""). Setting it to 'false' will only display
- *                                 the attribute name (e.g. data-example). Setting it to 'null' will not
- *                                 display anything.
+ * @param string       $id                         A unique string used as a reference. The $id argument may contain
+ *                                                 sub-hook(s).
+ * @param string       $tag                        The self-closing HTML tag. When set to false or an empty string, the
+ *                                                 markup HTML tag will not be built, but both action hooks will fire.
+ *                                                 If set to null, the function bails out, i.e. the markup HTML tag
+ *                                                 will not be built and neither action hook fires.
+ * @param string|array $attributes                 Optional. Query string or array of attributes. The array key defines
+ *                                                 the attribute name and the array value defines the attribute value.
+ *                                                 Setting the array value to '' will display the attribute value as
+ *                                                 empty
+ *                                                 (e.g. class=""). Setting it to 'false' will only display
+ *                                                 the attribute name (e.g. data-example). Setting it to 'null' will
+ *                                                 not
+ *                                                 display anything.
  *
  * @return string|void
  */
 function beans_selfclose_markup( $id, $tag, $attributes = array() ) {
 	global $_beans_is_selfclose_markup;
 
-	$_beans_is_selfclose_markup = true; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Used in function scope.
+	$_beans_is_selfclose_markup = true;
 
 	$html = call_user_func_array( 'beans_open_markup', func_get_args() );
 
@@ -213,25 +217,21 @@ function beans_selfclose_markup( $id, $tag, $attributes = array() ) {
 }
 
 /**
- * Echo self-close markup and attributes registered by ID.
- *
- * This function is shortcut of {@see beans_open_markup()}. It should be used for self-closing HTML markup such as
- * images or inputs.
- *
- * Note: You can pass additional arguments to the functions that are hooked to <tt>$id</tt>.
+ * Echo the self-closing HTML element's markup. This function is a wrapper for {@see beans_selfclose_markup()}.  See
+ * {@see beans_selfclose_markup()} for more details.
  *
  * @since 1.4.0
  *
  * @param string       $id         A unique string used as a reference. The $id argument may contain sub-hook(s).
- * @param string|bool  $tag        The HTML self-close tag.If set to False or empty, the markup HTML tag will
- *                                 be removed but the actions hook will be called. If set the Null, both
- *                                 markup HTML tag and actions hooks will be removed.
+ * @param string       $tag        The self-closing HTML tag. When set to false or an empty string, the markup HTML tag
+ *                                 will not be built, but both action hooks will fire. If set to null, the function
+ *                                 bails out, i.e. the markup HTML tag will not be built and neither action hook fires.
  * @param string|array $attributes Optional. Query string or array of attributes. The array key defines the
  *                                 attribute name and the array value defines the attribute value. Setting
  *                                 the array value to '' will display the attribute value as empty
  *                                 (e.g. class=""). Setting it to 'false' will only display
- *                                 the attribute name (e.g. data-example). Setting it to 'null' will not
- *                                 display anything.
+ *                                 the attribute name (e.g. data-example). Setting it to 'null' will not display
+ *                                 anything.
  *
  * @return void
  */

--- a/tests/phpunit/integration/api/html/beansOpenMarkup.php
+++ b/tests/phpunit/integration/api/html/beansOpenMarkup.php
@@ -68,7 +68,7 @@ class Tests_BeansOpenMarkup extends HTML_Test_Case {
 
 	/**
 	 * Test beans_open_markup() should fire _beans_render_action() for the "_after_markup" hooks when the global
-	 * $_temp_beans_selfclose_markup is set to true.
+	 * $_beans_is_selfclose_markup is set to true.
 	 */
 	public function test_should_fire_after_markup_hooks_when_selfclose_is_true() {
 		Monkey\Functions\expect( '__beans_render_title_after_markup' )
@@ -79,8 +79,8 @@ class Tests_BeansOpenMarkup extends HTML_Test_Case {
 			} );
 		add_action( 'beans_archive_title_after_markup', '__beans_render_title_after_markup' );
 
-		global $_temp_beans_selfclose_markup;
-		$_temp_beans_selfclose_markup = true; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Used in function scope.
+		global $_beans_is_selfclose_markup;
+		$_beans_is_selfclose_markup = true; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Used in function scope.
 
 		// Run the tests.
 		$actual = beans_open_markup( 'beans_archive_title', 'h1', array( 'class' => 'uk-article-title' ) );
@@ -88,7 +88,7 @@ class Tests_BeansOpenMarkup extends HTML_Test_Case {
 		$this->assertStringEndsWith( '<!-- _after_markup fired -->', $actual );
 
 		// Check that the global was unset.
-		$this->assertArrayNotHasKey( '_temp_beans_selfclose_markup', $GLOBALS );
+		$this->assertArrayNotHasKey( '_beans_is_selfclose_markup', $GLOBALS );
 	}
 
 	/**
@@ -137,7 +137,7 @@ EOB;
 
 	/**
 	 * Test beans_open_markup() should return a built self-closing HTML element when the global
-	 * $_temp_beans_selfclose_markup is set to true.
+	 * $_beans_is_selfclose_markup is set to true.
 	 */
 	public function test_should_return_built_self_closing_html_when_selfclose_markup_is_true() {
 		$args = array(
@@ -149,8 +149,8 @@ EOB;
 		);
 
 		// Run it with development mode off.
-		global $_temp_beans_selfclose_markup;
-		$_temp_beans_selfclose_markup = true; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Used in function scope.
+		global $_beans_is_selfclose_markup;
+		$_beans_is_selfclose_markup = true; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Used in function scope.
 
 		$actual   = beans_open_markup( 'beans_post_image_item', 'img', $args, 'http://example.com/image.png' );
 		$expected = <<<EOB
@@ -160,8 +160,8 @@ EOB;
 
 		// Run it with development mode on.
 		add_option( 'beans_dev_mode', 1 );
-		global $_temp_beans_selfclose_markup;
-		$_temp_beans_selfclose_markup = true; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Used in function scope.
+		global $_beans_is_selfclose_markup;
+		$_beans_is_selfclose_markup = true; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Used in function scope.
 
 		$actual   = beans_open_markup( 'beans_post_image_item', 'img', $args, 'http://example.com/image.png' );
 		$expected = <<<EOB

--- a/tests/phpunit/integration/api/html/beansOpenMarkup.php
+++ b/tests/phpunit/integration/api/html/beansOpenMarkup.php
@@ -80,7 +80,7 @@ class Tests_BeansOpenMarkup extends HTML_Test_Case {
 		add_action( 'beans_archive_title_after_markup', '__beans_render_title_after_markup' );
 
 		global $_beans_is_selfclose_markup;
-		$_beans_is_selfclose_markup = true; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Used in function scope.
+		$_beans_is_selfclose_markup = true;
 
 		// Run the tests.
 		$actual = beans_open_markup( 'beans_archive_title', 'h1', array( 'class' => 'uk-article-title' ) );
@@ -150,7 +150,7 @@ EOB;
 
 		// Run it with development mode off.
 		global $_beans_is_selfclose_markup;
-		$_beans_is_selfclose_markup = true; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Used in function scope.
+		$_beans_is_selfclose_markup = true;
 
 		$actual   = beans_open_markup( 'beans_post_image_item', 'img', $args, 'http://example.com/image.png' );
 		$expected = <<<EOB
@@ -161,7 +161,7 @@ EOB;
 		// Run it with development mode on.
 		add_option( 'beans_dev_mode', 1 );
 		global $_beans_is_selfclose_markup;
-		$_beans_is_selfclose_markup = true; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Used in function scope.
+		$_beans_is_selfclose_markup = true;
 
 		$actual   = beans_open_markup( 'beans_post_image_item', 'img', $args, 'http://example.com/image.png' );
 		$expected = <<<EOB

--- a/tests/phpunit/integration/api/html/beansSelfcloseMarkup.php
+++ b/tests/phpunit/integration/api/html/beansSelfcloseMarkup.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Tests for beans_selfclose_markup().
+ *
+ * @package Beans\Framework\Tests\Integration\API\HTML
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Integration\API\HTML;
+
+use Beans\Framework\Tests\Integration\API\HTML\Includes\HTML_Test_Case;
+use Brain\Monkey;
+
+require_once __DIR__ . '/includes/class-html-test-case.php';
+
+/**
+ * Class Tests_BeansSelfcloseMarkup
+ *
+ * @package Beans\Framework\Tests\Integration\API\HTML
+ * @group   api
+ * @group   api-html
+ */
+class Tests_BeansSelfcloseMarkup extends HTML_Test_Case {
+
+	/**
+	 * Test beans_selfclose_markup() should unset the temporary global when the tag is null.
+	 */
+	public function test_should_unset_temporary_global_when_tag_is_null() {
+
+		foreach ( static::$test_attachments as $attachment ) {
+			// Check before we start.
+			$this->assertArrayNotHasKey( '_temp_beans_selfclose_markup', $GLOBALS );
+
+			beans_selfclose_markup( $attachment['id'], null, $attachment['attributes'], $attachment['attachment'] );
+
+			// Check after we run the function.
+			$this->assertArrayNotHasKey( '_temp_beans_selfclose_markup', $GLOBALS );
+		}
+	}
+
+	/**
+	 * Test beans_selfclose_markup() should return null when the tag is set to null.
+	 */
+	public function test_should_return_null_when_tag_set_to_null() {
+
+		foreach ( static::$test_attachments as $attachment ) {
+			$this->assertNull( beans_selfclose_markup( $attachment['id'], null, $attachment['attributes'], $attachment['attachment'] ) );
+		}
+	}
+
+	/**
+	 * Test beans_selfclose_markup() should return the built HTML self-closing element.
+	 */
+	public function test_should_return_built_html_self_closing_element() {
+		// Check the first attachment.
+		$attachment = current( static::$test_attachments );
+		$expected   = <<<EOB
+<source media="(max-width: 200px)" srcset="https://example.com/small-image.png"/>
+EOB;
+		$this->assertSame( $expected, beans_selfclose_markup( $attachment['id'], $attachment['tag'], $attachment['attributes'], $attachment['attachment'] ) );
+
+		// Check the next one.
+		$attachment = next( static::$test_attachments );
+		$expected   = <<<EOB
+<img width="1200" height="600" src="https://example.com/image.png" alt="A background image." itemprop="image"/>
+EOB;
+		$this->assertSame( $expected, beans_selfclose_markup( $attachment['id'], $attachment['tag'], $attachment['attributes'], $attachment['attachment'] ) );
+	}
+}

--- a/tests/phpunit/integration/api/html/beansSelfcloseMarkup.php
+++ b/tests/phpunit/integration/api/html/beansSelfcloseMarkup.php
@@ -30,12 +30,12 @@ class Tests_BeansSelfcloseMarkup extends HTML_Test_Case {
 
 		foreach ( static::$test_attachments as $attachment ) {
 			// Check before we start.
-			$this->assertArrayNotHasKey( '_temp_beans_selfclose_markup', $GLOBALS );
+			$this->assertArrayNotHasKey( '_beans_is_selfclose_markup', $GLOBALS );
 
 			beans_selfclose_markup( $attachment['id'], null, $attachment['attributes'], $attachment['attachment'] );
 
 			// Check after we run the function.
-			$this->assertArrayNotHasKey( '_temp_beans_selfclose_markup', $GLOBALS );
+			$this->assertArrayNotHasKey( '_beans_is_selfclose_markup', $GLOBALS );
 		}
 	}
 

--- a/tests/phpunit/integration/api/html/beansSelfcloseMarkupE.php
+++ b/tests/phpunit/integration/api/html/beansSelfcloseMarkupE.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Tests for beans_selfclose_markup_e().
+ *
+ * @package Beans\Framework\Tests\Integration\API\HTML
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Integration\API\HTML;
+
+use Beans\Framework\Tests\Integration\API\HTML\Includes\HTML_Test_Case;
+use Brain\Monkey;
+
+require_once __DIR__ . '/includes/class-html-test-case.php';
+
+/**
+ * Class Tests_BeansSelfcloseMarkupE
+ *
+ * @package Beans\Framework\Tests\Integration\API\HTML
+ * @group   api
+ * @group   api-html
+ */
+class Tests_BeansSelfcloseMarkupE extends HTML_Test_Case {
+
+	/**
+	 * Test beans_selfclose_markup_e() should echo an empty string when the tag is set to null.
+	 */
+	public function test_should_return_null_when_tag_set_to_null() {
+
+		foreach ( static::$test_attachments as $attachment ) {
+			ob_start();
+			beans_selfclose_markup_e( $attachment['id'], null, $attachment['attributes'], $attachment['attachment'] );
+			$this->assertSame( '', ob_get_clean() );
+		}
+	}
+
+	/**
+	 * Test beans_selfclose_markup_e() should echo the built HTML self-closing element.
+	 */
+	public function test_should_return_built_html_self_closing_element() {
+		// Check the first attachment.
+		$attachment = current( static::$test_attachments );
+		$expected   = <<<EOB
+<source media="(max-width: 200px)" srcset="https://example.com/small-image.png"/>
+EOB;
+		ob_start();
+		beans_selfclose_markup_e( $attachment['id'], $attachment['tag'], $attachment['attributes'], $attachment['attachment'] );
+		$this->assertSame( $expected, ob_get_clean() );
+
+		// Check the next one.
+		$attachment = next( static::$test_attachments );
+		$expected   = <<<EOB
+<img width="1200" height="600" src="https://example.com/image.png" alt="A background image." itemprop="image"/>
+EOB;
+		ob_start();
+		beans_selfclose_markup_e( $attachment['id'], $attachment['tag'], $attachment['attributes'], $attachment['attachment'] );
+		$this->assertSame( $expected, ob_get_clean() );
+	}
+}

--- a/tests/phpunit/integration/api/html/fixtures/test-attachment.php
+++ b/tests/phpunit/integration/api/html/fixtures/test-attachment.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Array of test attachment HTML markup and attributes.
+ *
+ * @package Beans\Framework\Tests\Integration\API\HTML\Fixtures
+ *
+ * @since   1.5.0
+ */
+
+return array(
+	array(
+		'id'         => 'beans_post_image_small_item',
+		'tag'        => 'source',
+		'attributes' => array(
+			'media'  => '(max-width: 200px)',
+			'srcset' => 'https://example.com/small-image.png',
+		),
+		'attachment' => (object) array(
+			'id'          => 47,
+			'src'         => 'https://example.com/small-image.png',
+			'width'       => 200,
+			'height'      => 200,
+			'alt'         => 'Small image',
+			'title'       => 'This is a post title.',
+			'caption'     => 'This is the caption.',
+			'description' => 'This is the description.',
+		),
+	),
+	array(
+		'id'         => 'beans_post_image_item',
+		'tag'        => 'img',
+		'attributes' => array(
+			'width'  => 1200,
+			'height' => 600,
+			'src'         => 'https://example.com/image.png',
+			'alt'         => 'A background image.',
+			'itemprop' => 'image',
+		),
+		'attachment' => (object) array(
+			'id'          => 1047,
+			'src'         => 'https://example.com/image.png',
+			'width'       => 1200,
+			'height'      => 600,
+			'alt'         => 'A background image.',
+			'title'       => 'This is a post title.',
+			'caption'     => 'This is the caption.',
+			'description' => 'This is the description.',
+		),
+	),
+);

--- a/tests/phpunit/integration/api/html/includes/class-html-test-case.php
+++ b/tests/phpunit/integration/api/html/includes/class-html-test-case.php
@@ -33,15 +33,35 @@ abstract class HTML_Test_Case extends WP_UnitTestCase {
 	protected static $test_attributes;
 
 	/**
+	 * Array of attachments to test.
+	 *
+	 * @var array
+	 */
+	protected static $test_attachments;
+
+	/**
 	 * Setup the test before we run the test setups.
 	 */
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
 
-		static::$test_markup     = require dirname( __DIR__ ) . DIRECTORY_SEPARATOR . 'fixtures/test-markup.php';
-		static::$test_attributes = array_filter( static::$test_markup, function( $markup ) {
+		static::$test_markup      = require dirname( __DIR__ ) . DIRECTORY_SEPARATOR . 'fixtures/test-markup.php';
+		static::$test_attributes  = array_filter( static::$test_markup, function( $markup ) {
 			return isset( $markup['attributes'] );
 		} );
+		static::$test_attachments = require dirname( __DIR__ ) . DIRECTORY_SEPARATOR . 'fixtures/test-attachment.php';
+	}
+
+	/**
+	 * Prepares the test environment before each test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		// Reset the test fixtures.
+		reset( static::$test_markup );
+		reset( static::$test_attributes );
+		reset( static::$test_attachments );
 	}
 
 	/**

--- a/tests/phpunit/unit/api/html/beansOpenMarkup.php
+++ b/tests/phpunit/unit/api/html/beansOpenMarkup.php
@@ -67,7 +67,7 @@ class Tests_BeansOpenMarkup extends HTML_Test_Case {
 
 	/**
 	 * Test beans_open_markup() should fire _beans_render_action() for the "_after_markup" hooks when the global
-	 * $_temp_beans_selfclose_markup is set to true.
+	 * $_beans_is_selfclose_markup is set to true.
 	 */
 	public function test_should_fire_after_markup_hooks_when_selfclose_is_true() {
 		Monkey\Functions\when( 'beans_add_attributes' )->justReturn( 'class="uk-article-title"' );
@@ -77,13 +77,13 @@ class Tests_BeansOpenMarkup extends HTML_Test_Case {
 			->with( 'beans_archive_title_after_markup' )
 			->andReturn( 'Worked!' );
 
-		global $_temp_beans_selfclose_markup;
-		$_temp_beans_selfclose_markup = true; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Used in function scope.
+		global $_beans_is_selfclose_markup;
+		$_beans_is_selfclose_markup = true; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Used in function scope.
 
 		$this->assertContains( 'Worked!', beans_open_markup( 'beans_archive_title', 'h1', array( 'class' => 'uk-article-title' ) ) );
 
 		// Check that the global was unset.
-		$this->assertArrayNotHasKey( '_temp_beans_selfclose_markup', $GLOBALS );
+		$this->assertArrayNotHasKey( '_beans_is_selfclose_markup', $GLOBALS );
 	}
 
 	/**
@@ -143,7 +143,7 @@ EOB;
 
 	/**
 	 * Test beans_open_markup() should return a built self-closing HTML element when the global
-	 * $_temp_beans_selfclose_markup is set to true.
+	 * $_beans_is_selfclose_markup is set to true.
 	 */
 	public function test_should_return_built_self_closing_html_when_selfclose_markup_is_true() {
 		$args = array(
@@ -164,8 +164,8 @@ EOB;
 
 		// Run it with development mode off.
 		Monkey\Functions\expect( '_beans_is_html_dev_mode' )->once()->andReturn( false );
-		global $_temp_beans_selfclose_markup;
-		$_temp_beans_selfclose_markup = true; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Used in function scope.
+		global $_beans_is_selfclose_markup;
+		$_beans_is_selfclose_markup = true; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Used in function scope.
 
 		$actual   = beans_open_markup( 'beans_post_image_item', 'img', $args, 'http://example.com/image.png' );
 		$expected = <<<EOB
@@ -175,8 +175,8 @@ EOB;
 
 		// Run it with development mode on.
 		Monkey\Functions\expect( '_beans_is_html_dev_mode' )->once()->andReturn( true );
-		global $_temp_beans_selfclose_markup;
-		$_temp_beans_selfclose_markup = true; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Used in function scope.
+		global $_beans_is_selfclose_markup;
+		$_beans_is_selfclose_markup = true; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Used in function scope.
 
 		$actual   = beans_open_markup( 'beans_post_image_item', 'img', $args, 'http://example.com/image.png' );
 		$expected = <<<EOB

--- a/tests/phpunit/unit/api/html/beansOpenMarkup.php
+++ b/tests/phpunit/unit/api/html/beansOpenMarkup.php
@@ -78,7 +78,7 @@ class Tests_BeansOpenMarkup extends HTML_Test_Case {
 			->andReturn( 'Worked!' );
 
 		global $_beans_is_selfclose_markup;
-		$_beans_is_selfclose_markup = true; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Used in function scope.
+		$_beans_is_selfclose_markup = true;
 
 		$this->assertContains( 'Worked!', beans_open_markup( 'beans_archive_title', 'h1', array( 'class' => 'uk-article-title' ) ) );
 
@@ -165,7 +165,7 @@ EOB;
 		// Run it with development mode off.
 		Monkey\Functions\expect( '_beans_is_html_dev_mode' )->once()->andReturn( false );
 		global $_beans_is_selfclose_markup;
-		$_beans_is_selfclose_markup = true; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Used in function scope.
+		$_beans_is_selfclose_markup = true;
 
 		$actual   = beans_open_markup( 'beans_post_image_item', 'img', $args, 'http://example.com/image.png' );
 		$expected = <<<EOB
@@ -176,7 +176,7 @@ EOB;
 		// Run it with development mode on.
 		Monkey\Functions\expect( '_beans_is_html_dev_mode' )->once()->andReturn( true );
 		global $_beans_is_selfclose_markup;
-		$_beans_is_selfclose_markup = true; // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Used in function scope.
+		$_beans_is_selfclose_markup = true;
 
 		$actual   = beans_open_markup( 'beans_post_image_item', 'img', $args, 'http://example.com/image.png' );
 		$expected = <<<EOB

--- a/tests/phpunit/unit/api/html/beansSelfcloseMarkup.php
+++ b/tests/phpunit/unit/api/html/beansSelfcloseMarkup.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Tests for beans_selfclose_markup().
+ *
+ * @package Beans\Framework\Tests\Unit\API\HTML
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Unit\API\HTML;
+
+use Beans\Framework\Tests\Unit\API\HTML\Includes\HTML_Test_Case;
+use Brain\Monkey;
+
+require_once __DIR__ . '/includes/class-html-test-case.php';
+
+/**
+ * Class Tests_BeansSelfcloseMarkup
+ *
+ * @package Beans\Framework\Tests\Unit\API\HTML
+ * @group   api
+ * @group   api-html
+ */
+class Tests_BeansSelfcloseMarkup extends HTML_Test_Case {
+
+	/**
+	 * Test beans_selfclose_markup() should unset the temporary global when the tag is null.
+	 */
+	public function test_should_unset_temporary_global_when_tag_is_null() {
+		Monkey\Functions\when( 'beans_open_markup' )->justReturn();
+
+		foreach ( static::$test_attachments as $attachment ) {
+			// Check before we start.
+			$this->assertArrayNotHasKey( '_temp_beans_selfclose_markup', $GLOBALS );
+
+			beans_selfclose_markup( $attachment['id'], null, $attachment['attributes'], $attachment['attachment'] );
+
+			// Check after we run the function.
+			$this->assertArrayNotHasKey( '_temp_beans_selfclose_markup', $GLOBALS );
+		}
+	}
+
+	/**
+	 * Test beans_selfclose_markup() should invoke beans_open_markup().
+	 */
+	public function test_should_invoke_beans_open_markup() {
+
+		foreach ( static::$test_attachments as $attachment ) {
+			Monkey\Functions\expect( 'beans_open_markup' )
+				->once()
+				->with( $attachment['id'], $attachment['tag'], $attachment['attributes'], $attachment['attachment'] )
+				->andReturnNull();
+
+			beans_selfclose_markup( $attachment['id'], $attachment['tag'], $attachment['attributes'], $attachment['attachment'] );
+		}
+
+		// The assertions are above. This assertion is a placeholder, as PHPUnit requires a specific assert to run.
+		$this->assertTrue( true );
+	}
+}

--- a/tests/phpunit/unit/api/html/beansSelfcloseMarkup.php
+++ b/tests/phpunit/unit/api/html/beansSelfcloseMarkup.php
@@ -31,12 +31,12 @@ class Tests_BeansSelfcloseMarkup extends HTML_Test_Case {
 
 		foreach ( static::$test_attachments as $attachment ) {
 			// Check before we start.
-			$this->assertArrayNotHasKey( '_temp_beans_selfclose_markup', $GLOBALS );
+			$this->assertArrayNotHasKey( '_beans_is_selfclose_markup', $GLOBALS );
 
 			beans_selfclose_markup( $attachment['id'], null, $attachment['attributes'], $attachment['attachment'] );
 
 			// Check after we run the function.
-			$this->assertArrayNotHasKey( '_temp_beans_selfclose_markup', $GLOBALS );
+			$this->assertArrayNotHasKey( '_beans_is_selfclose_markup', $GLOBALS );
 		}
 	}
 

--- a/tests/phpunit/unit/api/html/beansSelfcloseMarkupE.php
+++ b/tests/phpunit/unit/api/html/beansSelfcloseMarkupE.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Tests for beans_selfclose_markup_e().
+ *
+ * @package Beans\Framework\Tests\Unit\API\HTML
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Unit\API\HTML;
+
+use Beans\Framework\Tests\Unit\API\HTML\Includes\HTML_Test_Case;
+use Brain\Monkey;
+
+require_once __DIR__ . '/includes/class-html-test-case.php';
+
+/**
+ * Class Tests_BeansSelfcloseMarkupE
+ *
+ * @package Beans\Framework\Tests\Unit\API\HTML
+ * @group   api
+ * @group   api-html
+ */
+class Tests_BeansSelfcloseMarkupE extends HTML_Test_Case {
+
+	/**
+	 * Test beans_selfclose_markup_e() should invoke beans_selfclose_markup().
+	 */
+	public function test_should_invoke_beans_open_markup() {
+
+		foreach ( static::$test_attachments as $attachment ) {
+			Monkey\Functions\expect( 'beans_selfclose_markup' )
+				->once()
+				->with( $attachment['id'], $attachment['tag'], $attachment['attributes'], $attachment['attachment'] )
+				->andReturnNull();
+
+			ob_start();
+			beans_selfclose_markup_e( $attachment['id'], $attachment['tag'], $attachment['attributes'], $attachment['attachment'] );
+			ob_get_clean();
+		}
+
+		// The assertions are above. This assertion is a placeholder, as PHPUnit requires a specific assert to run.
+		$this->assertTrue( true );
+	}
+}

--- a/tests/phpunit/unit/api/html/fixtures/test-attachment.php
+++ b/tests/phpunit/unit/api/html/fixtures/test-attachment.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Array of test attachment HTML markup and attributes.
+ *
+ * @package Beans\Framework\Tests\Unit\API\HTML\Fixtures
+ *
+ * @since   1.5.0
+ */
+
+return array(
+	array(
+		'id'         => 'beans_post_image_small_item',
+		'tag'        => 'source',
+		'attributes' => array(
+			'media'  => '(max-width: 200px)',
+			'srcset' => 'https://example.com/small-image.png',
+		),
+		'attachment' => (object) array(
+			'id'          => 47,
+			'src'         => 'https://example.com/small-image.png',
+			'width'       => 200,
+			'height'      => 200,
+			'alt'         => 'Small image',
+			'title'       => 'This is a post title.',
+			'caption'     => 'This is the caption.',
+			'description' => 'This is the description.',
+		),
+	),
+	array(
+		'id'         => 'beans_post_image_item',
+		'tag'        => 'img',
+		'attributes' => array(
+			'width'  => 1200,
+			'height' => 600,
+			'src'         => 'https://example.com/image.png',
+			'alt'         => 'A background image.',
+			'itemprop' => 'image',
+		),
+		'attachment' => (object) array(
+			'id'          => 1047,
+			'src'         => 'https://example.com/image.png',
+			'width'       => 1200,
+			'height'      => 600,
+			'alt'         => 'A background image.',
+			'title'       => 'This is a post title.',
+			'caption'     => 'This is the caption.',
+			'description' => 'This is the description.',
+		),
+	),
+);

--- a/tests/phpunit/unit/api/html/includes/class-html-test-case.php
+++ b/tests/phpunit/unit/api/html/includes/class-html-test-case.php
@@ -34,6 +34,13 @@ abstract class HTML_Test_Case extends Test_Case {
 	protected static $test_attributes;
 
 	/**
+	 * Array of attachments to test.
+	 *
+	 * @var array
+	 */
+	protected static $test_attachments;
+
+	/**
 	 * Setup the test before we run the test setups.
 	 */
 	public static function setUpBeforeClass() {
@@ -43,6 +50,7 @@ abstract class HTML_Test_Case extends Test_Case {
 		static::$test_attributes = array_filter( static::$test_markup, function( $markup ) {
 			return isset( $markup['attributes'] );
 		} );
+		static::$test_attachments = require dirname( __DIR__ ) . DIRECTORY_SEPARATOR . 'fixtures/test-attachment.php';
 	}
 
 	/**
@@ -59,6 +67,11 @@ abstract class HTML_Test_Case extends Test_Case {
 
 		$this->setup_function_mocks();
 		$this->setup_common_wp_stubs();
+
+		// Reset the test fixtures.
+		reset( static::$test_markup );
+		reset( static::$test_attributes );
+		reset( static::$test_attachments );
 	}
 
 	/**


### PR DESCRIPTION
Functions impacted: `beans_selfclose_markup` and `beans_selfclose_markup_e`.

1. Added integration and unit tests.
2. Fixed #192.
3. Improved documentation.
4. Removed unnecessary assignments for a slight reduction in memory and execution time.