### PR TITLE
Moved redundant test suite initializations to root.

### DIFF
--- a/tests/phpunit/functions.php
+++ b/tests/phpunit/functions.php
@@ -10,6 +10,66 @@
 namespace Beans\Framework\Tests;
 
 /**
+ * Initialize the test suite.
+ *
+ * @since 1.5.0
+ *
+ * @param string $test_suite Directory name of the test suite.
+ *
+ * @return void
+ */
+function init_test_suite( $test_suite ) {
+	check_readiness();
+
+	init_constants( $test_suite );
+
+	// Load the files.
+	$beans_root_dir = rtrim( BEANS_THEME_DIR, DIRECTORY_SEPARATOR );
+	require_once $beans_root_dir . '/vendor/autoload.php';
+	require_once __DIR__ . '/test-case-trait.php';
+
+	// Load Patchwork before everything else in order to allow us to redefine WordPress and Beans functions.
+	require_once $beans_root_dir . '/vendor/brain/monkey/inc/patchwork-loader.php';
+}
+
+/**
+ * Check the system's readiness to run the tests.
+ *
+ * @since 1.5.0
+ *
+ * @return void
+ */
+function check_readiness() {
+
+	if ( version_compare( phpversion(), '5.6.0', '<' ) ) {
+		trigger_error( 'Beans Unit Tests require PHP 5.6 or higher.', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Valid use case for our testing suite.
+	}
+
+	if ( ! file_exists( dirname( dirname( __DIR__ ) ) . '/vendor/autoload.php' ) ) {
+		trigger_error( 'Whoops, we need Composer before we start running tests.  Please type: `composer install`.  When done, try running `phpunit` again.', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Valid use case for our testing suite.
+	}
+}
+
+/**
+ * Initialize the constants.
+ *
+ * @since 1.5.0
+ *
+ * @param string $test_suite_folder Directory name of the test suite.
+ *
+ * @return void
+ */
+function init_constants( $test_suite_folder ) {
+	define( 'BEANS_TESTS_DIR', __DIR__ . DIRECTORY_SEPARATOR . $test_suite_folder );
+
+	$beans_root_dir = dirname( dirname( __DIR__ ) );
+	if ( 'unit' === $test_suite_folder ) {
+		$beans_root_dir .= DIRECTORY_SEPARATOR;
+	}
+	define( 'BEANS_THEME_DIR', $beans_root_dir );
+}
+
+/**
  * Resets Beans for the test suite.
  *
  * @since 1.5.0

--- a/tests/phpunit/integration/bootstrap.php
+++ b/tests/phpunit/integration/bootstrap.php
@@ -10,20 +10,20 @@
 
 namespace Beans\Framework\Tests\Integration;
 
+use function Beans\Framework\Tests\init_test_suite;
+
 if ( ! file_exists( '../../../wp-content' ) ) {
 	trigger_error( 'Unable to run the integration tests, because the wp-content folder does not exist.', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Valid use case for our testing suite.
 }
 
-define( 'BEANS_TESTS_DIR', __DIR__ );
-define( 'BEANS_THEME_DIR', dirname( dirname( dirname( __DIR__ ) ) ) );
+require_once dirname( dirname( __FILE__ ) ) . '/functions.php';
+init_test_suite( 'integration' );
+
 define( 'WP_CONTENT_DIR', dirname( dirname( dirname( getcwd() ) ) ) . '/wp-content/' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- Our tests need to define this constant.
 
 if ( ! defined( 'WP_PLUGIN_DIR' ) ) {
 	define( 'WP_PLUGIN_DIR', WP_CONTENT_DIR . 'plugins/' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- When this constant is not already defined, we define it here. It's a valid use case for our testing suite.
 }
-
-// Load Patchwork before everything else in order to allow us to redefine WordPress and Beans functions.
-require_once BEANS_THEME_DIR . '/vendor/brain/monkey/inc/patchwork-loader.php';
 
 /**
  * Get the WordPress' tests suite directory.
@@ -73,6 +73,4 @@ tests_add_filter( 'setup_theme', function() {
 require_once $beans_tests_dir . '/includes/bootstrap.php';
 
 // Load the Integration Test Case.
-require_once dirname( __DIR__ ) . '/functions.php';
-require_once dirname( __DIR__ ) . '/test-case-trait.php';
 require_once BEANS_TESTS_DIR . '/class-test-case.php';

--- a/tests/phpunit/unit/bootstrap.php
+++ b/tests/phpunit/unit/bootstrap.php
@@ -10,12 +10,11 @@
 
 namespace Beans\Framework\Tests\Unit;
 
-if ( version_compare( phpversion(), '5.6.0', '<' ) ) {
-	trigger_error( 'Beans Unit Tests require PHP 5.6 or higher.', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Valid use case for our testing suite.
-}
+use function Beans\Framework\Tests\init_test_suite;
 
-define( 'BEANS_TESTS_DIR', __DIR__ );
-define( 'BEANS_THEME_DIR', dirname( dirname( dirname( __DIR__ ) ) ) . DIRECTORY_SEPARATOR );
+require_once dirname( dirname( __FILE__ ) ) . '/functions.php';
+init_test_suite( 'unit' );
+
 define( 'BEANS_TESTS_LIB_DIR', BEANS_THEME_DIR . 'lib' . DIRECTORY_SEPARATOR );
 define( 'BEANS_API_PATH', BEANS_TESTS_LIB_DIR . DIRECTORY_SEPARATOR . 'api' . DIRECTORY_SEPARATOR );
 
@@ -24,15 +23,4 @@ if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', dirname( dirname( dirname( BEANS_THEME_DIR ) ) ) . '/' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- Valid use case for our testing suite.
 }
 
-// Time to load Composer's autoloader.
-$beans_autoload_path = BEANS_THEME_DIR . 'vendor/';
-
-if ( ! file_exists( $beans_autoload_path . 'autoload.php' ) ) {
-	trigger_error( 'Whoops, we need Composer before we start running tests.  Please type: `composer install`.  When done, try running `phpunit` again.', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error -- Valid use case for our testing suite.
-}
-require_once $beans_autoload_path . 'autoload.php';
-unset( $beans_autoload_path );
-
-require_once dirname( __DIR__ ) . '/functions.php';
-require_once dirname( __DIR__ ) . '/test-case-trait.php';
 require_once BEANS_TESTS_DIR . '/class-test-case.php';


### PR DESCRIPTION
Added common functionality to initialize each of the test suites.  These initializers keep our bootstrap files DRY and easier to read.