### PR TITLE
Disabled whitespacing phpcs rules inside of view files.

### DIFF
--- a/lib/api/fields/types/views/checkbox.php
+++ b/lib/api/fields/types/views/checkbox.php
@@ -8,6 +8,7 @@
  * @since   1.5.0 Moved to view file.
  */
 
+// phpcs:disable Generic.WhiteSpace.ScopeIndent.Incorrect, Generic.WhiteSpace.ScopeIndent.IncorrectExact -- View file is indented for HTML structure.
 ?>
 
 <input type="hidden" value="0" name="<?php echo esc_attr( $field['name'] ); ?>" />

--- a/lib/api/fields/types/views/image.php
+++ b/lib/api/fields/types/views/image.php
@@ -9,6 +9,7 @@
  */
 
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Variables are used within a function's scope.
+// phpcs:disable Generic.WhiteSpace.ScopeIndent.Incorrect, Generic.WhiteSpace.ScopeIndent.IncorrectExact -- View file is indented for HTML structure.
 ?>
 
 <button class="bs-add-image button button-small" type="button" <?php echo isset( $hide_add_link ) ? 'style="display: none"' : ''; ?>><?php echo esc_html( $link_text ); ?></button>
@@ -52,5 +53,3 @@ foreach ( $images as $image_id ) :
 	</div>
 <?php endforeach; ?>
 </div>
-<?php
-// phpcs:enable

--- a/lib/api/fields/types/views/radio.php
+++ b/lib/api/fields/types/views/radio.php
@@ -9,6 +9,7 @@
  */
 
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Variables are used within a function's scope.
+// phpcs:disable Generic.WhiteSpace.ScopeIndent.Incorrect, Generic.WhiteSpace.ScopeIndent.IncorrectExact -- View file is indented for HTML structure.
 ?>
 
 <fieldset class="bs-field-fieldset">
@@ -42,9 +43,5 @@ foreach ( $field['options'] as $value => $radio ) :
 endif;
 ?>
 		</label>
-<?php
-endforeach;
-?>
+<?php endforeach; ?>
 </fieldset>
-<?php
-// phpcs:enable

--- a/lib/api/fields/types/views/select.php
+++ b/lib/api/fields/types/views/select.php
@@ -8,10 +8,12 @@
  * @since   1.5.0 Moved to view file.
  */
 
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Called from within a function and not within global scope.
+// phpcs:disable Generic.WhiteSpace.ScopeIndent.Incorrect, Generic.WhiteSpace.ScopeIndent.IncorrectExact -- View file is indented for HTML structure.
 ?>
 
 <select id="<?php echo esc_html( $field['id'] ); ?>" name="<?php echo esc_attr( $field['name'] ); ?>" <?php echo beans_esc_attributes( $field['attributes'] ); ?>><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Escaping is handled in the function. ?>
-<?php foreach ( $field['options'] as $value => $label ) : // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Called from within a function and not within global scope. ?>
+<?php foreach ( $field['options'] as $value => $label ) : ?>
 	<option value="<?php echo esc_attr( $value ); ?>"<?php selected( $value, $field['value'] ); ?>><?php echo esc_html( $label ); ?></option>
 <?php endforeach; ?>
 </select>

--- a/lib/api/fields/types/views/slider.php
+++ b/lib/api/fields/types/views/slider.php
@@ -8,6 +8,7 @@
  * @since   1.5.0 Moved to view file.
  */
 
+// phpcs:disable Generic.WhiteSpace.ScopeIndent.Incorrect, Generic.WhiteSpace.ScopeIndent.IncorrectExact -- View file is indented for HTML structure.
 ?>
 
 <div class="bs-slider-wrap" slider_min="<?php echo (int) $field['min']; ?>" slider_max="<?php echo (int) $field['max']; ?>" slider_interval="<?php echo (int) $field['interval']; ?>">

--- a/lib/api/options/views/page.php
+++ b/lib/api/options/views/page.php
@@ -8,6 +8,7 @@
  * @since   1.5.0 Moved to view file.
  */
 
+// phpcs:disable Generic.WhiteSpace.ScopeIndent.Incorrect, Generic.WhiteSpace.ScopeIndent.IncorrectExact -- View file is indented for HTML structure.
 ?>
 
 <form action="" method="post" class="bs-options" data-page="<?php echo esc_attr( beans_get( 'page' ) ); ?>">

--- a/lib/api/options/views/reset-notice-error.php
+++ b/lib/api/options/views/reset-notice-error.php
@@ -8,6 +8,7 @@
  * @since   1.5.0 Moved to view file.
  */
 
+// phpcs:disable Generic.WhiteSpace.ScopeIndent.Incorrect, Generic.WhiteSpace.ScopeIndent.IncorrectExact -- View file is indented for HTML structure.
 ?>
 
 <div id="message" class="error">

--- a/lib/api/options/views/reset-notice-success.php
+++ b/lib/api/options/views/reset-notice-success.php
@@ -8,6 +8,7 @@
  * @since   1.5.0 Moved to view file.
  */
 
+// phpcs:disable Generic.WhiteSpace.ScopeIndent.Incorrect, Generic.WhiteSpace.ScopeIndent.IncorrectExact -- View file is indented for HTML structure.
 ?>
 
 <div id="message" class="updated">

--- a/lib/api/options/views/save-notice-error.php
+++ b/lib/api/options/views/save-notice-error.php
@@ -8,6 +8,7 @@
  * @since   1.5.0 Moved to view file.
  */
 
+// phpcs:disable Generic.WhiteSpace.ScopeIndent.Incorrect, Generic.WhiteSpace.ScopeIndent.IncorrectExact -- View file is indented for HTML structure.
 ?>
 
 <div id="message" class="error">

--- a/lib/api/options/views/save-notice-success.php
+++ b/lib/api/options/views/save-notice-success.php
@@ -8,6 +8,7 @@
  * @since   1.5.0 Moved to view file.
  */
 
+// phpcs:disable Generic.WhiteSpace.ScopeIndent.Incorrect, Generic.WhiteSpace.ScopeIndent.IncorrectExact -- View file is indented for HTML structure.
 ?>
 
 <div id="message" class="updated">

--- a/lib/api/term-meta/views/term-meta-field.php
+++ b/lib/api/term-meta/views/term-meta-field.php
@@ -8,6 +8,7 @@
  * @since   1.5.0 Moved to view file.
  */
 
+// phpcs:disable Generic.WhiteSpace.ScopeIndent.Incorrect, Generic.WhiteSpace.ScopeIndent.IncorrectExact -- View file is indented for HTML structure.
 ?>
 <tr class="form-field">
 	<th scope="row">


### PR DESCRIPTION
View files are indented for HTML structure.  When inserting PHP into the files, we do not want the PHP to drive indentation for the HTML.  Therefore, we disable the whitespacing rules.

The `phpcs:enable` was removed from the end of the file, as PHPCS rules reset for each file.  Therefore, this extra line of code is not needed.