### PR TITLE
Renamed test classes to comply with WPCS.

### DIFF
--- a/tests/phpunit/integration/api/compiler/beans-compiler/addContentMediaQuery.php
+++ b/tests/phpunit/integration/api/compiler/beans-compiler/addContentMediaQuery.php
@@ -15,13 +15,13 @@ use Beans\Framework\Tests\Integration\API\Compiler\Includes\Compiler_Test_Case;
 require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 
 /**
- * Class Tests_Beans_Compiler_Add_Content_Media_Query
+ * Class Tests_BeansCompiler_AddContentMediaQuery
  *
  * @package Beans\Framework\Tests\Integration\API\Compiler
  * @group   api
  * @group   api-compiler
  */
-class Tests_Beans_Compiler_Add_Content_Media_Query extends Compiler_Test_Case {
+class Tests_BeansCompiler_AddContentMediaQuery extends Compiler_Test_Case {
 
 	/**
 	 * Test add_content_media_query() should return original content when current fragment is callable.

--- a/tests/phpunit/integration/api/compiler/beans-compiler/cacheFile.php
+++ b/tests/phpunit/integration/api/compiler/beans-compiler/cacheFile.php
@@ -17,13 +17,13 @@ use org\bovigo\vfs\vfsStream;
 require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 
 /**
- * Class Tests_Beans_Compiler_Cache_File
+ * Class Tests_BeansCompiler_CacheFile
  *
  * @package Beans\Framework\Tests\Integration\API\Compiler
  * @group   api
  * @group   api-compiler
  */
-class Tests_Beans_Compiler_Cache_File extends Compiler_Test_Case {
+class Tests_BeansCompiler_CacheFile extends Compiler_Test_Case {
 
 	/**
 	 * Test cache_file() should not create the file.

--- a/tests/phpunit/integration/api/compiler/beans-compiler/combineFragments.php
+++ b/tests/phpunit/integration/api/compiler/beans-compiler/combineFragments.php
@@ -16,13 +16,13 @@ use org\bovigo\vfs\vfsStream;
 require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 
 /**
- * Class Tests_Beans_Compiler_Combine_Fragments
+ * Class Tests_BeansCompiler_CombineFragments
  *
  * @package Beans\Framework\Tests\Integration\API\Compiler
  * @group   api
  * @group   api-compiler
  */
-class Tests_Beans_Compiler_Combine_Fragments extends Compiler_Test_Case {
+class Tests_BeansCompiler_CombineFragments extends Compiler_Test_Case {
 
 	/**
 	 * The CSS content.

--- a/tests/phpunit/integration/api/compiler/beans-compiler/fileystem.php
+++ b/tests/phpunit/integration/api/compiler/beans-compiler/fileystem.php
@@ -16,13 +16,13 @@ use Brain\Monkey\Functions;
 require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 
 /**
- * Class Tests_Beans_Compiler_Filesystem
+ * Class Tests_BeansCompiler_Filesystem
  *
  * @package Beans\Framework\Tests\Integration\API\Compiler
  * @group   api
  * @group   api-compiler
  */
-class Tests_Beans_Compiler_Filesystem extends Compiler_Test_Case {
+class Tests_BeansCompiler_Filesystem extends Compiler_Test_Case {
 
 	/**
 	 * Test filesystem() should render a report and die when no filesystem is selected.

--- a/tests/phpunit/integration/api/compiler/beans-compiler/formatContent.php
+++ b/tests/phpunit/integration/api/compiler/beans-compiler/formatContent.php
@@ -14,13 +14,13 @@ use Beans\Framework\Tests\Integration\API\Compiler\Includes\Compiler_Test_Case;
 require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 
 /**
- * Class Tests_Beans_Compiler_Format_Content
+ * Class Tests_BeansCompiler_FormatContent
  *
  * @package Beans\Framework\Tests\Integration\API\Compiler
  * @group   api
  * @group   api-compiler
  */
-class Tests_Beans_Compiler_Format_Content extends Compiler_Test_Case {
+class Tests_BeansCompiler_FormatContent extends Compiler_Test_Case {
 
 	/**
 	 * The Less content.

--- a/tests/phpunit/integration/api/compiler/beans-compiler/getInternalContent.php
+++ b/tests/phpunit/integration/api/compiler/beans-compiler/getInternalContent.php
@@ -16,13 +16,13 @@ use org\bovigo\vfs\vfsStream;
 require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 
 /**
- * Class Tests_Beans_Compiler_Get_Internal_Content
+ * Class Tests_BeansCompiler_GetInternalContent
  *
  * @package Beans\Framework\Tests\Integration\API\Compiler
  * @group   api
  * @group   api-compiler
  */
-class Tests_Beans_Compiler_Get_Internal_Content extends Compiler_Test_Case {
+class Tests_BeansCompiler_GetInternalContent extends Compiler_Test_Case {
 
 	/**
 	 * Test get_internal_content() should return false when fragment is empty.

--- a/tests/phpunit/integration/api/compiler/beans-compiler/getRemoteContent.php
+++ b/tests/phpunit/integration/api/compiler/beans-compiler/getRemoteContent.php
@@ -15,13 +15,13 @@ use Beans\Framework\Tests\Integration\API\Compiler\Includes\Compiler_Test_Case;
 require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 
 /**
- * Class Tests_Beans_Compiler_Get_Remote_Content
+ * Class Tests_BeansCompiler_GetRemoteContent
  *
  * @package Beans\Framework\Tests\Integration\API\Compiler
  * @group   api
  * @group   api-compiler
  */
-class Tests_Beans_Compiler_Get_Remote_Content extends Compiler_Test_Case {
+class Tests_BeansCompiler_GetRemoteContent extends Compiler_Test_Case {
 
 	/**
 	 * Test get_remote_content() should return false when fragment is empty.

--- a/tests/phpunit/integration/api/compiler/beans-compiler/replaceCssUrl.php
+++ b/tests/phpunit/integration/api/compiler/beans-compiler/replaceCssUrl.php
@@ -15,13 +15,13 @@ use Beans\Framework\Tests\Integration\API\Compiler\Includes\Compiler_Test_Case;
 require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 
 /**
- * Class Tests_Beans_Compiler_Replace_Css_Url
+ * Class Tests_BeansCompiler_ReplaceCssUrl
  *
  * @package Beans\Framework\Tests\Integration\API\Compiler
  * @group   api
  * @group   api-compiler
  */
-class Tests_Beans_Compiler_Replace_Css_Url extends Compiler_Test_Case {
+class Tests_BeansCompiler_ReplaceCssUrl extends Compiler_Test_Case {
 
 	/**
 	 * Test replace_css_url() should return original content when there is no url source in the CSS.

--- a/tests/phpunit/integration/api/compiler/beans-compiler/runCompiler.php
+++ b/tests/phpunit/integration/api/compiler/beans-compiler/runCompiler.php
@@ -16,13 +16,13 @@ use org\bovigo\vfs\vfsStream;
 require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 
 /**
- * Class Tests_Beans_Compiler_Run_Compiler
+ * Class Tests_BeansCompiler_RunCompiler
  *
  * @package Beans\Framework\Tests\Integration\API\Compiler
  * @group   api
  * @group   api-compiler
  */
-class Tests_Beans_Compiler_Run_Compiler extends Compiler_Test_Case {
+class Tests_BeansCompiler_RunCompiler extends Compiler_Test_Case {
 
 	/**
 	 * The CSS content.

--- a/tests/phpunit/integration/api/compiler/beans-compiler/setFilename.php
+++ b/tests/phpunit/integration/api/compiler/beans-compiler/setFilename.php
@@ -15,13 +15,13 @@ use org\bovigo\vfs\vfsStream;
 require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 
 /**
- * Class Tests_Beans_Compiler_Set_Filename
+ * Class Tests_BeansCompiler_SetFilename
  *
  * @package Beans\Framework\Tests\Integration\API\Compiler
  * @group   api
  * @group   api-compiler
  */
-class Tests_Beans_Compiler_Set_Filename extends Compiler_Test_Case {
+class Tests_BeansCompiler_SetFilename extends Compiler_Test_Case {
 
 	/**
 	 * Test set_filename() should return the hash created with the modification time from each of the fragments.

--- a/tests/phpunit/unit/api/compiler/beans-compiler/addContentMediaQuery.php
+++ b/tests/phpunit/unit/api/compiler/beans-compiler/addContentMediaQuery.php
@@ -15,13 +15,13 @@ use Brain\Monkey;
 require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 
 /**
- * Class Tests_Beans_Compiler_Add_Content_Media_Query
+ * Class Tests_BeansCompiler_AddContentMediaQuery
  *
  * @package Beans\Framework\Tests\Unit\API\Compiler
  * @group   api
  * @group   api-compiler
  */
-class Tests_Beans_Compiler_Add_Content_Media_Query extends Compiler_Test_Case {
+class Tests_BeansCompiler_AddContentMediaQuery extends Compiler_Test_Case {
 
 	/**
 	 * Test add_content_media_query() should return original content when current fragment is callable.

--- a/tests/phpunit/unit/api/compiler/beans-compiler/cacheFile.php
+++ b/tests/phpunit/unit/api/compiler/beans-compiler/cacheFile.php
@@ -16,13 +16,13 @@ use org\bovigo\vfs\vfsStream;
 require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 
 /**
- * Class Tests_Beans_Compiler_Cache_File
+ * Class Tests_BeansCompiler_CacheFile
  *
  * @package Beans\Framework\Tests\Unit\API\Compiler
  * @group   api
  * @group   api-compiler
  */
-class Tests_Beans_Compiler_Cache_File extends Compiler_Test_Case {
+class Tests_BeansCompiler_CacheFile extends Compiler_Test_Case {
 
 	/**
 	 * Test cache_file() should not create the file when the filename is empty.

--- a/tests/phpunit/unit/api/compiler/beans-compiler/cacheFileExist.php
+++ b/tests/phpunit/unit/api/compiler/beans-compiler/cacheFileExist.php
@@ -15,13 +15,13 @@ use org\bovigo\vfs\vfsStream;
 require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 
 /**
- * Class Tests_Beans_Compiler_CacheFileExist
+ * Class Tests_BeansCompiler_CacheFileExist
  *
  * @package Beans\Framework\Tests\Unit\API\Compiler
  * @group   api
  * @group   api-compiler
  */
-class Tests_Beans_Compiler_CacheFileExist extends Compiler_Test_Case {
+class Tests_BeansCompiler_CacheFileExist extends Compiler_Test_Case {
 
 	/**
 	 * Test cache_file_exist() should return false when the filename has not been generated.

--- a/tests/phpunit/unit/api/compiler/beans-compiler/combineFragments.php
+++ b/tests/phpunit/unit/api/compiler/beans-compiler/combineFragments.php
@@ -16,13 +16,13 @@ use org\bovigo\vfs\vfsStream;
 require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 
 /**
- * Class Tests_Beans_Compiler_Combine_Fragments
+ * Class Tests_BeansCompiler_CombineFragments
  *
  * @package Beans\Framework\Tests\Unit\API\Compiler
  * @group   api
  * @group   api-compiler
  */
-class Tests_Beans_Compiler_Combine_Fragments extends Compiler_Test_Case {
+class Tests_BeansCompiler_CombineFragments extends Compiler_Test_Case {
 
 	/**
 	 * The CSS content.

--- a/tests/phpunit/unit/api/compiler/beans-compiler/fileystem.php
+++ b/tests/phpunit/unit/api/compiler/beans-compiler/fileystem.php
@@ -16,13 +16,13 @@ use Mockery;
 require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 
 /**
- * Class Tests_Beans_Compiler_Filesystem
+ * Class Tests_BeansCompiler_Filesystem
  *
  * @package Beans\Framework\Tests\Unit\API\Compiler
  * @group   api
  * @group   api-compiler
  */
-class Tests_Beans_Compiler_Filesystem extends Compiler_Test_Case {
+class Tests_BeansCompiler_Filesystem extends Compiler_Test_Case {
 
 	/**
 	 * Test filesystem() should return true when the WP Filesystem is initialized to WP_Filesystem_Direct.

--- a/tests/phpunit/unit/api/compiler/beans-compiler/formatContent.php
+++ b/tests/phpunit/unit/api/compiler/beans-compiler/formatContent.php
@@ -15,13 +15,13 @@ use Brain\Monkey;
 require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 
 /**
- * Class Tests_Beans_Compiler_Format_Content
+ * Class Tests_BeansCompiler_FormatContent
  *
  * @package Beans\Framework\Tests\Unit\API\Compiler
  * @group   api
  * @group   api-compiler
  */
-class Tests_Beans_Compiler_Format_Content extends Compiler_Test_Case {
+class Tests_BeansCompiler_FormatContent extends Compiler_Test_Case {
 
 	/**
 	 * The Less content.

--- a/tests/phpunit/unit/api/compiler/beans-compiler/get.php
+++ b/tests/phpunit/unit/api/compiler/beans-compiler/get.php
@@ -15,13 +15,13 @@ use org\bovigo\vfs\vfsStream;
 require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 
 /**
- * Class Tests_Beans_Compiler_Get
+ * Class Tests_BeansCompiler_Get
  *
  * @package Beans\Framework\Tests\Unit\API\Compiler
  * @group   api
  * @group   api-compiler
  */
-class Tests_Beans_Compiler_Get extends Compiler_Test_Case {
+class Tests_BeansCompiler_Get extends Compiler_Test_Case {
 
 	/**
 	 * Test should fix the configuration's dependency key.

--- a/tests/phpunit/unit/api/compiler/beans-compiler/getExtension.php
+++ b/tests/phpunit/unit/api/compiler/beans-compiler/getExtension.php
@@ -14,13 +14,13 @@ use Beans\Framework\Tests\Unit\API\Compiler\Includes\Compiler_Test_Case;
 require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 
 /**
- * Class Tests_Beans_Compiler_Get_Extension
+ * Class Tests_BeansCompiler_GetExtension
  *
  * @package Beans\Framework\Tests\Unit\API\Compiler
  * @group   api
  * @group   api-compiler
  */
-class Tests_Beans_Compiler_Get_Extension extends Compiler_Test_Case {
+class Tests_BeansCompiler_GetExtension extends Compiler_Test_Case {
 
 	/**
 	 * Test get_extension() should return "css" when the type is "style".

--- a/tests/phpunit/unit/api/compiler/beans-compiler/getFunctionContent.php
+++ b/tests/phpunit/unit/api/compiler/beans-compiler/getFunctionContent.php
@@ -16,13 +16,13 @@ use Mockery;
 require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 
 /**
- * Class Tests_Beans_Compiler_Get_Function_Content
+ * Class Tests_BeansCompiler_GetFunctionContent
  *
  * @package Beans\Framework\Tests\Unit\API\Compiler
  * @group   api
  * @group   api-compiler
  */
-class Tests_Beans_Compiler_Get_Function_Content extends Compiler_Test_Case {
+class Tests_BeansCompiler_GetFunctionContent extends Compiler_Test_Case {
 
 	/**
 	 * Test get_function_content() should return false when the given fragment is not callable.

--- a/tests/phpunit/unit/api/compiler/beans-compiler/getInternalContent.php
+++ b/tests/phpunit/unit/api/compiler/beans-compiler/getInternalContent.php
@@ -16,13 +16,13 @@ use org\bovigo\vfs\vfsStream;
 require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 
 /**
- * Class Tests_Beans_Compiler_Get_Internal_Content
+ * Class Tests_BeansCompiler_GetInternalContent
  *
  * @package Beans\Framework\Tests\Unit\API\Compiler
  * @group   api
  * @group   api-compiler
  */
-class Tests_Beans_Compiler_Get_Internal_Content extends Compiler_Test_Case {
+class Tests_BeansCompiler_GetInternalContent extends Compiler_Test_Case {
 
 	/**
 	 * Prepares the test environment before each test.

--- a/tests/phpunit/unit/api/compiler/beans-compiler/getRemoteContent.php
+++ b/tests/phpunit/unit/api/compiler/beans-compiler/getRemoteContent.php
@@ -15,13 +15,13 @@ use Brain\Monkey;
 require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 
 /**
- * Class Tests_Beans_Compiler_Get_Remote_Content
+ * Class Tests_BeansCompiler_GetRemoteContent
  *
  * @package Beans\Framework\Tests\Unit\API\Compiler
  * @group   api
  * @group   api-compiler
  */
-class Tests_Beans_Compiler_Get_Remote_Content extends Compiler_Test_Case {
+class Tests_BeansCompiler_GetRemoteContent extends Compiler_Test_Case {
 
 	/**
 	 * Test get_remote_content() should return false when the fragment is empty.

--- a/tests/phpunit/unit/api/compiler/beans-compiler/replaceCssUrl.php
+++ b/tests/phpunit/unit/api/compiler/beans-compiler/replaceCssUrl.php
@@ -15,13 +15,13 @@ use Brain\Monkey;
 require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 
 /**
- * Class Tests_Beans_Compiler_Replace_Css_Url
+ * Class Tests_BeansCompiler_ReplaceCssUrl
  *
  * @package Beans\Framework\Tests\Unit\API\Compiler
  * @group   api
  * @group   api-compiler
  */
-class Tests_Beans_Compiler_Replace_Css_Url extends Compiler_Test_Case {
+class Tests_BeansCompiler_ReplaceCssUrl extends Compiler_Test_Case {
 
 	/**
 	 * Test replace_css_url() should return original content when there is no url source in the CSS.

--- a/tests/phpunit/unit/api/compiler/beans-compiler/runCompiler.php
+++ b/tests/phpunit/unit/api/compiler/beans-compiler/runCompiler.php
@@ -16,13 +16,13 @@ use org\bovigo\vfs\vfsStream;
 require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 
 /**
- * Class Tests_Beans_Compiler_Run_Compiler
+ * Class Tests_BeansCompiler_RunCompiler
  *
  * @package Beans\Framework\Tests\Unit\API\Compiler
  * @group   api
  * @group   api-compiler
  */
-class Tests_Beans_Compiler_Run_Compiler extends Compiler_Test_Case {
+class Tests_BeansCompiler_RunCompiler extends Compiler_Test_Case {
 
 	/**
 	 * The CSS content.

--- a/tests/phpunit/unit/api/compiler/beans-compiler/setFilename.php
+++ b/tests/phpunit/unit/api/compiler/beans-compiler/setFilename.php
@@ -15,13 +15,13 @@ use org\bovigo\vfs\vfsStream;
 require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 
 /**
- * Class Tests_Beans_Compiler_Set_Filename
+ * Class Tests_BeansCompiler_SetFilename
  *
  * @package Beans\Framework\Tests\Unit\API\Compiler
  * @group   api
  * @group   api-compiler
  */
-class Tests_Beans_Compiler_Set_Filename extends Compiler_Test_Case {
+class Tests_BeansCompiler_SetFilename extends Compiler_Test_Case {
 
 	/**
 	 * Test set_filename() should return the hash created with the modification time from each of the fragments.

--- a/tests/phpunit/unit/api/compiler/beans-compiler/setFragments.php
+++ b/tests/phpunit/unit/api/compiler/beans-compiler/setFragments.php
@@ -16,13 +16,13 @@ use org\bovigo\vfs\vfsStream;
 require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 
 /**
- * Class Tests_Beans_Compiler_Set_Fragments
+ * Class Tests_BeansCompiler_SetFragments
  *
  * @package Beans\Framework\Tests\Unit\API\Compiler
  * @group   api
  * @group   api-compiler
  */
-class Tests_Beans_Compiler_Set_Fragments extends Compiler_Test_Case {
+class Tests_BeansCompiler_SetFragments extends Compiler_Test_Case {
 
 	/**
 	 * Test set_fragments() should return unchanged fragments, meaning no fragments were added or removed.


### PR DESCRIPTION
I failed to name this test classes properly in the previous commits.  The class naming standard is:

```
Tests_NameOfTheClass_NameOfTheMethod
```

This PR renames all of the `_Beans_Compiler` test classes to comply.