### PR TITLE
Added unit tests for _Beans_Anonymous_Action

### DIFF
--- a/lib/api/actions/class-beans-anonymous-action.php
+++ b/lib/api/actions/class-beans-anonymous-action.php
@@ -16,7 +16,7 @@
  *
  * @package Beans\Framework\API\Actions
  */
-final class _Beans_Anonymous_Actions {
+final class _Beans_Anonymous_Action {
 
 	/**
 	 * The callback to register to the given $hook.

--- a/lib/api/actions/class-beans-anonymous-action.php
+++ b/lib/api/actions/class-beans-anonymous-action.php
@@ -51,6 +51,6 @@ final class _Beans_Anonymous_Action {
 	 * @return void
 	 */
 	public function callback() {
-		echo call_user_func_array( $this->callback[0], $this->callback[1] ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- The callback should escape the output.
+		echo call_user_func_array( $this->callback[0], $this->callback[1] ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- The callback handles escaping its output, as Beans does not know what HTML or content will be passed back to it.
 	}
 }

--- a/lib/api/actions/functions.php
+++ b/lib/api/actions/functions.php
@@ -648,12 +648,12 @@ function _beans_build_action_array( $hook = null, $callback = null, $priority = 
  *                            in the order in which they were added to the action.
  * @param int    $number_args Optional. The number of arguments the function accepts. Default 1.
  *
- * @return _Beans_Anonymous_Actions
+ * @return _Beans_Anonymous_Action
  */
 function _beans_add_anonymous_action( $hook, array $callback, $priority = 10, $number_args = 1 ) {
 	require_once BEANS_API_PATH . 'actions/class-beans-anonymous-action.php';
 
-	return new _Beans_Anonymous_Actions( $hook, $callback, $priority, $number_args );
+	return new _Beans_Anonymous_Action( $hook, $callback, $priority, $number_args );
 }
 
 /**

--- a/tests/phpunit/integration/api/html/beansWrapInnerMarkup.php
+++ b/tests/phpunit/integration/api/html/beansWrapInnerMarkup.php
@@ -10,7 +10,6 @@
 namespace Beans\Framework\Tests\Integration\API\HTML;
 
 use Beans\Framework\Tests\Integration\API\HTML\Includes\HTML_Test_Case;
-use Brain\Monkey;
 
 require_once __DIR__ . '/includes/class-html-test-case.php';
 
@@ -31,7 +30,7 @@ class Tests_BeansWrapInnerMarkup extends HTML_Test_Case {
 	 * @param string $hook     To given hook's event name.
 	 * @param int    $priority The priority number for the callback.
 	 *
-	 * @return \_Beans_Anonymous_Actions
+	 * @return \_Beans_Anonymous_Action
 	 */
 	protected function get_instance_from_wp( $hook, $priority ) {
 		global $wp_filter;

--- a/tests/phpunit/integration/api/html/beansWrapMarkup.php
+++ b/tests/phpunit/integration/api/html/beansWrapMarkup.php
@@ -10,7 +10,6 @@
 namespace Beans\Framework\Tests\Integration\API\HTML;
 
 use Beans\Framework\Tests\Integration\API\HTML\Includes\HTML_Test_Case;
-use Brain\Monkey;
 
 require_once __DIR__ . '/includes/class-html-test-case.php';
 
@@ -31,7 +30,7 @@ class Tests_BeansWrapMarkup extends HTML_Test_Case {
 	 * @param string $hook     To given hook's event name.
 	 * @param int    $priority The priority number for the callback.
 	 *
-	 * @return \_Beans_Anonymous_Actions
+	 * @return \_Beans_Anonymous_Action
 	 */
 	protected function get_instance_from_wp( $hook, $priority ) {
 		global $wp_filter;

--- a/tests/phpunit/unit/api/actions/beans-anonymous-action/__construct.php
+++ b/tests/phpunit/unit/api/actions/beans-anonymous-action/__construct.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Tests for __construct() method for _Beans_Anonymous_Actions.
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Unit\API\Actions;
+
+use _Beans_Anonymous_Actions;
+use Beans\Framework\Tests\Unit\API\Actions\Includes\Actions_Test_Case;
+
+require_once dirname( __DIR__ ) . '/includes/class-actions-test-case.php';
+
+/**
+ * Class Tests_BeansAnonymousActions_Construct
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ * @group   api
+ * @group   api-actions
+ */
+class Tests_BeansAnonymousActions_Construct extends Actions_Test_Case {
+
+	/**
+	 * Prepares the test environment before each test.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		require_once BEANS_API_PATH . 'actions/class-beans-anonymous-action.php';
+	}
+
+	/**
+	 * Test __construct() should set the callback and arguments.
+	 */
+	public function test_should_set_callback_and_arguments() {
+		$anonymous_action = new _Beans_Anonymous_Actions( 'beans_test_do_foo', array(
+			'foo_test_callback',
+			array( 'foo', 'bar', 'baz' ),
+		) );
+
+		$this->assertSame( 'foo_test_callback', $anonymous_action->callback[0] );
+		$this->assertSame( array( 'foo', 'bar', 'baz' ), $anonymous_action->callback[1] );
+	}
+
+	/**
+	 * Test __construct() should add the action's hook.
+	 */
+	public function test_should_add_action_hook() {
+		$anonymous_action = new _Beans_Anonymous_Actions( 'beans_test_do_foo', array(
+			'foo_test_callback',
+			array( 'foo' ),
+		), 50, 3 );
+
+		$this->assertTrue( has_action( 'beans_test_do_foo', array( $anonymous_action, 'callback' ) ) );
+	}
+}

--- a/tests/phpunit/unit/api/actions/beans-anonymous-action/__construct.php
+++ b/tests/phpunit/unit/api/actions/beans-anonymous-action/__construct.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests for __construct() method for _Beans_Anonymous_Actions.
+ * Tests for __construct() method for _Beans_Anonymous_Action.
  *
  * @package Beans\Framework\Tests\Unit\API\Actions
  *
@@ -9,19 +9,19 @@
 
 namespace Beans\Framework\Tests\Unit\API\Actions;
 
-use _Beans_Anonymous_Actions;
+use _Beans_Anonymous_Action;
 use Beans\Framework\Tests\Unit\API\Actions\Includes\Actions_Test_Case;
 
 require_once dirname( __DIR__ ) . '/includes/class-actions-test-case.php';
 
 /**
- * Class Tests_BeansAnonymousActions_Construct
+ * Class Tests_BeansAnonymousAction_Construct
  *
  * @package Beans\Framework\Tests\Unit\API\Actions
  * @group   api
  * @group   api-actions
  */
-class Tests_BeansAnonymousActions_Construct extends Actions_Test_Case {
+class Tests_BeansAnonymousAction_Construct extends Actions_Test_Case {
 
 	/**
 	 * Prepares the test environment before each test.
@@ -36,7 +36,7 @@ class Tests_BeansAnonymousActions_Construct extends Actions_Test_Case {
 	 * Test __construct() should set the callback and arguments.
 	 */
 	public function test_should_set_callback_and_arguments() {
-		$anonymous_action = new _Beans_Anonymous_Actions( 'beans_test_do_foo', array(
+		$anonymous_action = new _Beans_Anonymous_Action( 'beans_test_do_foo', array(
 			'foo_test_callback',
 			array( 'foo', 'bar', 'baz' ),
 		) );
@@ -49,7 +49,7 @@ class Tests_BeansAnonymousActions_Construct extends Actions_Test_Case {
 	 * Test __construct() should add the action's hook.
 	 */
 	public function test_should_add_action_hook() {
-		$anonymous_action = new _Beans_Anonymous_Actions( 'beans_test_do_foo', array(
+		$anonymous_action = new _Beans_Anonymous_Action( 'beans_test_do_foo', array(
 			'foo_test_callback',
 			array( 'foo' ),
 		), 50, 3 );

--- a/tests/phpunit/unit/api/actions/beans-anonymous-action/__construct.php
+++ b/tests/phpunit/unit/api/actions/beans-anonymous-action/__construct.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests for __construct() method for _Beans_Anonymous_Action.
+ * Tests for __construct() method of _Beans_Anonymous_Action.
  *
  * @package Beans\Framework\Tests\Unit\API\Actions
  *

--- a/tests/phpunit/unit/api/actions/beans-anonymous-action/callback.php
+++ b/tests/phpunit/unit/api/actions/beans-anonymous-action/callback.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Tests for callback() method for _Beans_Anonymous_Actions.
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Unit\API\Actions;
+
+use _Beans_Anonymous_Actions;
+use Beans\Framework\Tests\Unit\API\Actions\Includes\Actions_Test_Case;
+use Brain\Monkey;
+
+require_once dirname( __DIR__ ) . '/includes/class-actions-test-case.php';
+
+/**
+ * Class Tests_BeansAddAction
+ *
+ * @package Beans\Framework\Tests\Unit\API\Actions
+ * @group   api
+ * @group   api-actions
+ */
+class Tests_BeansAnonymousActions_Callback extends Actions_Test_Case {
+
+	/**
+	 * Prepares the test environment before each test.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		require_once BEANS_API_PATH . 'actions/class-beans-anonymous-action.php';
+	}
+
+	/**
+	 * Test callback() should invoke the given callback, passing the arguments to it.
+	 */
+	public function test_should_invoke_callback() {
+		$anonymous_action = new _Beans_Anonymous_Actions( 'beans_test_do_foo', array(
+			'foo_test_callback',
+			array( 'foo', 'bar' ),
+		), 20, 2 );
+
+		// Check that the callback is invoked with each of its parameters.
+		Monkey\Functions\expect( 'foo_test_callback' )
+			->once()
+			->with( 'foo', 'bar' )
+			->andReturnFirstArg();
+
+		ob_start();
+		$anonymous_action->callback();
+		ob_get_clean();
+
+		// Placeholder for PHPUnit, as it requires an assertion.  The real test is the "expect" above.
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * Test callback() should echo the returned content.
+	 */
+	public function test_should_echo_returned_content() {
+		$anonymous_action = new _Beans_Anonymous_Actions( 'beans_test_do_foo', array(
+			'foo_test_callback',
+			array( 'Cool Beans!', 'It worked!' ),
+		) );
+
+		Monkey\Functions\when( 'foo_test_callback' )->alias( function( $arg1, $arg2 ) {
+			return "{$arg1} {$arg2}";
+		} );
+
+		ob_start();
+		$anonymous_action->callback();
+		$this->assertEquals( 'Cool Beans! It worked!', ob_get_clean() );
+	}
+}

--- a/tests/phpunit/unit/api/actions/beans-anonymous-action/callback.php
+++ b/tests/phpunit/unit/api/actions/beans-anonymous-action/callback.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests for callback() method for _Beans_Anonymous_Actions.
+ * Tests for callback() method for _Beans_Anonymous_Action.
  *
  * @package Beans\Framework\Tests\Unit\API\Actions
  *
@@ -9,20 +9,20 @@
 
 namespace Beans\Framework\Tests\Unit\API\Actions;
 
-use _Beans_Anonymous_Actions;
+use _Beans_Anonymous_Action;
 use Beans\Framework\Tests\Unit\API\Actions\Includes\Actions_Test_Case;
 use Brain\Monkey;
 
 require_once dirname( __DIR__ ) . '/includes/class-actions-test-case.php';
 
 /**
- * Class Tests_BeansAddAction
+ * Class Tests_BeansAnonymousAction_Callback
  *
  * @package Beans\Framework\Tests\Unit\API\Actions
  * @group   api
  * @group   api-actions
  */
-class Tests_BeansAnonymousActions_Callback extends Actions_Test_Case {
+class Tests_BeansAnonymousAction_Callback extends Actions_Test_Case {
 
 	/**
 	 * Prepares the test environment before each test.
@@ -37,7 +37,7 @@ class Tests_BeansAnonymousActions_Callback extends Actions_Test_Case {
 	 * Test callback() should invoke the given callback, passing the arguments to it.
 	 */
 	public function test_should_invoke_callback() {
-		$anonymous_action = new _Beans_Anonymous_Actions( 'beans_test_do_foo', array(
+		$anonymous_action = new _Beans_Anonymous_Action( 'beans_test_do_foo', array(
 			'foo_test_callback',
 			array( 'foo', 'bar' ),
 		), 20, 2 );
@@ -60,7 +60,7 @@ class Tests_BeansAnonymousActions_Callback extends Actions_Test_Case {
 	 * Test callback() should echo the returned content.
 	 */
 	public function test_should_echo_returned_content() {
-		$anonymous_action = new _Beans_Anonymous_Actions( 'beans_test_do_foo', array(
+		$anonymous_action = new _Beans_Anonymous_Action( 'beans_test_do_foo', array(
 			'foo_test_callback',
 			array( 'Cool Beans!', 'It worked!' ),
 		) );

--- a/tests/phpunit/unit/api/actions/beans-anonymous-action/callback.php
+++ b/tests/phpunit/unit/api/actions/beans-anonymous-action/callback.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Tests for callback() method for _Beans_Anonymous_Action.
+ * Tests for callback() method of _Beans_Anonymous_Action.
  *
  * @package Beans\Framework\Tests\Unit\API\Actions
  *

--- a/tests/phpunit/unit/api/html/fixtures/class-anonymous-action-stub.php
+++ b/tests/phpunit/unit/api/html/fixtures/class-anonymous-action-stub.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Stub for the _Beans_Anonymous_Actions.
+ * Stub for the _Beans_Anonymous_Action.
  *
  * @package Beans\Framework\Tests\Unit\API\HTML\Fixtures
  *


### PR DESCRIPTION
This PR adds unit tests for the `_Beans_Anonymous_Action`.  It also renames the class to a singular noun, as the class is the blueprint for a single anonymous action.

I want to note here that I did review the use of registering the hook in the constructor.  This practice is frowned upon; however, in this case, the point of instantiating the object is register the anonymous callback to the given hook.  Therefore, it is a valid use case.