### PR TITLE
Fixes the Template API to mock wp_head() & Clarifies intent.

### DIFF
--- a/tests/phpunit/integration/api/template/beansLoadDefaultTemplate.php
+++ b/tests/phpunit/integration/api/template/beansLoadDefaultTemplate.php
@@ -32,19 +32,34 @@ class Tests_BeansLoadDefaultTemplate extends Test_Case {
 	}
 
 	/**
-	 * Test beans_load_default_template() should return true after loading the given structure.
+	 * Test beans_load_default_template() should load the default structure when the given file does not exist, but its
+	 * basename is a Beans' structure.
 	 */
-	public function test_should_return_true_after_loading_structure() {
-		// Check with an invalid path to the structure.
+	public function test_should_load_default_structure_when_given_file_does_not_exist_but_basename_is_beans_structure() {
+		// Check with a relative invalid path.
 		$file = '/path/to/structure/content.php';
+
+		// Check that the given file does not exist.
+		$this->assertFileNotExists( $file );
+
+		// Check that 'content.php' does exist in Beans.
 		$this->assertFileExists( BEANS_STRUCTURE_PATH . basename( $file ) );
+
+		// Check that it renders.
 		ob_start();
 		$this->assertTrue( beans_load_default_template( $file ) );
 		$this->assertStringStartsWith( '<div class="tm-content"', ob_get_clean() );
 
-		// Check with an absolute path to the structure.
-		$file = __DIR__ . 'fixtures/structure/header.php';
+		// Check with an invalid absolute path.
+		$file = __DIR__ . '/fixtures/structure/header.php';
+
+		// Check that the given file does not exist.
+		$this->assertFileNotExists( $file );
+
+		// Check that 'header.php' does exist in Beans.
 		$this->assertFileExists( BEANS_STRUCTURE_PATH . basename( $file ) );
+
+		// Check that it renders.
 		ob_start();
 		$this->assertTrue( beans_load_default_template( $file ) );
 		$this->assertStringStartsWith( '<!DOCTYPE html>', ob_get_clean() );

--- a/tests/phpunit/integration/api/template/beansLoadDefaultTemplate.php
+++ b/tests/phpunit/integration/api/template/beansLoadDefaultTemplate.php
@@ -10,6 +10,7 @@
 namespace Beans\Framework\Tests\Integration\API\Template;
 
 use Beans\Framework\Tests\Integration\Test_Case;
+use Brain\Monkey;
 
 /**
  * Class Tests_BeansLoadDefaultTemplate
@@ -46,9 +47,16 @@ class Tests_BeansLoadDefaultTemplate extends Test_Case {
 		$this->assertFileExists( BEANS_STRUCTURE_PATH . basename( $file ) );
 
 		// Check that it renders.
+		$this->go_to( '/' );
+		Monkey\Functions\expect( 'do_action' )->once()->with( 'beans_content' )->andReturn();
 		ob_start();
 		$this->assertTrue( beans_load_default_template( $file ) );
-		$this->assertStringStartsWith( '<div class="tm-content"', ob_get_clean() );
+		$html = ob_get_clean();
+
+		$expected = <<<EOB
+<div class="tm-content" role="main" itemprop="mainEntityOfPage" itemscope="itemscope" itemtype="http://schema.org/Blog">
+EOB;
+		$this->assertStringStartsWith( $expected, trim( $html ) );
 
 		// Check with an invalid absolute path.
 		$file = __DIR__ . '/fixtures/structure/header.php';
@@ -61,6 +69,8 @@ class Tests_BeansLoadDefaultTemplate extends Test_Case {
 
 		// Check that it renders.
 		ob_start();
+		Monkey\Functions\expect( 'do_action' )->with( 'beans_head' )->andReturn();
+		Monkey\Functions\expect( 'wp_head' )->andReturn();
 		$this->assertTrue( beans_load_default_template( $file ) );
 		$this->assertStringStartsWith( '<!DOCTYPE html>', ob_get_clean() );
 	}

--- a/tests/phpunit/unit/api/template/beansLoadDefaultTemplate.php
+++ b/tests/phpunit/unit/api/template/beansLoadDefaultTemplate.php
@@ -38,19 +38,34 @@ class Tests_BeansLoadDefaultTemplate extends Template_Test_Case {
 	}
 
 	/**
-	 * Test beans_load_default_template() should return true after loading the given structure.
+	 * Test beans_load_default_template() should load the default structure when the given file does not exist, but its
+	 * basename is a Beans' structure.
 	 */
-	public function test_should_return_true_after_loading_structure() {
-		// Check with an invalid path to the structure.
+	public function test_should_load_default_structure_when_given_file_does_not_exist_but_basename_is_beans_structure() {
+		// Check with a relative invalid path.
 		$file = '/path/to/structure/content.php';
+
+		// Check that the given file does not exist.
+		$this->assertFileNotExists( $file );
+
+		// Check that 'content.php' does exist in Beans.
 		$this->assertFileExists( BEANS_STRUCTURE_PATH . basename( $file ) );
+
+		// Check that it renders.
 		ob_start();
 		$this->assertTrue( beans_load_default_template( $file ) );
 		$this->assertSame( $this->mock_filesystem->getChild( 'structure/content.php' )->getContent(), ob_get_clean() );
 
-		// Check with an absolute path to the structure.
-		$file = __DIR__ . 'fixtures/structure/header.php';
+		// Check with an invalid absolute path.
+		$file = __DIR__ . '/fixtures/structure/header.php';
+
+		// Check that the given file does not exist.
+		$this->assertFileNotExists( $file );
+
+		// Check that 'header.php' does exist in Beans.
 		$this->assertFileExists( BEANS_STRUCTURE_PATH . basename( $file ) );
+
+		// Check that it renders.
 		ob_start();
 		$this->assertTrue( beans_load_default_template( $file ) );
 		$this->assertSame( $this->mock_filesystem->getChild( 'structure/header.php' )->getContent(), ob_get_clean() );


### PR DESCRIPTION
The Template API integration tests for the `beans_load_default_template()` causes the trunk tests to fail. Why? We were letting `wp_head()` run.  There's no need in this suite. 

1. This PR adds mocks for non-essential functionality.
2. It makes the tests intent more clear, as it confused me when I went back to fix it (and I wrote it originally LOL).