### PR TITLE
Bug fix on post meta screen conditions not being correctly evaluated

### DIFF
--- a/lib/api/post-meta/functions-admin.php
+++ b/lib/api/post-meta/functions-admin.php
@@ -103,6 +103,7 @@ function beans_register_post_meta( array $fields, $conditions, $section, $args =
  * @return bool
  */
 function _beans_is_post_meta_conditions( $conditions ) {
+
 	// If user has designated boolean true, it's always true. Nothing more to do here.
 	if ( true === $conditions ) {
 		return true;

--- a/lib/api/post-meta/functions-admin.php
+++ b/lib/api/post-meta/functions-admin.php
@@ -103,10 +103,10 @@ function beans_register_post_meta( array $fields, $conditions, $section, $args =
  * @return bool
  */
 function _beans_is_post_meta_conditions( $conditions ) {
-    // If user has designated boolean true, it's always true. Nothing more to do here.
-    if ( true === $conditions ) {
-        return true;
-    }
+	// If user has designated boolean true, it's always true. Nothing more to do here.
+	if ( true === $conditions ) {
+		return true;
+	}
 
 	// Check if it is a new post and treat it as such.
 	if ( false !== stripos( $_SERVER['REQUEST_URI'], 'post-new.php' ) ) {

--- a/lib/api/post-meta/functions-admin.php
+++ b/lib/api/post-meta/functions-admin.php
@@ -103,6 +103,10 @@ function beans_register_post_meta( array $fields, $conditions, $section, $args =
  * @return bool
  */
 function _beans_is_post_meta_conditions( $conditions ) {
+    // If user has designated boolean true, it's always true. Nothing more to do here.
+    if ( true === $conditions ) {
+        return true;
+    }
 
 	// Check if it is a new post and treat it as such.
 	if ( false !== stripos( $_SERVER['REQUEST_URI'], 'post-new.php' ) ) {
@@ -136,7 +140,6 @@ function _beans_is_post_meta_conditions( $conditions ) {
 	}
 
 	$statements = array(
-		true === $conditions,
 		in_array( $current_post_type, (array) $conditions, true ), // Check post type.
 		isset( $post_id ) && in_array( $post_id, (array) $conditions, true ), // Check post id.
 		isset( $post_id ) && in_array( get_post_meta( $post_id, '_wp_page_template', true ), (array) $conditions, true ), // Check page template.


### PR DESCRIPTION
Check for a Boolean `true` at the beginning instead of waiting til the end. Otherwise, other conditions might not allow us to evaluate the more general case.