### PR TITLE
Escape HTML API

### DIFF
--- a/lib/api/html/functions.php
+++ b/lib/api/html/functions.php
@@ -58,7 +58,7 @@ function beans_output( $id, $output ) {
  */
 function beans_output_e( $id, $output ) {
 	$args = func_get_args();
-	echo call_user_func_array( 'beans_output', $args ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Pending security audit.
+	echo call_user_func_array( 'beans_output', $args ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Escaped in beans_output.
 }
 
 /**

--- a/lib/api/html/functions.php
+++ b/lib/api/html/functions.php
@@ -133,7 +133,7 @@ function beans_open_markup( $id, $tag, $attributes = array() ) {
 
 	// Build the opening tag when tag is available.
 	if ( $tag ) {
-		$output .= '<' . $tag . ' ' . call_user_func_array( 'beans_add_attributes', $attributes_args ) . ( _beans_is_html_dev_mode() ? ' data-markup-id="' . $id . '"' : null ) . ( $_beans_is_selfclose_markup ? '/' : '' ) . '>';
+		$output .= '<' . esc_attr( $tag ) . ' ' . call_user_func_array( 'beans_add_attributes', $attributes_args ) . ( _beans_is_html_dev_mode() ? ' data-markup-id="' . esc_attr( $id ) . '"' : null ) . ( $_beans_is_selfclose_markup ? '/' : '' ) . '>';
 	}
 
 	// Set and then fire the after action hook.
@@ -163,7 +163,7 @@ function beans_open_markup( $id, $tag, $attributes = array() ) {
  */
 function beans_open_markup_e( $id, $tag, $attributes = array() ) {
 	$args = func_get_args();
-	echo call_user_func_array( 'beans_open_markup', $args ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Pending security audit.
+	echo call_user_func_array( 'beans_open_markup', $args ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Escaped in beans_open_markup().
 }
 
 /**
@@ -217,7 +217,7 @@ function beans_selfclose_markup( $id, $tag, $attributes = array() ) {
  * @return void
  */
 function beans_selfclose_markup_e( $id, $tag, $attributes = array() ) {
-	echo call_user_func_array( 'beans_selfclose_markup', func_get_args() ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Pending security audit.
+	echo call_user_func_array( 'beans_selfclose_markup', func_get_args() ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Escaped in beans_open_markup().
 }
 
 /**

--- a/lib/api/html/functions.php
+++ b/lib/api/html/functions.php
@@ -257,7 +257,7 @@ function beans_close_markup( $id, $tag ) {
 
 	// Build the closing tag when tag is available.
 	if ( $tag ) {
-		$output .= '</' . $tag . '>';
+		$output .= '</' . esc_attr( $tag ) . '>';
 	}
 
 	// Set and then fire the after action hook.
@@ -282,7 +282,7 @@ function beans_close_markup( $id, $tag ) {
  */
 function beans_close_markup_e( $id, $tag ) {
 	$args = func_get_args();
-	echo call_user_func_array( 'beans_close_markup', $args ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Pending security audit.
+	echo call_user_func_array( 'beans_close_markup', $args ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Escaped in beans_close_markup().
 }
 
 /**

--- a/lib/api/html/functions.php
+++ b/lib/api/html/functions.php
@@ -39,7 +39,7 @@ function beans_output( $id, $output ) {
 	}
 
 	if ( _beans_is_html_dev_mode() ) {
-		$id = esc_attr( $id );
+		$id     = esc_attr( $id );
 		$output = "<!-- open output: $id -->" . $output . "<!-- close output: $id -->";
 	}
 

--- a/lib/api/html/functions.php
+++ b/lib/api/html/functions.php
@@ -39,6 +39,7 @@ function beans_output( $id, $output ) {
 	}
 
 	if ( _beans_is_html_dev_mode() ) {
+		$id = esc_attr( $id );
 		$output = "<!-- open output: $id -->" . $output . "<!-- close output: $id -->";
 	}
 

--- a/tests/phpunit/integration/api/html/beansCloseMarkup.php
+++ b/tests/phpunit/integration/api/html/beansCloseMarkup.php
@@ -132,4 +132,21 @@ EOB;
 		$this->assertEquals( 2, did_action( 'beans_archive_title_append_markup' ) );
 		$this->assertEquals( 2, did_action( 'beans_archive_title_after_markup' ) );
 	}
+
+	/**
+	 * Test beans_close_markup() should escape the closing tag.
+	 */
+	public function test_should_escape_closing_tag() {
+		$expected = <<<EOB
+</&lt;script&gt;alert(&quot;Should escape me.&quot;)&lt;/script&gt;>
+EOB;
+		// Check when given as the tag.
+		$this->assertSame( $expected, beans_close_markup( 'beans_post_title', '<script>alert("Should escape me.")</script>' ) );
+
+		// Check when tag is filtered.
+		add_filter( 'beans_post_title_markup', function() {
+			return '<script>alert("Should escape me.")</script>';
+		});
+		$this->assertSame( $expected, beans_close_markup( 'beans_post_title', 'h1' ) );
+	}
 }

--- a/tests/phpunit/integration/api/html/beansOpenMarkup.php
+++ b/tests/phpunit/integration/api/html/beansOpenMarkup.php
@@ -198,4 +198,39 @@ EOB;
 		$this->assertEquals( 2, did_action( 'beans_archive_title_prepend_markup' ) );
 		$this->assertEquals( 0, did_action( 'beans_archive_title_after_markup' ) );
 	}
+
+	/**
+	 * Test beans_open_markup() should escape the built HTML tag.
+	 */
+	public function test_should_escape_built_html_tag() {
+		$expected = <<<EOB
+<&lt;script&gt;alert(&quot;Should escape me.&quot;)&lt;/script&gt; class="uk-article-title" itemprop="headline">
+EOB;
+		// Check when given as the tag.
+		$actual = beans_open_markup( 'beans_post_title', '<script>alert("Should escape me.")</script>', array(
+			'class'    => 'uk-article-title',
+			'itemprop' => 'headline',
+		) );
+		$this->assertSame( $expected, $actual );
+
+		// Check when tag is filtered.
+		add_filter( 'beans_post_title_markup', function() {
+			return '<script>alert("Should escape me.")</script>';
+		} );
+		$actual = beans_open_markup( 'beans_post_title', 'h1', array(
+			'class'    => 'uk-article-title',
+			'itemprop' => 'headline',
+		) );
+		$this->assertSame( $expected, $actual );
+
+		// Check the attributes too.
+		$expected = <<<EOB
+<a href="http://example.com/testing-ensure-safe?val=scriptalert(Should%20escape%20me.);/script" title="Testing to ensure safe." rel="bookmark">
+EOB;
+		$this->assertSame( $expected, beans_open_markup( 'beans_post_title_link', 'a', array(
+			'href'  => 'http://example.com/testing-ensure-safe?val=<script>alert("Should escape me.");</script>',
+			'title' => 'Testing to ensure safe.',
+			'rel'   => 'bookmark',
+		) ) );
+	}
 }


### PR DESCRIPTION
Escaped HTML built by the API.  Tested using this [script](https://gist.github.com/hellofromtonya/99cb29fcacbc14c5eac7aa1b902bd0c5), which you can put into your Beans child theme's functions.php file.

Updated Rule comments to note compliance.

Added tests to both the `beans_open_markup` and `beans_close_markup` test suites to ensure code built by Beans is safe.

This PR is part of the ongoing #143 Safety Audit.