### PR TITLE
Improvements to Beans Compiler test suite.

### DIFF
--- a/tests/phpunit/integration/api/compiler/beans-compiler/addContentMediaQuery.php
+++ b/tests/phpunit/integration/api/compiler/beans-compiler/addContentMediaQuery.php
@@ -24,7 +24,7 @@ require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 class Tests_BeansCompiler_AddContentMediaQuery extends Compiler_Test_Case {
 
 	/**
-	 * Test add_content_media_query() should return original content when current fragment is callable.
+	 * Test _Beans_Compiler::add_content_media_query() should return original content when current fragment is callable.
 	 */
 	public function test_should_return_content_when_fragment_is_callable() {
 		$compiler = new _Beans_Compiler( array() );
@@ -40,7 +40,7 @@ EOB;
 	}
 
 	/**
-	 * Test add_content_media_query() should return original content when there are no query args.
+	 * Test _Beans_Compiler::add_content_media_query() should return original content when there are no query args.
 	 */
 	public function test_should_return_content_when_no_query_args() {
 		$compiler = new _Beans_Compiler( array() );
@@ -59,8 +59,8 @@ EOB;
 	}
 
 	/**
-	 * Test add_content_media_query() should return original content when the 'beans_compiler_media_query'
-	 * query arg is not present in the current fragment.
+	 * Test _Beans_Compiler::add_content_media_query() should return original content when the
+	 * 'beans_compiler_media_query' query arg is not present in the current fragment.
 	 */
 	public function test_should_return_content_when_no_media_query() {
 		$compiler = new _Beans_Compiler( array() );
@@ -79,7 +79,7 @@ EOB;
 	}
 
 	/**
-	 * Test add_content_media_query() should wrap the content in the specified media query.
+	 * Test _Beans_Compiler::add_content_media_query() should wrap the content in the specified media query.
 	 */
 	public function test_should_wrap_content_in_media_query() {
 		$compiler      = new _Beans_Compiler( array() );

--- a/tests/phpunit/integration/api/compiler/beans-compiler/cacheFile.php
+++ b/tests/phpunit/integration/api/compiler/beans-compiler/cacheFile.php
@@ -26,7 +26,7 @@ require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 class Tests_BeansCompiler_CacheFile extends Compiler_Test_Case {
 
 	/**
-	 * Test cache_file() should not create the file.
+	 * Test _Beans_Compiler::cache_file() should not create the file.
 	 */
 	public function test_should_not_create_the_file() {
 		$compiler = new _Beans_Compiler( array(
@@ -53,7 +53,7 @@ class Tests_BeansCompiler_CacheFile extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test cache_file() should create the compiled jQuery file.
+	 * Test _Beans_Compiler::cache_file() should create the compiled jQuery file.
 	 */
 	public function test_should_create_compiled_jquery_file() {
 		$compiler = new _Beans_Compiler( array(
@@ -80,7 +80,7 @@ class Tests_BeansCompiler_CacheFile extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test cache_file() should create the compiled JavaScript file.
+	 * Test _Beans_Compiler::cache_file() should create the compiled JavaScript file.
 	 */
 	public function test_should_create_compiled_javascript_file() {
 		$compiler = new _Beans_Compiler( array(
@@ -106,7 +106,7 @@ class Tests_BeansCompiler_CacheFile extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test cache_file() should create the compiled CSS file.
+	 * Test _Beans_Compiler::cache_file() should create the compiled CSS file.
 	 */
 	public function test_should_create_compiled_css_file() {
 		$compiler = new _Beans_Compiler( array(
@@ -130,7 +130,7 @@ class Tests_BeansCompiler_CacheFile extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test cache_file() should create the compiled LESS file.
+	 * Test _Beans_Compiler::cache_file() should create the compiled LESS file.
 	 */
 	public function test_should_create_compiled_less_file() {
 		$compiler = new _Beans_Compiler( array(

--- a/tests/phpunit/integration/api/compiler/beans-compiler/combineFragments.php
+++ b/tests/phpunit/integration/api/compiler/beans-compiler/combineFragments.php
@@ -67,7 +67,7 @@ class Tests_BeansCompiler_CombineFragments extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test combine_fragments() should return an empty string when there are no fragments to combine.
+	 * Test _Beans_Compiler::combine_fragments() should return an empty string when there are no fragments to combine.
 	 */
 	public function test_should_return_empty_string_when_no_fragments() {
 		$compiler = new _Beans_Compiler( array() );
@@ -78,7 +78,7 @@ class Tests_BeansCompiler_CombineFragments extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test combine_fragments() should return an empty string when the fragment does not exist.
+	 * Test _Beans_Compiler::combine_fragments() should return an empty string when the fragment does not exist.
 	 */
 	public function test_should_return_empty_string_when_fragment_does_not_exist() {
 		$fragment = vfsStream::url( 'compiled/fixtures/' ) . 'invalid-file.js';
@@ -91,7 +91,7 @@ class Tests_BeansCompiler_CombineFragments extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test combine_fragments() should compile the Less fragments and return the compiled CSS.
+	 * Test _Beans_Compiler::combine_fragments() should compile the Less fragments and return the compiled CSS.
 	 */
 	public function test_should_compile_less_and_return_css() {
 		$compiler = new _Beans_Compiler( array(
@@ -122,7 +122,7 @@ EOB;
 	}
 
 	/**
-	 * Test combine_fragments() should return minified, compiled Less from the Less combined fragments.
+	 * Test _Beans_Compiler::combine_fragments() should return minified, compiled Less from the Less combined fragments.
 	 */
 	public function test_should_return_minified_compiled_less() {
 		$compiler = new _Beans_Compiler( array(
@@ -145,7 +145,7 @@ EOB;
 	}
 
 	/**
-	 * Test combine_fragments() should return the original jQuery when site is not in development mode,
+	 * Test _Beans_Compiler::combine_fragments() should return the original jQuery when site is not in development mode,
 	 * but "minify_js" is disabled.
 	 */
 	public function test_should_return_original_jquery_when_minify_js_disabled() {
@@ -169,7 +169,7 @@ EOB;
 	}
 
 	/**
-	 * Test combine_fragments() should return the original jQuery when "minify_js" is enabled,
+	 * Test _Beans_Compiler::combine_fragments() should return the original jQuery when "minify_js" is enabled,
 	 * but the site is in development mode.
 	 */
 	public function test_should_always_return_original_jquery_when_in_dev_mode() {
@@ -193,7 +193,7 @@ EOB;
 	}
 
 	/**
-	 * Test combine_fragments() should return minified jQuery.
+	 * Test _Beans_Compiler::combine_fragments() should return minified jQuery.
 	 */
 	public function test_should_return_minified_jquery() {
 		$compiler = new _Beans_Compiler( array(
@@ -216,8 +216,8 @@ EOB;
 	}
 
 	/**
-	 * Test combine_fragments() should return the original JavaScript when site is not in development mode,
-	 * but "minify_js" is disabled.
+	 * Test _Beans_Compiler::combine_fragments() should return the original JavaScript when site is not in development
+	 * mode, but "minify_js" is disabled.
 	 */
 	public function test_should_return_original_js_when_minify_js_disabled() {
 		$compiler = new _Beans_Compiler( array(
@@ -243,7 +243,7 @@ EOB;
 	}
 
 	/**
-	 * Test combine_fragments() should return the original JavaScript when "minify_js" is enabled,
+	 * Test _Beans_Compiler::combine_fragments() should return the original JavaScript when "minify_js" is enabled,
 	 * but the site is in development mode.
 	 */
 	public function test_should_always_return_original_js_when_in_dev_mode() {
@@ -269,7 +269,7 @@ EOB;
 	}
 
 	/**
-	 * Test combine_fragments() should return minified JavaScript.
+	 * Test _Beans_Compiler::combine_fragments() should return minified JavaScript.
 	 */
 	public function test_should_return_minified_javascript() {
 		$compiler = new _Beans_Compiler( array(

--- a/tests/phpunit/integration/api/compiler/beans-compiler/fileystem.php
+++ b/tests/phpunit/integration/api/compiler/beans-compiler/fileystem.php
@@ -25,7 +25,7 @@ require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 class Tests_BeansCompiler_Filesystem extends Compiler_Test_Case {
 
 	/**
-	 * Test filesystem() should render a report and die when no filesystem is selected.
+	 * Test _Beans_Compiler::filesystem() should render a report and die when no filesystem is selected.
 	 */
 	public function test_should_render_report_and_die_when_no_filesystem_selected() {
 		$compiler = new _Beans_Compiler( array() );
@@ -59,7 +59,7 @@ class Tests_BeansCompiler_Filesystem extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test filesystem() should initialize the WP Filesystem.
+	 * Test _Beans_Compiler::filesystem() should initialize the WP Filesystem.
 	 */
 	public function test_should_init_wp_filesystem() {
 		$compiler = new _Beans_Compiler( array() );
@@ -79,7 +79,7 @@ class Tests_BeansCompiler_Filesystem extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test filesystem() should set WP_Filesystem_Direct when not set as WP_Filesystem method.
+	 * Test _Beans_Compiler::filesystem() should set WP_Filesystem_Direct when not set as WP_Filesystem method.
 	 */
 	public function test_should_set_wp_filesystem_direct() {
 		// First, set something else as the WP_Filesystem method.

--- a/tests/phpunit/integration/api/compiler/beans-compiler/formatContent.php
+++ b/tests/phpunit/integration/api/compiler/beans-compiler/formatContent.php
@@ -57,7 +57,7 @@ class Tests_BeansCompiler_FormatContent extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test format_content() should return original content when the "type" is not
+	 * Test _Beans_Compiler::format_content() should return original content when the "type" is not
 	 * a style or script (per the configuration).
 	 */
 	public function test_should_return_original_content_when_type_not_style_or_script() {
@@ -72,7 +72,8 @@ class Tests_BeansCompiler_FormatContent extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test format_content() should return compiled CSS (not minified) from the Less combined fragments.
+	 * Test _Beans_Compiler::format_content() should return compiled CSS (not minified) from the Less combined
+	 * fragments.
 	 */
 	public function test_should_return_compiled_css() {
 		$compiler = new \_Beans_Compiler( array(
@@ -98,7 +99,7 @@ EOB;
 	}
 
 	/**
-	 * Test format_content() should return minified, compiled CSS from the Less combined fragments.
+	 * Test _Beans_Compiler::format_content() should return minified, compiled CSS from the Less combined fragments.
 	 */
 	public function test_should_return_minified_compiled_css() {
 		$compiler = new \_Beans_Compiler( array(
@@ -118,7 +119,7 @@ EOB;
 	}
 
 	/**
-	 * Test format_content() should return the original jQuery when site is not in development mode,
+	 * Test _Beans_Compiler::format_content() should return the original jQuery when site is not in development mode,
 	 * but "minify_js" is disabled.
 	 */
 	public function test_should_return_original_jquery_when_minify_js_disabled() {
@@ -136,7 +137,7 @@ EOB;
 	}
 
 	/**
-	 * Test format_content() should return the original jQuery when "minify_js" is enabled,
+	 * Test _Beans_Compiler::format_content() should return the original jQuery when "minify_js" is enabled,
 	 * but the site is in development mode.
 	 */
 	public function test_should_always_return_original_jquery_when_in_dev_mode() {
@@ -154,7 +155,7 @@ EOB;
 	}
 
 	/**
-	 * Test format_content() should return minified jQuery when "minify_js" is enabled
+	 * Test _Beans_Compiler::format_content() should return minified jQuery when "minify_js" is enabled
 	 * and the site is not in development mode.
 	 */
 	public function test_should_return_minified_jquery_when_not_in_dev_mode_and_minify_js_enabled() {
@@ -177,8 +178,8 @@ EOB;
 	}
 
 	/**
-	 * Test format_content() should return the original JavaScript when site is not in development mode,
-	 * but "minify_js" is disabled.
+	 * Test _Beans_Compiler::format_content() should return the original JavaScript when site is not in development
+	 * mode, but "minify_js" is disabled.
 	 */
 	public function test_should_return_original_js_when_minify_js_disabled() {
 		$compiler = new \_Beans_Compiler( array(
@@ -195,7 +196,7 @@ EOB;
 	}
 
 	/**
-	 * Test format_content() should return the original JavaScript when "minify_js" is enabled,
+	 * Test _Beans_Compiler::format_content() should return the original JavaScript when "minify_js" is enabled,
 	 * but the site is in development mode.
 	 */
 	public function test_should_always_return_original_js_when_in_dev_mode() {
@@ -213,7 +214,7 @@ EOB;
 	}
 
 	/**
-	 * Test format_content() should return minified JavaScript when "minify_js" is enabled
+	 * Test _Beans_Compiler::format_content() should return minified JavaScript when "minify_js" is enabled
 	 * and the site is not in development mode.
 	 */
 	public function test_should_return_minified_js_when_not_in_dev_mode_and_minify_js_enabled() {

--- a/tests/phpunit/integration/api/compiler/beans-compiler/getInternalContent.php
+++ b/tests/phpunit/integration/api/compiler/beans-compiler/getInternalContent.php
@@ -25,7 +25,7 @@ require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 class Tests_BeansCompiler_GetInternalContent extends Compiler_Test_Case {
 
 	/**
-	 * Test get_internal_content() should return false when fragment is empty.
+	 * Test _Beans_Compiler::get_internal_content() should return false when fragment is empty.
 	 */
 	public function test_should_return_false_when_fragment_is_empty() {
 		$compiler = new _Beans_Compiler( array() );
@@ -35,7 +35,7 @@ class Tests_BeansCompiler_GetInternalContent extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test get_internal_content() should return false when the file does not exist.
+	 * Test _Beans_Compiler::get_internal_content() should return false when the file does not exist.
 	 */
 	public function test_should_return_false_when_file_does_not_exist() {
 		// Set up the compiler.
@@ -50,7 +50,7 @@ class Tests_BeansCompiler_GetInternalContent extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test get_internal_content() should return a fragment's contents.
+	 * Test _Beans_Compiler::get_internal_content() should return a fragment's contents.
 	 */
 	public function test_should_return_fragment_contents() {
 		// Set up the compiler.

--- a/tests/phpunit/integration/api/compiler/beans-compiler/getRemoteContent.php
+++ b/tests/phpunit/integration/api/compiler/beans-compiler/getRemoteContent.php
@@ -24,7 +24,7 @@ require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 class Tests_BeansCompiler_GetRemoteContent extends Compiler_Test_Case {
 
 	/**
-	 * Test get_remote_content() should return false when fragment is empty.
+	 * Test _Beans_Compiler::get_remote_content() should return false when fragment is empty.
 	 */
 	public function test_should_return_false_when_fragment_is_empty() {
 		$compiler = new _Beans_Compiler( array() );
@@ -34,7 +34,8 @@ class Tests_BeansCompiler_GetRemoteContent extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test get_remote_content() should return empty string when the remote site or file does not exist.
+	 * Test _Beans_Compiler::get_remote_content() should return empty string when the remote site or file does not
+	 * exist.
 	 */
 	public function test_should_return_empty_string_when_remote_does_not_exist() {
 		$fragment = 'http://beans.local/invalid-file.js';
@@ -48,7 +49,7 @@ class Tests_BeansCompiler_GetRemoteContent extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test get_remote_content() should return the content when fragment is a relative url.
+	 * Test _Beans_Compiler::get_remote_content() should return the content when fragment is a relative url.
 	 */
 	public function test_should_return_content_when_fragment_is_relative_url() {
 		$fragment = '//fonts.googleapis.com/css?family=Lato';
@@ -67,7 +68,7 @@ class Tests_BeansCompiler_GetRemoteContent extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test get_remote_content() should return the content when fragment is an http URL.
+	 * Test _Beans_Compiler::get_remote_content() should return the content when fragment is an http URL.
 	 */
 	public function test_should_return_content_when_fragment_is_http() {
 		$fragment = 'http://fonts.googleapis.com/css?family=Roboto';
@@ -86,7 +87,7 @@ class Tests_BeansCompiler_GetRemoteContent extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test get_remote_content() should return the content when fragment is an https URL.
+	 * Test _Beans_Compiler::get_remote_content() should return the content when fragment is an https URL.
 	 */
 	public function test_should_return_content_when_fragment_is_https() {
 		$fragment = 'https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css';

--- a/tests/phpunit/integration/api/compiler/beans-compiler/replaceCssUrl.php
+++ b/tests/phpunit/integration/api/compiler/beans-compiler/replaceCssUrl.php
@@ -24,7 +24,7 @@ require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 class Tests_BeansCompiler_ReplaceCssUrl extends Compiler_Test_Case {
 
 	/**
-	 * Test replace_css_url() should return original content when there is no url source in the CSS.
+	 * Test _Beans_Compiler::replace_css_url() should return original content when there is no url source in the CSS.
 	 */
 	public function test_should_return_original_content_when_no_url() {
 		$compiler = new _Beans_Compiler( array() );
@@ -46,7 +46,7 @@ EOB;
 	}
 
 	/**
-	 * Test replace_css_url() should return original content when it has a valid URI.
+	 * Test _Beans_Compiler::replace_css_url() should return original content when it has a valid URI.
 	 */
 	public function test_should_return_original_content_when_valid_uri() {
 		$compiler = new _Beans_Compiler( array() );
@@ -64,7 +64,7 @@ EOB;
 	}
 
 	/**
-	 * Test replace_css_url() should convert the relative URL when it does not have ../.
+	 * Test _Beans_Compiler::replace_css_url() should convert the relative URL when it does not have ../.
 	 */
 	public function test_should_convert_relative_url_when_no_up_levels() {
 		$compiler = new _Beans_Compiler( array() );
@@ -88,7 +88,7 @@ EOB;
 	}
 
 	/**
-	 * Test replace_css_url() should convert the relative URL.
+	 * Test _Beans_Compiler::replace_css_url() should convert the relative URL.
 	 */
 	public function test_should_convert_relative_url() {
 		$compiler = new _Beans_Compiler( array() );
@@ -140,7 +140,7 @@ EOB;
 	}
 
 	/**
-	 * Test replace_css_url() should convert a deeper relative URL.
+	 * Test _Beans_Compiler::replace_css_url() should convert a deeper relative URL.
 	 */
 	public function test_should_convert_deeper_relative_url() {
 		$compiler = new _Beans_Compiler( array() );

--- a/tests/phpunit/integration/api/compiler/beans-compiler/runCompiler.php
+++ b/tests/phpunit/integration/api/compiler/beans-compiler/runCompiler.php
@@ -75,7 +75,7 @@ class Tests_BeansCompiler_RunCompiler extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test cache_file() should enqueue the existing cached file when no modifications (no fragments
+	 * Test _Beans_Compiler::cache_file() should enqueue the existing cached file when no modifications (no fragments
 	 * have changed to warrant re-compiling the file).
 	 */
 	public function test_should_enqueue_existing_cached_file_when_no_modifications() {
@@ -116,8 +116,8 @@ class Tests_BeansCompiler_RunCompiler extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test cache_file() should recompile when a fragment(s) changes.  When this happens, the existing cached file
-	 * is removed and the new file is stored in the filesystem.
+	 * Test _Beans_Compiler::cache_file() should recompile when a fragment(s) changes.  When this happens, the existing
+	 * cached file is removed and the new file is stored in the filesystem.
 	 */
 	public function test_should_recompile_when_fragments_change() {
 		$fragment = vfsStream::url( 'compiled/fixtures/jquery.test.js' );
@@ -190,7 +190,8 @@ class Tests_BeansCompiler_RunCompiler extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test cache_file() should compile jQuery, saving it to the virtual filesystem and enqueuing it in WordPress.
+	 * Test _Beans_Compiler::cache_file() should compile jQuery, saving it to the virtual filesystem and enqueuing it
+	 * in WordPress.
 	 */
 	public function test_should_compile_save_and_enqueue_jquery() {
 		$fragment = vfsStream::url( 'compiled/fixtures/jquery.test.js' );
@@ -223,7 +224,8 @@ class Tests_BeansCompiler_RunCompiler extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test cache_file() should compile JavaScript, saving it to the virtual filesystem and enqueuing it in WordPress.
+	 * Test _Beans_Compiler::cache_file() should compile JavaScript, saving it to the virtual filesystem and enqueuing
+	 * it in WordPress.
 	 */
 	public function test_should_compile_save_and_enqueue_js() {
 		$fragment = vfsStream::url( 'compiled/fixtures/my-game-clock.js' );
@@ -255,7 +257,8 @@ class Tests_BeansCompiler_RunCompiler extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test cache_file() should compile CSS, saving it to the virtual filesystem and enqueuing it in WordPress.
+	 * Test _Beans_Compiler::cache_file() should compile CSS, saving it to the virtual filesystem and enqueuing it in
+	 * WordPress.
 	 */
 	public function test_should_compile_save_and_enqueue_css() {
 		$fragment = vfsStream::url( 'compiled/fixtures/style.css' );
@@ -287,7 +290,8 @@ class Tests_BeansCompiler_RunCompiler extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test cache_file() should compile Less, saving it to the virtual filesystem and enqueuing it in WordPress.
+	 * Test _Beans_Compiler::cache_file() should compile Less, saving it to the virtual filesystem and enqueuing it in
+	 * WordPress.
 	 */
 	public function test_should_compile_save_and_enqueue_less() {
 		$config   = array(

--- a/tests/phpunit/integration/api/compiler/beans-compiler/setFilename.php
+++ b/tests/phpunit/integration/api/compiler/beans-compiler/setFilename.php
@@ -24,7 +24,8 @@ require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 class Tests_BeansCompiler_SetFilename extends Compiler_Test_Case {
 
 	/**
-	 * Test set_filename() should return the hash created with the modification time from each of the fragments.
+	 * Test _Beans_Compiler::set_filename() should return the hash created with the modification time from each of the
+	 * fragments.
 	 */
 	public function test_should_return_hash_created_with_fragments_filemtime() {
 		$fragment = vfsStream::url( 'compiled/fixtures/jquery.test.js' );
@@ -51,7 +52,7 @@ class Tests_BeansCompiler_SetFilename extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test set_filename() should exclude external fragments.
+	 * Test _Beans_Compiler::set_filename() should exclude external fragments.
 	 */
 	public function test_should_exclude_external_fragments() {
 		$fragment = vfsStream::url( 'compiled/fixtures/my-game-clock.js' );
@@ -86,7 +87,7 @@ class Tests_BeansCompiler_SetFilename extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test set_filename() should remove the old compiled file.
+	 * Test _Beans_Compiler::set_filename() should remove the old compiled file.
 	 */
 	public function test_should_remove_old_file() {
 		$fragment = vfsStream::url( 'compiled/fixtures/jquery.test.js' );

--- a/tests/phpunit/integration/api/compiler/includes/class-compiler-test-case.php
+++ b/tests/phpunit/integration/api/compiler/includes/class-compiler-test-case.php
@@ -9,6 +9,7 @@
 
 namespace Beans\Framework\Tests\Integration\API\Compiler\Includes;
 
+use _Beans_Compiler;
 use WP_UnitTestCase;
 use Mockery;
 use org\bovigo\vfs\vfsStream;
@@ -134,7 +135,7 @@ abstract class Compiler_Test_Case extends WP_UnitTestCase {
 	 *
 	 * @since 1.5.0
 	 *
-	 * @param \_Beans_Compiler $compiler The Compiler instance.
+	 * @param _Beans_Compiler $compiler The Compiler instance.
 	 * @param mixed            $fragment The given value to set.
 	 *
 	 * @return void
@@ -153,10 +154,10 @@ abstract class Compiler_Test_Case extends WP_UnitTestCase {
 	 *
 	 * @param array $config Compiler's configuration.
 	 *
-	 * @return \_Beans_Compiler
+	 * @return _Beans_Compiler
 	 */
 	protected function create_compiler( $config ) {
-		$compiler = new \_Beans_Compiler( $config );
+		$compiler = new _Beans_Compiler( $config );
 
 		$dir = ( new \ReflectionClass( $compiler ) )->getProperty( 'dir' );
 		$dir->setAccessible( true );
@@ -174,7 +175,7 @@ abstract class Compiler_Test_Case extends WP_UnitTestCase {
 	 *
 	 * @since 1.5.0
 	 *
-	 * @param \_Beans_Compiler $compiler  Instance of the compiler.
+	 * @param _Beans_Compiler $compiler  Instance of the compiler.
 	 * @param array            $config    The compiler's configuration.
 	 * @param int              $filemtime Optional. The fragment's filemtime. Default is null.
 	 *

--- a/tests/phpunit/integration/api/compiler/includes/class-compiler-test-case.php
+++ b/tests/phpunit/integration/api/compiler/includes/class-compiler-test-case.php
@@ -136,9 +136,10 @@ abstract class Compiler_Test_Case extends WP_UnitTestCase {
 	 * @since 1.5.0
 	 *
 	 * @param _Beans_Compiler $compiler The Compiler instance.
-	 * @param mixed            $fragment The given value to set.
+	 * @param mixed           $fragment The given value to set.
 	 *
 	 * @return void
+	 * @throws \ReflectionException Throws reflection error.
 	 */
 	protected function set_current_fragment( $compiler, $fragment ) {
 		$current_fragment = ( new \ReflectionClass( $compiler ) )->getProperty( 'current_fragment' );
@@ -155,6 +156,7 @@ abstract class Compiler_Test_Case extends WP_UnitTestCase {
 	 * @param array $config Compiler's configuration.
 	 *
 	 * @return _Beans_Compiler
+	 * @throws \ReflectionException Throws reflection error.
 	 */
 	protected function create_compiler( $config ) {
 		$compiler = new _Beans_Compiler( $config );
@@ -167,6 +169,7 @@ abstract class Compiler_Test_Case extends WP_UnitTestCase {
 		}
 
 		$dir->setAccessible( false );
+
 		return $compiler;
 	}
 
@@ -176,8 +179,8 @@ abstract class Compiler_Test_Case extends WP_UnitTestCase {
 	 * @since 1.5.0
 	 *
 	 * @param _Beans_Compiler $compiler  Instance of the compiler.
-	 * @param array            $config    The compiler's configuration.
-	 * @param int              $filemtime Optional. The fragment's filemtime. Default is null.
+	 * @param array           $config    The compiler's configuration.
+	 * @param int             $filemtime Optional. The fragment's filemtime. Default is null.
 	 *
 	 * @return string
 	 */
@@ -261,6 +264,7 @@ abstract class Compiler_Test_Case extends WP_UnitTestCase {
 var clickHandler=function(event){event.preventDefault();}
 $(document).ready(function(){init();});})(jQuery);
 EOB;
+
 		return str_replace( '/$', '$', $compiled_content );
 	}
 

--- a/tests/phpunit/unit/api/compiler/beans-compiler/addContentMediaQuery.php
+++ b/tests/phpunit/unit/api/compiler/beans-compiler/addContentMediaQuery.php
@@ -24,7 +24,7 @@ require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 class Tests_BeansCompiler_AddContentMediaQuery extends Compiler_Test_Case {
 
 	/**
-	 * Test add_content_media_query() should return original content when current fragment is callable.
+	 * Test _Beans_Compiler::add_content_media_query() should return original content when current fragment is callable.
 	 */
 	public function test_should_return_content_when_fragment_is_callable() {
 		Monkey\Functions\expect( 'wp_parse_args' )->never();
@@ -43,7 +43,7 @@ EOB;
 	}
 
 	/**
-	 * Test add_content_media_query() should return original content when there are no query args.
+	 * Test _Beans_Compiler::add_content_media_query() should return original content when there are no query args.
 	 */
 	public function test_should_return_content_when_no_query_args() {
 		Monkey\Functions\expect( 'wp_parse_args' )->never();
@@ -65,8 +65,8 @@ EOB;
 	}
 
 	/**
-	 * Test add_content_media_query() should return original content when the 'beans_compiler_media_query'
-	 * query arg is not present in the current fragment.
+	 * Test _Beans_Compiler::add_content_media_query() should return original content when the
+	 * 'beans_compiler_media_query' query arg is not present in the current fragment.
 	 */
 	public function test_should_return_content_when_no_media_query() {
 		Monkey\Functions\expect( 'wp_parse_args' )->never();
@@ -88,7 +88,7 @@ EOB;
 	}
 
 	/**
-	 * Test add_content_media_query() should wrap the content in the specified media query.
+	 * Test _Beans_Compiler::add_content_media_query() should wrap the content in the specified media query.
 	 */
 	public function test_should_wrap_content_in_media_query() {
 		$compiler      = $this->create_compiler( array() );

--- a/tests/phpunit/unit/api/compiler/beans-compiler/cacheFile.php
+++ b/tests/phpunit/unit/api/compiler/beans-compiler/cacheFile.php
@@ -25,7 +25,7 @@ require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 class Tests_BeansCompiler_CacheFile extends Compiler_Test_Case {
 
 	/**
-	 * Test cache_file() should not create the file when the filename is empty.
+	 * Test _Beans_Compiler::cache_file() should not create the file when the filename is empty.
 	 */
 	public function test_should_not_create_the_file_when_filename_empty() {
 		$compiler = $this->create_compiler( array(
@@ -45,7 +45,7 @@ class Tests_BeansCompiler_CacheFile extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test cache_file() should create the compiled jQuery file.
+	 * Test _Beans_Compiler::cache_file() should create the compiled jQuery file.
 	 */
 	public function test_should_create_compiled_jquery_file() {
 		$compiler = $this->create_compiler( array(
@@ -74,7 +74,7 @@ class Tests_BeansCompiler_CacheFile extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test cache_file() should create the compiled JavaScript file.
+	 * Test _Beans_Compiler::cache_file() should create the compiled JavaScript file.
 	 */
 	public function test_should_create_compiled_javascript_file() {
 		$compiler = $this->create_compiler( array(
@@ -102,7 +102,7 @@ class Tests_BeansCompiler_CacheFile extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test cache_file() should create the compiled CSS file.
+	 * Test _Beans_Compiler::cache_file() should create the compiled CSS file.
 	 */
 	public function test_should_create_compiled_css_file() {
 		$compiler = $this->create_compiler( array(
@@ -129,7 +129,7 @@ class Tests_BeansCompiler_CacheFile extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test cache_file() should create the compiled LESS file.
+	 * Test _Beans_Compiler::cache_file() should create the compiled LESS file.
 	 */
 	public function test_should_create_compiled_less_file() {
 		$compiler = $this->create_compiler( array(

--- a/tests/phpunit/unit/api/compiler/beans-compiler/cacheFileExist.php
+++ b/tests/phpunit/unit/api/compiler/beans-compiler/cacheFileExist.php
@@ -24,7 +24,7 @@ require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 class Tests_BeansCompiler_CacheFileExist extends Compiler_Test_Case {
 
 	/**
-	 * Test cache_file_exist() should return false when the filename has not been generated.
+	 * Test _Beans_Compiler::cache_file_exist() should return false when the filename has not been generated.
 	 */
 	public function test_should_return_false_when_filename_not_generated() {
 		$fragment = vfsStream::url( 'compiled/fixtures/my-game-clock.js' );
@@ -39,7 +39,7 @@ class Tests_BeansCompiler_CacheFileExist extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test cache_file_exist() should return false when the cached file does not exist.
+	 * Test _Beans_Compiler::cache_file_exist() should return false when the cached file does not exist.
 	 */
 	public function test_should_return_false_when_file_does_not_exist() {
 		$fragment = vfsStream::url( 'compiled/fixtures/my-game-clock.js' );
@@ -59,7 +59,7 @@ class Tests_BeansCompiler_CacheFileExist extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test cache_file_exist() should return true when the cached file does exist.
+	 * Test _Beans_Compiler::cache_file_exist() should return true when the cached file does exist.
 	 */
 	public function test_should_return_true_when_file_exists() {
 		$fragment = vfsStream::url( 'compiled/fixtures/my-game-clock.js' );

--- a/tests/phpunit/unit/api/compiler/beans-compiler/combineFragments.php
+++ b/tests/phpunit/unit/api/compiler/beans-compiler/combineFragments.php
@@ -67,7 +67,7 @@ class Tests_BeansCompiler_CombineFragments extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test combine_fragments() should return an empty string when there are no fragments to combine.
+	 * Test _Beans_Compiler::combine_fragments() should return an empty string when there are no fragments to combine.
 	 */
 	public function test_should_return_empty_string_when_no_fragments() {
 		$compiler = $this->create_compiler( array() );
@@ -78,7 +78,7 @@ class Tests_BeansCompiler_CombineFragments extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test combine_fragments() should return an empty string when the fragment does not exist.
+	 * Test _Beans_Compiler::combine_fragments() should return an empty string when the fragment does not exist.
 	 */
 	public function test_should_return_empty_string_when_fragment_does_not_exist() {
 		$fragment = vfsStream::url( 'compiled/fixtures/' ) . 'invalid-file.js';
@@ -102,7 +102,7 @@ class Tests_BeansCompiler_CombineFragments extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test combine_fragments() should compile the LESS fragments and return the compiled CSS.
+	 * Test _Beans_Compiler::combine_fragments() should compile the LESS fragments and return the compiled CSS.
 	 */
 	public function test_should_compile_less_and_return_css() {
 		$compiler = $this->create_compiler( array(
@@ -135,7 +135,7 @@ EOB;
 	}
 
 	/**
-	 * Test combine_fragments() should return minified, compiled CSS from the Less combined fragments.
+	 * Test _Beans_Compiler::combine_fragments() should return minified, compiled CSS from the Less combined fragments.
 	 */
 	public function test_should_return_minified_compiled_css() {
 		$compiler = $this->create_compiler( array(
@@ -160,7 +160,7 @@ EOB;
 	}
 
 	/**
-	 * Test combine_fragments() should return the original jQuery when site is not in development mode,
+	 * Test _Beans_Compiler::combine_fragments() should return the original jQuery when site is not in development mode,
 	 * but "minify_js" is disabled.
 	 */
 	public function test_should_return_original_jquery_when_minify_js_disabled() {
@@ -186,7 +186,7 @@ EOB;
 	}
 
 	/**
-	 * Test combine_fragments() should return the original jQuery when "minify_js" is enabled,
+	 * Test _Beans_Compiler::combine_fragments() should return the original jQuery when "minify_js" is enabled,
 	 * but the site is in development mode.
 	 */
 	public function test_should_always_return_original_jquery_when_in_dev_mode() {
@@ -212,7 +212,7 @@ EOB;
 	}
 
 	/**
-	 * Test combine_fragments() should return minified jQuery.
+	 * Test _Beans_Compiler::combine_fragments() should return minified jQuery.
 	 */
 	public function test_should_return_minified_jquery() {
 		$compiler = $this->create_compiler( array(
@@ -237,8 +237,8 @@ EOB;
 	}
 
 	/**
-	 * Test combine_fragments() should return the original JavaScript when site is not in development mode,
-	 * but "minify_js" is disabled.
+	 * Test _Beans_Compiler::combine_fragments() should return the original JavaScript when site is not in development
+	 * mode, but "minify_js" is disabled.
 	 */
 	public function test_should_return_original_js_when_minify_js_disabled() {
 		$compiler = $this->create_compiler( array(
@@ -262,7 +262,7 @@ EOB;
 	}
 
 	/**
-	 * Test combine_fragments() should return the original JavaScript when "minify_js" is enabled,
+	 * Test _Beans_Compiler::combine_fragments() should return the original JavaScript when "minify_js" is enabled,
 	 * but the site is in development mode.
 	 */
 	public function test_should_always_return_original_js_when_in_dev_mode() {
@@ -287,7 +287,7 @@ EOB;
 	}
 
 	/**
-	 * Test combine_fragments() should return minified JavaScript.
+	 * Test _Beans_Compiler::combine_fragments() should return minified JavaScript.
 	 */
 	public function test_should_return_minified_javascript() {
 		$compiler = $this->create_compiler( array(

--- a/tests/phpunit/unit/api/compiler/beans-compiler/fileystem.php
+++ b/tests/phpunit/unit/api/compiler/beans-compiler/fileystem.php
@@ -25,7 +25,8 @@ require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 class Tests_BeansCompiler_Filesystem extends Compiler_Test_Case {
 
 	/**
-	 * Test filesystem() should return true when the WP Filesystem is initialized to WP_Filesystem_Direct.
+	 * Test _Beans_Compiler::filesystem() should return true when the WP Filesystem is initialized to
+	 * WP_Filesystem_Direct.
 	 */
 	public function test_should_return_true_when_wp_filesystem_is_init() {
 		// Initialize the wp_filesystem global variable.

--- a/tests/phpunit/unit/api/compiler/beans-compiler/formatContent.php
+++ b/tests/phpunit/unit/api/compiler/beans-compiler/formatContent.php
@@ -58,7 +58,7 @@ class Tests_BeansCompiler_FormatContent extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test format_content() should return original content when the "type" is not
+	 * Test _Beans_Compiler::format_content() should return original content when the "type" is not
 	 * a style or script (per the configuration).
 	 */
 	public function test_should_return_original_content_when_type_not_style_or_script() {
@@ -75,7 +75,8 @@ class Tests_BeansCompiler_FormatContent extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test format_content() should return compiled CSS (not minified) from the Less combined fragments.
+	 * Test _Beans_Compiler::format_content() should return compiled CSS (not minified) from the Less combined
+	 * fragments.
 	 */
 	public function test_should_return_compiled_css() {
 		$compiler = $this->create_compiler( array(
@@ -102,7 +103,7 @@ EOB;
 	}
 
 	/**
-	 * Test format_content() should return minified, compiled CSS from the Less combined fragments.
+	 * Test _Beans_Compiler::format_content() should return minified, compiled CSS from the Less combined fragments.
 	 */
 	public function test_should_return_minified_compiled_css() {
 		$compiler = $this->create_compiler( array(
@@ -133,7 +134,7 @@ EOB;
 	}
 
 	/**
-	 * Test format_content() should return the original jQuery when site is not in development mode,
+	 * Test _Beans_Compiler::format_content() should return the original jQuery when site is not in development mode,
 	 * but "minify_js" is disabled.
 	 */
 	public function test_should_return_original_jquery_when_minify_js_disabled() {
@@ -152,7 +153,7 @@ EOB;
 	}
 
 	/**
-	 * Test format_content() should return the original jQuery when "minify_js" is enabled,
+	 * Test _Beans_Compiler::format_content() should return the original jQuery when "minify_js" is enabled,
 	 * but the site is in development mode.
 	 */
 	public function test_should_always_return_original_jquery_when_in_dev_mode() {
@@ -171,7 +172,7 @@ EOB;
 	}
 
 	/**
-	 * Test format_content() should return minified jQuery when "minify_js" is enabled
+	 * Test _Beans_Compiler::format_content() should return minified jQuery when "minify_js" is enabled
 	 * and the site is not in development mode.
 	 */
 	public function test_should_return_minified_jquery_when_not_in_dev_mode_and_minify_js_enabled() {
@@ -198,8 +199,8 @@ EOB;
 	}
 
 	/**
-	 * Test format_content() should return the original JavaScript when site is not in development mode,
-	 * but "minify_js" is disabled.
+	 * Test _Beans_Compiler::format_content() should return the original JavaScript when site is not in development
+	 * mode, but "minify_js" is disabled.
 	 */
 	public function test_should_return_original_js_when_minify_js_disabled() {
 		$compiler = $this->create_compiler( array(
@@ -217,7 +218,7 @@ EOB;
 	}
 
 	/**
-	 * Test format_content() should return the original JavaScript when "minify_js" is enabled,
+	 * Test _Beans_Compiler::format_content() should return the original JavaScript when "minify_js" is enabled,
 	 * but the site is in development mode.
 	 */
 	public function test_should_always_return_original_js_when_in_dev_mode() {
@@ -236,7 +237,7 @@ EOB;
 	}
 
 	/**
-	 * Test format_content() should return minified JavaScript when "minify_js" is enabled
+	 * Test _Beans_Compiler::format_content() should return minified JavaScript when "minify_js" is enabled
 	 * and the site is not in development mode.
 	 */
 	public function test_should_return_minified_js_when_not_in_dev_mode_and_minify_js_enabled() {

--- a/tests/phpunit/unit/api/compiler/beans-compiler/get.php
+++ b/tests/phpunit/unit/api/compiler/beans-compiler/get.php
@@ -24,7 +24,7 @@ require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 class Tests_BeansCompiler_Get extends Compiler_Test_Case {
 
 	/**
-	 * Test should fix the configuration's dependency key.
+	 * Test _Beans_Compiler::_get() should fix the configuration's dependency key.
 	 */
 	public function test_should_fix_configuration_dependency_key() {
 		$config = array(
@@ -42,7 +42,7 @@ class Tests_BeansCompiler_Get extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test should return the configuration.
+	 * Test _Beans_Compiler::_get() should return the configuration.
 	 */
 	public function test_should_return_configuration() {
 		$compiler = $this->create_compiler( array(
@@ -87,7 +87,7 @@ class Tests_BeansCompiler_Get extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test should return the absolute path to the compiled files directory.
+	 * Test _Beans_Compiler::_get() should return the absolute path to the compiled files directory.
 	 */
 	public function test_should_return_absolute_path_to_compiled_files_dir() {
 		$config = array(
@@ -103,7 +103,7 @@ class Tests_BeansCompiler_Get extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test should return URL to the compiled files directory.
+	 * Test _Beans_Compiler::_get() should return URL to the compiled files directory.
 	 */
 	public function test_should_return_url_to_compiled_files_dir() {
 		$config = array(

--- a/tests/phpunit/unit/api/compiler/beans-compiler/getExtension.php
+++ b/tests/phpunit/unit/api/compiler/beans-compiler/getExtension.php
@@ -23,7 +23,7 @@ require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 class Tests_BeansCompiler_GetExtension extends Compiler_Test_Case {
 
 	/**
-	 * Test get_extension() should return "css" when the type is "style".
+	 * Test _Beans_Compiler::get_extension() should return "css" when the type is "style".
 	 */
 	public function test_should_return_css_when_style() {
 		$compiler = $this->create_compiler( array( 'type' => 'style' ) );
@@ -32,7 +32,7 @@ class Tests_BeansCompiler_GetExtension extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test get_extension() should return "js" when the type is "script".
+	 * Test _Beans_Compiler::get_extension() should return "js" when the type is "script".
 	 */
 	public function test_should_return_js_when_script() {
 		$compiler = $this->create_compiler( array( 'type' => 'script' ) );
@@ -41,7 +41,7 @@ class Tests_BeansCompiler_GetExtension extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test get_extension() should return null when the type is invalid.
+	 * Test _Beans_Compiler::get_extension() should return null when the type is invalid.
 	 */
 	public function test_should_return_null_when_invalid_type() {
 		$compiler = $this->create_compiler( array( 'type' => 'invalid' ) );

--- a/tests/phpunit/unit/api/compiler/beans-compiler/getFunctionContent.php
+++ b/tests/phpunit/unit/api/compiler/beans-compiler/getFunctionContent.php
@@ -25,7 +25,7 @@ require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 class Tests_BeansCompiler_GetFunctionContent extends Compiler_Test_Case {
 
 	/**
-	 * Test get_function_content() should return false when the given fragment is not callable.
+	 * Test _Beans_Compiler::get_function_content() should return false when the given fragment is not callable.
 	 */
 	public function test_should_return_false_when_fragment_not_callable() {
 		$compiler = $this->create_compiler();
@@ -41,7 +41,7 @@ class Tests_BeansCompiler_GetFunctionContent extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test get_function_content() should return content from a function.
+	 * Test _Beans_Compiler::get_function_content() should return content from a function.
 	 */
 	public function test_should_return_content_from_function() {
 		$fragment = 'beans_test_get_function_content_callback';
@@ -56,7 +56,7 @@ class Tests_BeansCompiler_GetFunctionContent extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test get_function_content() should return content from an object's method.
+	 * Test _Beans_Compiler::get_function_content() should return content from an object's method.
 	 */
 	public function test_should_return_content_from_method() {
 		$compiler = $this->create_compiler();

--- a/tests/phpunit/unit/api/compiler/beans-compiler/getInternalContent.php
+++ b/tests/phpunit/unit/api/compiler/beans-compiler/getInternalContent.php
@@ -34,7 +34,7 @@ class Tests_BeansCompiler_GetInternalContent extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test get_internal_content() should return false when fragment is empty.
+	 * Test _Beans_Compiler::get_internal_content() should return false when fragment is empty.
 	 */
 	public function test_should_return_false_when_fragment_is_empty() {
 		$compiler = $this->create_compiler();
@@ -44,7 +44,7 @@ class Tests_BeansCompiler_GetInternalContent extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test get_internal_content() should return false when the file does not exist.
+	 * Test _Beans_Compiler::get_internal_content() should return false when the file does not exist.
 	 */
 	public function test_should_return_false_when_file_does_not_exist() {
 		$compiler = $this->create_compiler();
@@ -55,7 +55,7 @@ class Tests_BeansCompiler_GetInternalContent extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test get_internal_content() should return a fragment's contents.
+	 * Test _Beans_Compiler::get_internal_content() should return a fragment's contents.
 	 */
 	public function test_should_return_fragment_contents() {
 		$fragment = vfsStream::url( 'compiled/fixtures/test.less' );

--- a/tests/phpunit/unit/api/compiler/beans-compiler/getRemoteContent.php
+++ b/tests/phpunit/unit/api/compiler/beans-compiler/getRemoteContent.php
@@ -24,7 +24,7 @@ require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 class Tests_BeansCompiler_GetRemoteContent extends Compiler_Test_Case {
 
 	/**
-	 * Test get_remote_content() should return false when the fragment is empty.
+	 * Test _Beans_Compiler::get_remote_content() should return false when the fragment is empty.
 	 */
 	public function test_should_return_false_when_fragment_is_empty() {
 		$compiler = $this->create_compiler( array() );
@@ -40,7 +40,8 @@ class Tests_BeansCompiler_GetRemoteContent extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test get_remote_content() should return an empty string when the remote site or file does not exist on http.
+	 * Test _Beans_Compiler::get_remote_content() should return an empty string when the remote site or file does not
+	 * exist on http.
 	 */
 	public function test_should_return_empty_string_when_remote_does_not_exist_on_http() {
 		// Set up the compiler.
@@ -57,7 +58,8 @@ class Tests_BeansCompiler_GetRemoteContent extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test get_remote_content() should return an empty string when the remote site or file does not exist on https.
+	 * Test _Beans_Compiler::get_remote_content() should return an empty string when the remote site or file does not
+	 * exist on https.
 	 */
 	public function test_should_return_empty_string_when_remote_does_not_exist_on_https() {
 		// Set up the compiler.
@@ -74,7 +76,8 @@ class Tests_BeansCompiler_GetRemoteContent extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test get_remote_content() should retry and then return false when the remote file does not exist.
+	 * Test _Beans_Compiler::get_remote_content() should retry and then return false when the remote file does not
+	 * exist.
 	 */
 	public function test_should_retry_and_return_false_when_remote_file_does_not_exist() {
 		// Set up the compiler.
@@ -107,7 +110,7 @@ class Tests_BeansCompiler_GetRemoteContent extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test get_remote_content() should return the content when the fragment has a relative url.
+	 * Test _Beans_Compiler::get_remote_content() should return the content when the fragment has a relative url.
 	 */
 	public function test_should_return_content_when_relative_url() {
 		// Set up the compiler.
@@ -143,7 +146,7 @@ class Tests_BeansCompiler_GetRemoteContent extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test get_remote_content() should return the content when the fragment has an http URL.
+	 * Test _Beans_Compiler::get_remote_content() should return the content when the fragment has an http URL.
 	 */
 	public function test_should_return_content_when_http() {
 		// Set up the compiler.
@@ -179,7 +182,7 @@ class Tests_BeansCompiler_GetRemoteContent extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test get_remote_content() should return the content when the fragment has an https URL.
+	 * Test _Beans_Compiler::get_remote_content() should return the content when the fragment has an https URL.
 	 */
 	public function test_should_return_content_when_https() {
 		// Set up the compiler.

--- a/tests/phpunit/unit/api/compiler/beans-compiler/replaceCssUrl.php
+++ b/tests/phpunit/unit/api/compiler/beans-compiler/replaceCssUrl.php
@@ -24,7 +24,7 @@ require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 class Tests_BeansCompiler_ReplaceCssUrl extends Compiler_Test_Case {
 
 	/**
-	 * Test replace_css_url() should return original content when there is no url source in the CSS.
+	 * Test _Beans_Compiler::replace_css_url() should return original content when there is no url source in the CSS.
 	 */
 	public function test_should_return_original_content_when_no_url() {
 		$compiler = $this->create_compiler();
@@ -46,7 +46,7 @@ EOB;
 	}
 
 	/**
-	 * Test replace_css_url() should return original content when the CSS source has a valid URI.
+	 * Test _Beans_Compiler::replace_css_url() should return original content when the CSS source has a valid URI.
 	 */
 	public function test_should_return_original_content_when_valid_uri() {
 		$compiler = $this->create_compiler();
@@ -64,7 +64,7 @@ EOB;
 	}
 
 	/**
-	 * Test replace_css_url() should convert the relative URL when it does not have ../.
+	 * Test _Beans_Compiler::replace_css_url() should convert the relative URL when it does not have ../.
 	 */
 	public function test_should_convert_relative_url_when_no_up_levels() {
 		$compiler = $this->create_compiler();
@@ -90,7 +90,7 @@ EOB;
 	}
 
 	/**
-	 * Test replace_css_url() should convert the relative URL.
+	 * Test _Beans_Compiler::replace_css_url() should convert the relative URL.
 	 */
 	public function test_should_convert_relative_url() {
 		$compiler = $this->create_compiler();
@@ -144,7 +144,7 @@ EOB;
 	}
 
 	/**
-	 * Test replace_css_url() should convert a deeper relative URL.
+	 * Test _Beans_Compiler::replace_css_url() should convert a deeper relative URL.
 	 */
 	public function test_should_convert_deeper_relative_url() {
 		$compiler = $this->create_compiler();

--- a/tests/phpunit/unit/api/compiler/beans-compiler/runCompiler.php
+++ b/tests/phpunit/unit/api/compiler/beans-compiler/runCompiler.php
@@ -67,7 +67,7 @@ class Tests_BeansCompiler_RunCompiler extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test cache_file() should enqueue the existing cached file when no modifications (no fragments
+	 * Test _Beans_Compiler::cache_file() should enqueue the existing cached file when no modifications (no fragments
 	 * have changed to warrant re-compiling the file).
 	 */
 	public function test_should_enqueue_existing_cached_file_when_no_modifications() {
@@ -121,8 +121,8 @@ class Tests_BeansCompiler_RunCompiler extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test cache_file() should recompile when a fragment(s) changes.  When this happens, the existing cached file
-	 * is removed and the new file is stored in the filesystem.
+	 * Test _Beans_Compiler::cache_file() should recompile when a fragment(s) changes.  When this happens, the existing
+	 * cached file is removed and the new file is stored in the filesystem.
 	 */
 	public function test_should_recompile_when_fragments_change() {
 		$fragment = vfsStream::url( 'compiled/fixtures/jquery.test.js' );
@@ -197,7 +197,8 @@ class Tests_BeansCompiler_RunCompiler extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test cache_file() should compile jQuery, saving it to the virtual filesystem and enqueuing it in WordPress.
+	 * Test _Beans_Compiler::cache_file() should compile jQuery, saving it to the virtual filesystem and enqueuing it
+	 * in WordPress.
 	 */
 	public function test_should_compile_save_and_enqueue_jquery() {
 		$fragment = vfsStream::url( 'compiled/fixtures/jquery.test.js' );
@@ -226,7 +227,8 @@ class Tests_BeansCompiler_RunCompiler extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test cache_file() should compile JavaScript, saving it to the virtual filesystem and enqueuing it in WordPress.
+	 * Test _Beans_Compiler::cache_file() should compile JavaScript, saving it to the virtual filesystem and enqueuing
+	 * it in WordPress.
 	 */
 	public function test_should_compile_save_and_enqueue_js() {
 		$fragment = vfsStream::url( 'compiled/fixtures/my-game-clock.js' );
@@ -255,7 +257,8 @@ class Tests_BeansCompiler_RunCompiler extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test cache_file() should compile CSS, saving it to the virtual filesystem and enqueuing it in WordPress.
+	 * Test _Beans_Compiler::cache_file() should compile CSS, saving it to the virtual filesystem and enqueuing it in
+	 * WordPress.
 	 */
 	public function test_should_compile_save_and_enqueue_css() {
 		$fragment = vfsStream::url( 'compiled/fixtures/style.css' );
@@ -284,7 +287,8 @@ class Tests_BeansCompiler_RunCompiler extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test cache_file() should compile Less, saving it to the virtual filesystem and enqueuing it in WordPress.
+	 * Test _Beans_Compiler::cache_file() should compile Less, saving it to the virtual filesystem and enqueuing it in
+	 * WordPress.
 	 */
 	public function test_should_compile_save_and_enqueue_less() {
 		$config   = array(

--- a/tests/phpunit/unit/api/compiler/beans-compiler/setFilename.php
+++ b/tests/phpunit/unit/api/compiler/beans-compiler/setFilename.php
@@ -24,7 +24,8 @@ require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 class Tests_BeansCompiler_SetFilename extends Compiler_Test_Case {
 
 	/**
-	 * Test set_filename() should return the hash created with the modification time from each of the fragments.
+	 * Test _Beans_Compiler::set_filename() should return the hash created with the modification time from each of the
+	 * fragments.
 	 */
 	public function test_should_return_hash_created_with_fragments_filemtime() {
 		$fragment = vfsStream::url( 'compiled/fixtures/jquery.test.js' );
@@ -49,7 +50,7 @@ class Tests_BeansCompiler_SetFilename extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test set_filename() should exclude external fragments.
+	 * Test _Beans_Compiler::set_filename() should exclude external fragments.
 	 */
 	public function test_should_exclude_external_fragments() {
 		$fragment = vfsStream::url( 'compiled/fixtures/my-game-clock.js' );
@@ -77,7 +78,7 @@ class Tests_BeansCompiler_SetFilename extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test set_filename() should remove the old compiled file.
+	 * Test _Beans_Compiler::set_filename() should remove the old compiled file.
 	 */
 	public function test_should_remove_old_file() {
 		$fragment = vfsStream::url( 'compiled/fixtures/jquery.test.js' );

--- a/tests/phpunit/unit/api/compiler/beans-compiler/setFragments.php
+++ b/tests/phpunit/unit/api/compiler/beans-compiler/setFragments.php
@@ -25,7 +25,8 @@ require_once dirname( __DIR__ ) . '/includes/class-compiler-test-case.php';
 class Tests_BeansCompiler_SetFragments extends Compiler_Test_Case {
 
 	/**
-	 * Test set_fragments() should return unchanged fragments, meaning no fragments were added or removed.
+	 * Test _Beans_Compiler::set_fragments() should return unchanged fragments, meaning no fragments were added or
+	 * removed.
 	 */
 	public function test_should_return_unchanged_fragments() {
 		$config = array(
@@ -55,7 +56,8 @@ class Tests_BeansCompiler_SetFragments extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test set_fragments() should return fragments merged with the fragments stored in the global variable.
+	 * Test _Beans_Compiler::set_fragments() should return fragments merged with the fragments stored in the global
+	 * variable.
 	 */
 	public function test_should_return_fragments_merged_with_global() {
 		$config = array(
@@ -93,7 +95,7 @@ class Tests_BeansCompiler_SetFragments extends Compiler_Test_Case {
 	}
 
 	/**
-	 * Test set_fragments() should fire the "beans_compiler_fragments_{id}" event.
+	 * Test _Beans_Compiler::set_fragments() should fire the "beans_compiler_fragments_{id}" event.
 	 */
 	public function test_should_fire_event() {
 		$config = array(

--- a/tests/phpunit/unit/api/compiler/includes/class-compiler-test-case.php
+++ b/tests/phpunit/unit/api/compiler/includes/class-compiler-test-case.php
@@ -80,17 +80,7 @@ abstract class Compiler_Test_Case extends Test_Case {
 		$this->set_up_virtual_filesystem();
 		$this->compiled_dir = vfsStream::url( 'compiled' );
 		$this->compiled_url = 'http:://beans.local/compiled/';
-
-		Functions\when( 'wp_upload_dir' )->justReturn( array(
-			'path'    => '',
-			'url'     => '',
-			'subdir'  => '',
-			'basedir' => $this->compiled_dir,
-			'baseurl' => $this->compiled_url,
-			'error'   => false,
-		) );
-		Functions\when( 'is_admin' )->justReturn( $this->is_admin );
-		Functions\when( 'site_url' )->justReturn( 'http:://beans.local' );
+		$this->setup_function_mocks();
 
 		$this->load_original_functions( array(
 			'api/utilities/functions.php',
@@ -114,6 +104,22 @@ abstract class Compiler_Test_Case extends Test_Case {
 
 		Mockery::close();
 		parent::tearDown();
+	}
+
+	/**
+	 * Set up function mocks.
+	 */
+	protected function setup_function_mocks() {
+		Functions\when( 'wp_upload_dir' )->justReturn( array(
+			'path'    => '',
+			'url'     => '',
+			'subdir'  => '',
+			'basedir' => $this->compiled_dir,
+			'baseurl' => $this->compiled_url,
+			'error'   => false,
+		) );
+		Functions\when( 'is_admin' )->justReturn( $this->is_admin );
+		Functions\when( 'site_url' )->justReturn( 'http:://beans.local' );
 	}
 
 	/**

--- a/tests/phpunit/unit/api/compiler/includes/class-compiler-test-case.php
+++ b/tests/phpunit/unit/api/compiler/includes/class-compiler-test-case.php
@@ -219,7 +219,7 @@ abstract class Compiler_Test_Case extends Test_Case {
 	 * @since 1.5.0
 	 *
 	 * @param _Beans_Compiler $compiler The Compiler instance.
-	 * @param mixed            $fragment The given value to set.
+	 * @param mixed           $fragment The given value to set.
 	 *
 	 * @return \ReflectionProperty|string
 	 * @throws \ReflectionException Throws an exception if property does not exist.
@@ -234,8 +234,8 @@ abstract class Compiler_Test_Case extends Test_Case {
 	 * @since 1.5.0
 	 *
 	 * @param _Beans_Compiler $compiler  Instance of the compiler.
-	 * @param array            $config    The compiler's configuration.
-	 * @param int              $filemtime Optional. The fragment's filemtime. Default is null.
+	 * @param array           $config    The compiler's configuration.
+	 * @param int             $filemtime Optional. The fragment's filemtime. Default is null.
 	 *
 	 * @return string
 	 */

--- a/tests/phpunit/unit/api/compiler/includes/class-compiler-test-case.php
+++ b/tests/phpunit/unit/api/compiler/includes/class-compiler-test-case.php
@@ -63,9 +63,6 @@ abstract class Compiler_Test_Case extends Test_Case {
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();
 
-		require_once BEANS_TESTS_LIB_DIR . 'api/compiler/class-beans-compiler.php';
-		require_once BEANS_TESTS_LIB_DIR . 'api/compiler/functions.php';
-
 		if ( ! defined( 'FS_CHMOD_FILE' ) ) {
 			define( 'FS_CHMOD_FILE', 0644 ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- Valid constant.
 		}
@@ -84,6 +81,8 @@ abstract class Compiler_Test_Case extends Test_Case {
 
 		$this->load_original_functions( array(
 			'api/utilities/functions.php',
+			'api/compiler/class-beans-compiler.php',
+			'api/compiler/functions.php',
 		) );
 	}
 
@@ -91,7 +90,6 @@ abstract class Compiler_Test_Case extends Test_Case {
 	 * Tear down the test fixture.
 	 */
 	protected function tearDown() {
-
 		// Reset the global fragments container.
 		global $_beans_compiler_added_fragments;
 		$_beans_compiler_added_fragments = array(

--- a/tests/phpunit/unit/api/compiler/includes/class-compiler-test-case.php
+++ b/tests/phpunit/unit/api/compiler/includes/class-compiler-test-case.php
@@ -9,6 +9,7 @@
 
 namespace Beans\Framework\Tests\Unit\API\Compiler\Includes;
 
+use _Beans_Compiler;
 use Beans\Framework\Tests\Unit\Test_Case;
 use Brain\Monkey;
 use Brain\Monkey\Functions;
@@ -203,13 +204,13 @@ abstract class Compiler_Test_Case extends Test_Case {
 	 *
 	 * @param array $config Compiler's configuration parameters.
 	 *
-	 * @return \_Beans_Compiler
+	 * @return _Beans_Compiler
 	 */
 	protected function create_compiler( array $config = array() ) {
 		Monkey\Functions\when( 'beans_get_compiler_dir' )->justReturn( vfsStream::url( 'compiled/beans/compiler/' ) );
 		Monkey\Functions\when( 'beans_get_compiler_url' )->justReturn( $this->compiled_url . 'beans/compiler/' );
 
-		return new \_Beans_Compiler( $config );
+		return new _Beans_Compiler( $config );
 	}
 
 	/**
@@ -217,7 +218,7 @@ abstract class Compiler_Test_Case extends Test_Case {
 	 *
 	 * @since 1.5.0
 	 *
-	 * @param \_Beans_Compiler $compiler The Compiler instance.
+	 * @param _Beans_Compiler $compiler The Compiler instance.
 	 * @param mixed            $fragment The given value to set.
 	 *
 	 * @return \ReflectionProperty|string
@@ -232,7 +233,7 @@ abstract class Compiler_Test_Case extends Test_Case {
 	 *
 	 * @since 1.5.0
 	 *
-	 * @param \_Beans_Compiler $compiler  Instance of the compiler.
+	 * @param _Beans_Compiler $compiler  Instance of the compiler.
 	 * @param array            $config    The compiler's configuration.
 	 * @param int              $filemtime Optional. The fragment's filemtime. Default is null.
 	 *


### PR DESCRIPTION
Fixed loading of the unit tests files, which were still loading in the pre set up process, i.e. `setUpBeforeClass`.  Moved them to our new `load_original_functions()` method to ensure they load _after_ Patchwork is initialized.

Other minor changes which included standardizing the test documentation to include the class name, i.e.:

```
Test Class_Name::method_name() should.....
```