### PR TITLE
Tests & Improvements for UIkit API enqueue components

### DIFF
--- a/lib/api/uikit/class-beans-uikit.php
+++ b/lib/api/uikit/class-beans-uikit.php
@@ -272,7 +272,7 @@ final class _Beans_Uikit {
 		}
 
 		// Clean up by removing duplicates and empties.
-		return array_filter( $this->get_unique_values( $components ) );
+		return array_filter( beans_array_unique( $components ) );
 	}
 
 	/**
@@ -342,23 +342,10 @@ final class _Beans_Uikit {
 				continue;
 			}
 
-			$source[ $key ] = $this->get_unique_values( $value );
+			$source[ $key ] = beans_array_unique( $value );
 		}
 
 		return $source;
-	}
-
-	/**
-	 * Get an array of unique values from the given array.
-	 *
-	 * @since 1.5.0
-	 *
-	 * @param array $array The given array to process.
-	 *
-	 * @return array
-	 */
-	private function get_unique_values( array $array ) {
-		return array_values( array_unique( $array ) );
 	}
 
 	/**

--- a/lib/api/uikit/functions.php
+++ b/lib/api/uikit/functions.php
@@ -11,7 +11,7 @@
  *
  * @package Beans\Framework\API\UIkit
  *
- * @since 1.0.0
+ * @since   1.0.0
  */
 
 /**
@@ -27,11 +27,11 @@
  *
  * @since 1.0.0
  *
- * @param string|array $components Name of the component(s) to include as an indexed array. The name(s) must be
- *                                 the UIkit component filename without the extention (e.g. 'grid'). Set to true
- *                                 load all components.
- * @param string       $type       Optional. Type of UIkit components ('core' or 'add-ons').
- * @param bool         $autoload   Optional. Automatically include components dependencies.
+ * @param string|array|bool $components Name of the component(s) to include as an indexed array. The name(s) must be
+ *                                      the UIkit component filename without the extension (e.g. 'grid'). Set to true
+ *                                      load all components.
+ * @param string            $type       Optional. Type of UIkit components ('core' or 'add-ons').
+ * @param bool              $autoload   Optional. Automatically include components dependencies.
  *
  * @return void
  */
@@ -51,7 +51,7 @@ function beans_uikit_enqueue_components( $components, $type = 'core', $autoload 
 		}
 	}
 
-	// Add components.
+	// Add components into the registry.
 	$_beans_uikit_enqueued_items['components'][ $type ] = array_merge( (array) $_beans_uikit_enqueued_items['components'][ $type ], (array) $components );
 }
 
@@ -208,7 +208,7 @@ if ( ! isset( $_beans_uikit_enqueued_items ) ) {
 /**
  * Get registered theme.
  *
- * @since 1.0.0
+ * @since  1.0.0
  * @ignore
  * @access private
  *
@@ -233,7 +233,7 @@ add_action( 'wp_enqueue_scripts', '_beans_uikit_enqueue_assets', 7 );
 /**
  * Enqueue UIkit assets.
  *
- * @since 1.0.0
+ * @since  1.0.0
  * @ignore
  * @access private
  *
@@ -261,7 +261,7 @@ add_action( 'admin_enqueue_scripts', '_beans_uikit_enqueue_admin_assets', 7 );
 /**
  * Enqueue UIkit admin assets.
  *
- * @since 1.0.0
+ * @since  1.0.0
  * @ignore
  * @access private
  *

--- a/lib/api/uikit/functions.php
+++ b/lib/api/uikit/functions.php
@@ -42,12 +42,7 @@ function beans_uikit_enqueue_components( $components, $type = 'core', $autoload 
 	if ( true === $components ) {
 		$components = beans_uikit_get_all_components( $type );
 	} elseif ( $autoload ) {
-		$uikit     = new _Beans_Uikit();
-		$autoloads = $uikit->get_autoload_components( (array) $components );
-
-		foreach ( $autoloads as $autotype => $autoload ) {
-			beans_uikit_enqueue_components( $autoload, $autotype, false );
-		}
+		_beans_uikit_autoload_dependencies( $components );
 	}
 
 	// Add components into the registry.
@@ -179,6 +174,41 @@ function beans_uikit_get_all_components( $type = 'core' ) {
 	$uikit = new _Beans_Uikit();
 
 	return $uikit->get_all_components( $type );
+}
+
+/**
+ * Gets all of the UIkit dependencies for the given component(s).
+ *
+ * @since 1.5.0
+ *
+ * @param string|array $components Name of the component(s) to process. The name(s) must be
+ *                                 the UIkit component filename without the extension (e.g. 'grid').
+ *
+ * @return array
+ */
+function beans_uikit_get_all_dependencies( $components ) {
+	$uikit = new _Beans_Uikit();
+
+	return $uikit->get_autoload_components( (array) $components );
+}
+
+/**
+ * Autoload all the component dependencies.
+ *
+ * @since  1.5.0
+ * @ignore
+ * @access private
+ *
+ * @param string|array $components Name of the component(s) to include as an indexed array. The name(s) must be
+ *                                 the UIkit component filename without the extension (e.g. 'grid').
+ *
+ * @return void
+ */
+function _beans_uikit_autoload_dependencies( $components ) {
+
+	foreach ( beans_uikit_get_all_dependencies( $components ) as $type => $autoload ) {
+		beans_uikit_enqueue_components( $autoload, $type, false );
+	}
 }
 
 /**

--- a/lib/api/uikit/functions.php
+++ b/lib/api/uikit/functions.php
@@ -40,8 +40,7 @@ function beans_uikit_enqueue_components( $components, $type = 'core', $autoload 
 
 	// Get all uikit components.
 	if ( true === $components ) {
-		$uikit      = new _Beans_Uikit();
-		$components = $uikit->get_all_components( $type );
+		$components = beans_uikit_get_all_components( $type );
 	} elseif ( $autoload ) {
 		$uikit     = new _Beans_Uikit();
 		$autoloads = $uikit->get_autoload_components( (array) $components );
@@ -79,8 +78,7 @@ function beans_uikit_dequeue_components( $components, $type = 'core' ) {
 	global $_beans_uikit_enqueued_items;
 
 	if ( true === $components ) {
-		$uikit      = new _Beans_Uikit();
-		$components = $uikit->get_all_components( $type );
+		$components = beans_uikit_get_all_components( $type );
 	}
 
 	// Remove components.
@@ -166,6 +164,21 @@ function beans_uikit_enqueue_theme( $id, $path = false ) {
 function beans_uikit_dequeue_theme( $id ) {
 	global $_beans_uikit_enqueued_items;
 	unset( $_beans_uikit_enqueued_items['themes'][ $id ] );
+}
+
+/**
+ * Gets all of the UIkit components for the given type, i.e. for core or add-ons.
+ *
+ * @since 1.5.0
+ *
+ * @param string $type Optional. Type of UIkit components ('core' or 'add-ons').
+ *
+ * @return array
+ */
+function beans_uikit_get_all_components( $type = 'core' ) {
+	$uikit = new _Beans_Uikit();
+
+	return $uikit->get_all_components( $type );
 }
 
 /**

--- a/lib/api/uikit/functions.php
+++ b/lib/api/uikit/functions.php
@@ -29,7 +29,7 @@
  *
  * @param string|array|bool $components Name of the component(s) to include as an indexed array. The name(s) must be
  *                                      the UIkit component filename without the extension (e.g. 'grid'). Set to true
- *                                      load all components.
+ *                                      to load all components.
  * @param string            $type       Optional. Type of UIkit components ('core' or 'add-ons').
  * @param bool              $autoload   Optional. Automatically include components dependencies.
  *
@@ -162,7 +162,7 @@ function beans_uikit_dequeue_theme( $id ) {
 }
 
 /**
- * Gets all of the UIkit components for the given type, i.e. for core or add-ons.
+ * Get all of the UIkit components for the given type, i.e. for core or add-ons.
  *
  * @since 1.5.0
  *
@@ -177,7 +177,7 @@ function beans_uikit_get_all_components( $type = 'core' ) {
 }
 
 /**
- * Gets all of the UIkit dependencies for the given component(s).
+ * Get all of the UIkit dependencies for the given component(s).
  *
  * @since 1.5.0
  *

--- a/lib/api/uikit/functions.php
+++ b/lib/api/uikit/functions.php
@@ -52,7 +52,7 @@ function beans_uikit_enqueue_components( $components, $type = 'core', $autoload 
 	}
 
 	// Add components into the registry.
-	$_beans_uikit_enqueued_items['components'][ $type ] = array_merge( (array) $_beans_uikit_enqueued_items['components'][ $type ], (array) $components );
+	$_beans_uikit_enqueued_items['components'][ $type ] = beans_join_arrays_clean( (array) $_beans_uikit_enqueued_items['components'][ $type ], (array) $components );
 }
 
 /**

--- a/lib/api/utilities/functions.php
+++ b/lib/api/utilities/functions.php
@@ -543,7 +543,7 @@ function beans_join_arrays( array &$array1, array $array2 ) {
 }
 
 /**
- * Removes duplicate values from the given array and re-indexes to start at element 0.  Keys are not preserved.
+ * Remove duplicate values from the given array and re-indexes to start at element 0.  Keys are not preserved.
  *
  * @since 1.5.0
  *

--- a/lib/api/utilities/functions.php
+++ b/lib/api/utilities/functions.php
@@ -534,11 +534,49 @@ function beans_join_arrays( array &$array1, array $array2 ) {
 	// If the 1st array is empty, set it to the 2nd array. Then bail out as we're done.
 	if ( empty( $array1 ) ) {
 		$array1 = $array2;
+
 		return;
 	}
 
 	// Both arrays have elements. Let's join them together.
 	$array1 = array_merge( $array1, $array2 );
+}
+
+/**
+ * Removes duplicate values from the given array and re-indexes to start at element 0.  Keys are not preserved.
+ *
+ * @since 1.5.0
+ *
+ * @param array $array The given array to filter.
+ *
+ * @return array
+ */
+function beans_array_unique( array $array ) {
+	return array_values( array_unique( $array ) );
+}
+
+/**
+ * Join the given arrays and clean the merged array by removing duplicates and empties. By default, the clean joined
+ * array is re-indexed; however, setting the third parameter to `false` will preserve the keys.
+ *
+ * @since 1.5.0
+ *
+ * @param array $array1  Initial array to join.
+ * @param array $array2  The array to merge into $array1.
+ * @param bool  $reindex When true, re-indexes the clean array; else, preserves the keys.
+ *
+ * @return array
+ */
+function beans_join_arrays_clean( array $array1, array $array2, $reindex = true ) {
+	beans_join_arrays( $array1, $array2 );
+
+	if ( empty( $array1 ) ) {
+		return $array1;
+	}
+
+	$array1 = array_filter( array_unique( $array1 ) );
+
+	return $reindex ? array_values( $array1 ) : $array1;
 }
 
 /**
@@ -563,7 +601,7 @@ function _beans_is_uri( $maybe_uri ) {
 /**
  * Checks if WP is doing ajax.
  *
- * @since 1.5.0
+ * @since  1.5.0
  * @ignore
  * @access private
  *
@@ -576,7 +614,7 @@ function _beans_doing_ajax() {
 /**
  * Checks if WP is doing an autosave.
  *
- * @since 1.5.0
+ * @since  1.5.0
  * @ignore
  * @access private
  *

--- a/tests/phpunit/integration/api/uikit/beansUikitAutoloadDependencies.php
+++ b/tests/phpunit/integration/api/uikit/beansUikitAutoloadDependencies.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Tests for _beans_uikit_autoload_dependencies().
+ *
+ * @package Beans\Framework\Tests\Integration\API\UIkit
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Integration\API\UIkit;
+
+use Beans\Framework\Tests\Integration\API\UIkit\Includes\UIkit_Test_Case;
+
+require_once __DIR__ . '/includes/class-uikit-test-case.php';
+
+/**
+ * Class Tests_BeansUikitAutoloadDependencies
+ *
+ * @package Beans\Framework\Tests\Integration\API\UIkit
+ * @group   api
+ * @group   api-uikit
+ */
+class Tests_BeansUikitAutoloadDependencies extends UIkit_Test_Case {
+
+	/**
+	 * Test _beans_uikit_autoload_dependencies() should add each core (autoload) dependency into the registry.
+	 */
+	public function test_should_add_each_core_dependency_into_registry() {
+		global $_beans_uikit_enqueued_items;
+
+		_beans_uikit_autoload_dependencies( [ 'alert', 'button', 'overlay', 'tab' ] );
+		$this->assertSame( [ 'flex', 'switcher' ], $_beans_uikit_enqueued_items['components']['core'] );
+	}
+
+	/**
+	 * Test _beans_uikit_autoload_dependencies() should add each add-ons (autoload) dependency into the registry.
+	 */
+	public function test_should_add_each_addons_dependency_into_registry() {
+		global $_beans_uikit_enqueued_items;
+
+		_beans_uikit_autoload_dependencies( [ 'accordion', 'autocomplete', 'slideset' ] );
+		$this->assertSame( [ 'dotnav', 'slidenav' ], $_beans_uikit_enqueued_items['components']['add-ons'] );
+	}
+
+	/**
+	 * Test _beans_uikit_autoload_dependencies() should add each (autoload) dependency into the registry.
+	 */
+	public function test_should_add_each_dependency_into_registry() {
+		global $_beans_uikit_enqueued_items;
+
+		_beans_uikit_autoload_dependencies( [ 'lightbox', 'slideshow' ] );
+		$expected    = [
+			'core'    => [
+				'animation',
+				'flex',
+				'close',
+				'modal',
+				'overlay',
+			],
+			'add-ons' => [
+				'slidenav',
+				'dotnav',
+			],
+		];
+		$this->assertSame( $expected, $_beans_uikit_enqueued_items['components'] );
+	}
+}

--- a/tests/phpunit/integration/api/uikit/beansUikitAutoloadDependencies.php
+++ b/tests/phpunit/integration/api/uikit/beansUikitAutoloadDependencies.php
@@ -49,7 +49,7 @@ class Tests_BeansUikitAutoloadDependencies extends UIkit_Test_Case {
 		global $_beans_uikit_enqueued_items;
 
 		_beans_uikit_autoload_dependencies( [ 'lightbox', 'slideshow' ] );
-		$expected    = [
+		$expected = [
 			'core'    => [
 				'animation',
 				'flex',

--- a/tests/phpunit/integration/api/uikit/beansUikitEnqueueComponents.php
+++ b/tests/phpunit/integration/api/uikit/beansUikitEnqueueComponents.php
@@ -62,7 +62,7 @@ class Tests_BeansUikitEnqueueComponents extends UIkit_Test_Case {
 		$this->assertEmpty( $_beans_uikit_enqueued_items['components']['add-ons'] );
 		beans_uikit_enqueue_components( 'lightbox', 'add-ons', true );
 		$expected = [
-			'core' => [
+			'core'    => [
 				'animation',
 				'flex',
 				'close',

--- a/tests/phpunit/integration/api/uikit/beansUikitEnqueueComponents.php
+++ b/tests/phpunit/integration/api/uikit/beansUikitEnqueueComponents.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Tests for beans_uikit_enqueue_components().
+ *
+ * @package Beans\Framework\Tests\Integration\API\UIkit
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Integration\API\UIkit;
+
+use Beans\Framework\Tests\Integration\API\UIkit\Includes\UIkit_Test_Case;
+
+require_once __DIR__ . '/includes/class-uikit-test-case.php';
+
+/**
+ * Class Tests_BeansUikitEnqueueComponents
+ *
+ * @package Beans\Framework\Tests\Integration\API\UIkit
+ * @group   api
+ * @group   api-uikit
+ */
+class Tests_BeansUikitEnqueueComponents extends UIkit_Test_Case {
+
+	/**
+	 * Test beans_uikit_enqueue_components() should add the given core components and each (autoload) dependency into
+	 * registry.
+	 */
+	public function test_should_add_given_core_components_and_each_dependency_into_registry() {
+		global $_beans_uikit_enqueued_items;
+		$components = [
+			'alert',
+			'button',
+			'overlay',
+			'tab',
+		];
+
+		$this->assertEmpty( $_beans_uikit_enqueued_items['components']['core'] );
+		beans_uikit_enqueue_components( $components, 'core', true );
+		$expected = array_merge( [ 'flex', 'switcher' ], $components );
+		$this->assertSame( $expected, $_beans_uikit_enqueued_items['components']['core'] );
+
+		$expected[] = 'close';
+		$expected[] = 'modal';
+		beans_uikit_enqueue_components( 'modal', 'core', true );
+		$this->assertSame( $expected, $_beans_uikit_enqueued_items['components']['core'] );
+
+		$expected[] = 'animation';
+		$expected[] = 'scrollspy';
+		beans_uikit_enqueue_components( 'scrollspy', 'core', true );
+		$this->assertSame( $expected, $_beans_uikit_enqueued_items['components']['core'] );
+	}
+
+	/**
+	 * Test beans_uikit_enqueue_components() should add the given addons components and each (autoload) dependency into
+	 * registry.
+	 */
+	public function test_should_add_given_addons_components_and_each_dependency_into_registry() {
+		global $_beans_uikit_enqueued_items;
+
+		$this->assertEmpty( $_beans_uikit_enqueued_items['components']['core'] );
+		$this->assertEmpty( $_beans_uikit_enqueued_items['components']['add-ons'] );
+		beans_uikit_enqueue_components( 'lightbox', 'add-ons', true );
+		$expected = [
+			'core'    => [
+				'animation',
+				'flex',
+				'close',
+				'modal',
+				'overlay',
+			],
+			'add-ons' => [
+				'slidenav',
+				'lightbox',
+			],
+		];
+		$this->assertSame( $expected, $_beans_uikit_enqueued_items['components'] );
+
+		beans_uikit_enqueue_components( 'slider', 'add-ons', true );
+		$expected['add-ons'][] = 'slidenav';
+		$expected['add-ons'][] = 'slider';
+		$this->assertSame( $expected, $_beans_uikit_enqueued_items['components'] );
+
+		beans_uikit_enqueue_components( [ 'accordion', 'autocomplete', 'slideset' ], 'add-ons', true );
+		$expected['core']  = array_merge( $expected['core'], [ 'animation', 'flex' ] );
+		$expected['add-ons'] = array_merge( $expected['add-ons'], [ 'dotnav', 'slidenav', 'accordion', 'autocomplete', 'slideset' ] );
+		$this->assertSame( $expected, $_beans_uikit_enqueued_items['components'] );
+	}
+}

--- a/tests/phpunit/integration/api/uikit/beansUikitEnqueueComponents.php
+++ b/tests/phpunit/integration/api/uikit/beansUikitEnqueueComponents.php
@@ -77,13 +77,11 @@ class Tests_BeansUikitEnqueueComponents extends UIkit_Test_Case {
 		$this->assertSame( $expected, $_beans_uikit_enqueued_items['components'] );
 
 		beans_uikit_enqueue_components( 'slider', 'add-ons', true );
-		$expected['add-ons'][] = 'slidenav';
 		$expected['add-ons'][] = 'slider';
 		$this->assertSame( $expected, $_beans_uikit_enqueued_items['components'] );
 
 		beans_uikit_enqueue_components( [ 'accordion', 'autocomplete', 'slideset' ], 'add-ons', true );
-		$expected['core']  = array_merge( $expected['core'], [ 'animation', 'flex' ] );
-		$expected['add-ons'] = array_merge( $expected['add-ons'], [ 'dotnav', 'slidenav', 'accordion', 'autocomplete', 'slideset' ] );
+		$expected['add-ons'] = array_merge( $expected['add-ons'], [ 'dotnav', 'accordion', 'autocomplete', 'slideset' ] );
 		$this->assertSame( $expected, $_beans_uikit_enqueued_items['components'] );
 	}
 }

--- a/tests/phpunit/integration/api/uikit/beansUikitEnqueueComponents.php
+++ b/tests/phpunit/integration/api/uikit/beansUikitEnqueueComponents.php
@@ -24,7 +24,7 @@ class Tests_BeansUikitEnqueueComponents extends UIkit_Test_Case {
 
 	/**
 	 * Test beans_uikit_enqueue_components() should add the given core components and each (autoload) dependency into
-	 * registry.
+	 * the registry.
 	 */
 	public function test_should_add_given_core_components_and_each_dependency_into_registry() {
 		global $_beans_uikit_enqueued_items;
@@ -53,7 +53,7 @@ class Tests_BeansUikitEnqueueComponents extends UIkit_Test_Case {
 
 	/**
 	 * Test beans_uikit_enqueue_components() should add the given addons components and each (autoload) dependency into
-	 * registry.
+	 * the registry.
 	 */
 	public function test_should_add_given_addons_components_and_each_dependency_into_registry() {
 		global $_beans_uikit_enqueued_items;
@@ -62,7 +62,7 @@ class Tests_BeansUikitEnqueueComponents extends UIkit_Test_Case {
 		$this->assertEmpty( $_beans_uikit_enqueued_items['components']['add-ons'] );
 		beans_uikit_enqueue_components( 'lightbox', 'add-ons', true );
 		$expected = [
-			'core'    => [
+			'core' => [
 				'animation',
 				'flex',
 				'close',
@@ -81,7 +81,93 @@ class Tests_BeansUikitEnqueueComponents extends UIkit_Test_Case {
 		$this->assertSame( $expected, $_beans_uikit_enqueued_items['components'] );
 
 		beans_uikit_enqueue_components( [ 'accordion', 'autocomplete', 'slideset' ], 'add-ons', true );
-		$expected['add-ons'] = array_merge( $expected['add-ons'], [ 'dotnav', 'accordion', 'autocomplete', 'slideset' ] );
+		$expected['add-ons'] = array_merge( $expected['add-ons'], [
+			'dotnav',
+			'accordion',
+			'autocomplete',
+			'slideset',
+		] );
 		$this->assertSame( $expected, $_beans_uikit_enqueued_items['components'] );
+	}
+
+	/**
+	 * Test beans_uikit_enqueue_components() should add all core components into the registry when $components is true.
+	 */
+	public function test_should_add_all_core_components_into_registry_when_components_is_true() {
+		global $_beans_uikit_enqueued_items;
+
+		beans_uikit_enqueue_components( true );
+
+		$this->assertCount( 42, $_beans_uikit_enqueued_items['components']['core'] );
+
+		// Check common components.
+		$this->assertContains( 'alert', $_beans_uikit_enqueued_items['components']['core'] );
+		$this->assertContains( 'button', $_beans_uikit_enqueued_items['components']['core'] );
+		$this->assertContains( 'cover', $_beans_uikit_enqueued_items['components']['core'] );
+		$this->assertContains( 'grid', $_beans_uikit_enqueued_items['components']['core'] );
+		$this->assertContains( 'nav', $_beans_uikit_enqueued_items['components']['core'] );
+		$this->assertContains( 'offcanvas', $_beans_uikit_enqueued_items['components']['core'] );
+		$this->assertContains( 'tab', $_beans_uikit_enqueued_items['components']['core'] );
+		$this->assertContains( 'utility', $_beans_uikit_enqueued_items['components']['core'] );
+
+		// Spot check the unique LESS components.
+		$this->assertContains( 'base', $_beans_uikit_enqueued_items['components']['core'] );
+		$this->assertContains( 'close', $_beans_uikit_enqueued_items['components']['core'] );
+		$this->assertContains( 'column', $_beans_uikit_enqueued_items['components']['core'] );
+		$this->assertContains( 'description-list', $_beans_uikit_enqueued_items['components']['core'] );
+		$this->assertContains( 'thumbnail', $_beans_uikit_enqueued_items['components']['core'] );
+		$this->assertContains( 'variables', $_beans_uikit_enqueued_items['components']['core'] );
+
+		// Spot check the unique JS components.
+		$this->assertContains( 'core', $_beans_uikit_enqueued_items['components']['core'] );
+		$this->assertContains( 'scrollspy', $_beans_uikit_enqueued_items['components']['core'] );
+		$this->assertContains( 'smooth-scroll', $_beans_uikit_enqueued_items['components']['core'] );
+		$this->assertContains( 'toggle', $_beans_uikit_enqueued_items['components']['core'] );
+		$this->assertContains( 'touch', $_beans_uikit_enqueued_items['components']['core'] );
+
+		// Check the components do not contain add-ons.
+		$this->assertNotContains( 'accordion', $_beans_uikit_enqueued_items['components']['core'] );
+		$this->assertNotContains( 'datepicker', $_beans_uikit_enqueued_items['components']['core'] );
+		$this->assertNotContains( 'notify', $_beans_uikit_enqueued_items['components']['core'] );
+		$this->assertNotContains( 'progress', $_beans_uikit_enqueued_items['components']['core'] );
+	}
+
+	/**
+	 * Test beans_uikit_enqueue_components() should add all add-ons components into the registry when $components is
+	 * true.
+	 */
+	public function test_should_add_all_addons_components_into_registry_when_components_is_true() {
+		global $_beans_uikit_enqueued_items;
+
+		beans_uikit_enqueue_components( true, 'add-ons' );
+
+		$this->assertCount( 29, $_beans_uikit_enqueued_items['components']['add-ons'] );
+
+		// Check common components.
+		$this->assertContains( 'accordion', $_beans_uikit_enqueued_items['components']['add-ons'] );
+		$this->assertContains( 'autocomplete', $_beans_uikit_enqueued_items['components']['add-ons'] );
+		$this->assertContains( 'datepicker', $_beans_uikit_enqueued_items['components']['add-ons'] );
+		$this->assertContains( 'form-password', $_beans_uikit_enqueued_items['components']['add-ons'] );
+		$this->assertContains( 'search', $_beans_uikit_enqueued_items['components']['add-ons'] );
+		$this->assertContains( 'sticky', $_beans_uikit_enqueued_items['components']['add-ons'] );
+		$this->assertContains( 'tooltip', $_beans_uikit_enqueued_items['components']['add-ons'] );
+		$this->assertContains( 'upload', $_beans_uikit_enqueued_items['components']['add-ons'] );
+
+		// Spot check the unique LESS components.
+		$this->assertContains( 'dotnav', $_beans_uikit_enqueued_items['components']['add-ons'] );
+		$this->assertContains( 'form-advanced', $_beans_uikit_enqueued_items['components']['add-ons'] );
+		$this->assertContains( 'htmleditor', $_beans_uikit_enqueued_items['components']['add-ons'] );
+
+		// Spot check the unique JS components.
+		$this->assertContains( 'parallax', $_beans_uikit_enqueued_items['components']['add-ons'] );
+		$this->assertContains( 'lightbox', $_beans_uikit_enqueued_items['components']['add-ons'] );
+		$this->assertContains( 'slideshow-fx', $_beans_uikit_enqueued_items['components']['add-ons'] );
+		$this->assertContains( 'timepicker', $_beans_uikit_enqueued_items['components']['add-ons'] );
+
+		// Check the components do not contain add-ons.
+		$this->assertNotContains( 'alert', $_beans_uikit_enqueued_items['components']['add-ons'] );
+		$this->assertNotContains( 'badge', $_beans_uikit_enqueued_items['components']['add-ons'] );
+		$this->assertNotContains( 'base', $_beans_uikit_enqueued_items['components']['add-ons'] );
+		$this->assertNotContains( 'close', $_beans_uikit_enqueued_items['components']['add-ons'] );
 	}
 }

--- a/tests/phpunit/integration/api/uikit/includes/class-uikit-test-case.php
+++ b/tests/phpunit/integration/api/uikit/includes/class-uikit-test-case.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Test Case for Beans' UIkit API integration tests.
+ *
+ * @package Beans\Framework\Tests\Integration\API\UIkit\Includes
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Integration\API\UIkit\Includes;
+
+use Beans\Framework\Tests\Integration\Test_Case;
+use org\bovigo\vfs\vfsStream;
+
+/**
+ * Abstract Class UIkit_Test_Case
+ *
+ * @package Beans\Framework\Tests\Integration\API\UIkit\Includes
+ */
+abstract class UIkit_Test_Case extends Test_Case {
+
+	/**
+	 * Instance of vfsStreamDirectory to mock the filesystem.
+	 *
+	 * @var vfsStreamDirectory
+	 */
+	protected $mock_filesystem;
+
+	/**
+	 * Prepares the test environment before each test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->set_up_virtual_filesystem();
+		$this->set_up_uploads_directory();
+
+		$this->reset_globals();
+	}
+
+	/**
+	 * Set up the virtual filesystem.
+	 */
+	protected function set_up_virtual_filesystem() {
+		$this->mock_filesystem = vfsStream::setup(
+			'virtual-wp-content',
+			0755,
+			$this->get_virtual_structure()
+		);
+	}
+
+	/**
+	 * Get the virtual filesystem's structure.
+	 */
+	protected function get_virtual_structure() {
+		return [
+			'themes'  => [
+				'beans-child' => [
+					'assets'        => [
+						'js'   => [
+							'alert.min.js' => '',
+						],
+						'less' => [
+							'theme' => [
+								'alert.less'     => '',
+								'article.less'   => '',
+								'panel.less'     => '',
+								'variables.less' => '',
+								'style.less'     => '',
+								'variables.less' => '',
+							],
+						],
+					],
+					'functions.php' => '',
+					'style.css'     => '',
+				],
+			],
+			'uploads' => [
+				'beans' => [
+					'compiler' => [
+						'uikit' => [
+							'index.php' => '',
+						],
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Set the Uploads directory to our virtual filesystem.
+	 */
+	protected function set_up_uploads_directory() {
+		add_filter( 'upload_dir', function( array $uploads_dir ) {
+			$compiled_dir = vfsStream::url( 'virtual-wp-content/uploads' );
+
+			$uploads_dir['path']    = $compiled_dir . $uploads_dir['subdir'];
+			$uploads_dir['url']     = str_replace( 'wp-content/uploads', 'compiled', $uploads_dir['url'] );
+			$uploads_dir['basedir'] = $compiled_dir;
+			$uploads_dir['baseurl'] = str_replace( 'wp-content/uploads', 'compiled', $uploads_dir['baseurl'] );
+
+			return $uploads_dir;
+		} );
+	}
+
+	/**
+	 * Reset the global containers.
+	 */
+	protected function reset_globals() {
+		global $_beans_uikit_enqueued_items, $_beans_uikit_registered_items;
+
+		$_beans_uikit_enqueued_items = array(
+			'components' => array(
+				'core'    => array(),
+				'add-ons' => array(),
+			),
+			'themes'     => array(),
+		);
+
+		$_beans_uikit_registered_items = array(
+			'themes' => array(
+				'default'         => BEANS_API_PATH . 'uikit/src/themes/default',
+				'almost-flat'     => BEANS_API_PATH . 'uikit/src/themes/almost-flat',
+				'gradient'        => BEANS_API_PATH . 'uikit/src/themes/gradient',
+				'wordpress-admin' => BEANS_API_PATH . 'uikit/themes/wordpress-admin',
+			),
+		);
+	}
+}

--- a/tests/phpunit/unit/api/uikit/beansUikitEnqueueComponents.php
+++ b/tests/phpunit/unit/api/uikit/beansUikitEnqueueComponents.php
@@ -9,8 +9,8 @@
 
 namespace Beans\Framework\Tests\Unit\API\UIkit;
 
-use _Beans_Uikit;
 use Beans\Framework\Tests\Unit\API\UIkit\Includes\UIkit_Test_Case;
+use Brain\Monkey;
 
 require_once __DIR__ . '/includes/class-uikit-test-case.php';
 
@@ -159,5 +159,46 @@ class Tests_BeansUikitEnqueueComponents extends UIkit_Test_Case {
 		], 'add-ons', false );
 		$this->assertCount( 5, $_beans_uikit_enqueued_items['components']['add-ons'] );
 		$this->assertSame( $addons, $_beans_uikit_enqueued_items['components']['add-ons'] );
+	}
+
+	/**
+	 * Test beans_uikit_enqueue_components() should add all core components into the registry when $components is true.
+	 */
+	public function test_should_add_all_core_components_into_registry_when_components_is_true() {
+		$components = [
+			'alert',
+			'animation',
+			'article',
+			'badge',
+			'base',
+		];
+
+		Monkey\Functions\expect( 'beans_uikit_get_all_components' )->once()->with( 'core' )->andReturn( $components );
+
+		beans_uikit_enqueue_components( true );
+
+		global $_beans_uikit_enqueued_items;
+		$this->assertSame( $components, $_beans_uikit_enqueued_items['components']['core'] );
+	}
+
+	/**
+	 * Test beans_uikit_enqueue_components() should add all add-ons components into the registry when $components is true.
+	 */
+	public function test_should_add_all_addons_components_into_registry_when_components_is_true() {
+		$components = [
+			'accordion',
+			'autocomplete',
+			'datepicker',
+			'dotnav',
+			'form-advanced',
+			'sticky',
+		];
+
+		Monkey\Functions\expect( 'beans_uikit_get_all_components' )->once()->with( 'add-ons' )->andReturn( $components );
+
+		beans_uikit_enqueue_components( true, 'add-ons' );
+
+		global $_beans_uikit_enqueued_items;
+		$this->assertSame( $components, $_beans_uikit_enqueued_items['components']['add-ons'] );
 	}
 }

--- a/tests/phpunit/unit/api/uikit/beansUikitEnqueueComponents.php
+++ b/tests/phpunit/unit/api/uikit/beansUikitEnqueueComponents.php
@@ -24,7 +24,7 @@ require_once __DIR__ . '/includes/class-uikit-test-case.php';
 class Tests_BeansUikitEnqueueComponents extends UIkit_Test_Case {
 
 	/**
-	 * Test beans_uikit_enqueue_components() should add then given core component into registry when given a string.
+	 * Test beans_uikit_enqueue_components() should add the given core component into the registry when given a string.
 	 */
 	public function test_should_add_given_core_component_into_registry_when_given_string() {
 		global $_beans_uikit_enqueued_items;
@@ -45,7 +45,7 @@ class Tests_BeansUikitEnqueueComponents extends UIkit_Test_Case {
 	}
 
 	/**
-	 * Test beans_uikit_enqueue_components() should add then given add-ons component into registry when given a string.
+	 * Test beans_uikit_enqueue_components() should add the given add-ons component into the registry when given a string.
 	 */
 	public function test_should_add_given_addons_component_into_registry_when_given_string() {
 		global $_beans_uikit_enqueued_items;
@@ -66,7 +66,7 @@ class Tests_BeansUikitEnqueueComponents extends UIkit_Test_Case {
 	}
 
 	/**
-	 * Test beans_uikit_enqueue_components() should add the given core components into registry.
+	 * Test beans_uikit_enqueue_components() should add the given core components into the registry.
 	 */
 	public function test_should_add_given_core_components_into_registry() {
 		global $_beans_uikit_enqueued_items;
@@ -88,7 +88,7 @@ class Tests_BeansUikitEnqueueComponents extends UIkit_Test_Case {
 	}
 
 	/**
-	 * Test beans_uikit_enqueue_components() should add the given add-ons components into registry.
+	 * Test beans_uikit_enqueue_components() should add the given add-ons components into the registry.
 	 */
 	public function test_should_add_given_addons_components_into_registry() {
 		global $_beans_uikit_enqueued_items;

--- a/tests/phpunit/unit/api/uikit/beansUikitEnqueueComponents.php
+++ b/tests/phpunit/unit/api/uikit/beansUikitEnqueueComponents.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * Tests for beans_uikit_enqueue_components().
+ *
+ * @package Beans\Framework\Tests\Unit\API\UIkit
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Unit\API\UIkit;
+
+use _Beans_Uikit;
+use Beans\Framework\Tests\Unit\API\UIkit\Includes\UIkit_Test_Case;
+
+require_once __DIR__ . '/includes/class-uikit-test-case.php';
+
+/**
+ * Class Tests_BeansUikitEnqueueComponents
+ *
+ * @package Beans\Framework\Tests\Unit\API\UIkit
+ * @group   api
+ * @group   api-uikit
+ */
+class Tests_BeansUikitEnqueueComponents extends UIkit_Test_Case {
+
+	/**
+	 * Test beans_uikit_enqueue_components() should add then given core component into registry when given a string.
+	 */
+	public function test_should_add_given_core_component_into_registry_when_given_string() {
+		global $_beans_uikit_enqueued_items;
+
+		// Test when the registry is empty.
+		$this->assertEmpty( $_beans_uikit_enqueued_items['components']['core'] );
+		beans_uikit_enqueue_components( 'alert', 'core', false );
+		$expected = [ 'alert' ];
+		$this->assertSame( $expected, $_beans_uikit_enqueued_items['components']['core'] );
+
+		// Test when components are already in the registry.
+		beans_uikit_enqueue_components( 'button', 'core', false );
+		$expected[] = 'button';
+		$this->assertSame( $expected, $_beans_uikit_enqueued_items['components']['core'] );
+		beans_uikit_enqueue_components( 'overlay', 'core', false );
+		$expected[] = 'overlay';
+		$this->assertSame( $expected, $_beans_uikit_enqueued_items['components']['core'] );
+	}
+
+	/**
+	 * Test beans_uikit_enqueue_components() should add then given add-ons component into registry when given a string.
+	 */
+	public function test_should_add_given_addons_component_into_registry_when_given_string() {
+		global $_beans_uikit_enqueued_items;
+
+		// Test when the registry is empty.
+		$this->assertEmpty( $_beans_uikit_enqueued_items['components']['add-ons'] );
+		beans_uikit_enqueue_components( 'accordion', 'add-ons', false );
+		$expected = [ 'accordion' ];
+		$this->assertSame( $expected, $_beans_uikit_enqueued_items['components']['add-ons'] );
+
+		// Test when components are already in the registry.
+		beans_uikit_enqueue_components( 'datepicker', 'add-ons', false );
+		$expected[] = 'datepicker';
+		$this->assertSame( $expected, $_beans_uikit_enqueued_items['components']['add-ons'] );
+		beans_uikit_enqueue_components( 'sticky', 'add-ons', false );
+		$expected[] = 'sticky';
+		$this->assertSame( $expected, $_beans_uikit_enqueued_items['components']['add-ons'] );
+	}
+
+	/**
+	 * Test beans_uikit_enqueue_components() should add the given core components into registry.
+	 */
+	public function test_should_add_given_core_components_into_registry() {
+		global $_beans_uikit_enqueued_items;
+		$components = [
+			'alert',
+			'button',
+			'overlay',
+		];
+
+		// Test when the registry is empty.
+		$this->assertEmpty( $_beans_uikit_enqueued_items['components']['core'] );
+		beans_uikit_enqueue_components( $components, 'core', false );
+		$this->assertSame( $components, $_beans_uikit_enqueued_items['components']['core'] );
+
+		// Test when components are already in the registry.
+		beans_uikit_enqueue_components( [ 'tab' ], 'core', false );
+		$expected = array_merge( $components, [ 'tab' ] );
+		$this->assertSame( $expected, $_beans_uikit_enqueued_items['components']['core'] );
+	}
+
+	/**
+	 * Test beans_uikit_enqueue_components() should add the given add-ons components into registry.
+	 */
+	public function test_should_add_given_addons_components_into_registry() {
+		global $_beans_uikit_enqueued_items;
+		$components = [
+			'accordion',
+			'autocomplete',
+			'datepicker',
+			'sticky',
+			'tooltip',
+		];
+
+		// Test when the registry is empty.
+		$this->assertEmpty( $_beans_uikit_enqueued_items['components']['add-ons'] );
+		beans_uikit_enqueue_components( $components, 'add-ons', false );
+		$this->assertSame( $components, $_beans_uikit_enqueued_items['components']['add-ons'] );
+
+		// Test when components are already in the registry.
+		beans_uikit_enqueue_components( [ 'notify' ], 'add-ons', false );
+		$expected = array_merge( $components, [ 'notify' ] );
+		$this->assertSame( $expected, $_beans_uikit_enqueued_items['components']['add-ons'] );
+	}
+}

--- a/tests/phpunit/unit/api/uikit/beansUikitEnqueueComponents.php
+++ b/tests/phpunit/unit/api/uikit/beansUikitEnqueueComponents.php
@@ -182,7 +182,8 @@ class Tests_BeansUikitEnqueueComponents extends UIkit_Test_Case {
 	}
 
 	/**
-	 * Test beans_uikit_enqueue_components() should add all add-ons components into the registry when $components is true.
+	 * Test beans_uikit_enqueue_components() should add all add-ons components into the registry when $components is
+	 * true.
 	 */
 	public function test_should_add_all_addons_components_into_registry_when_components_is_true() {
 		$components = [
@@ -200,5 +201,54 @@ class Tests_BeansUikitEnqueueComponents extends UIkit_Test_Case {
 
 		global $_beans_uikit_enqueued_items;
 		$this->assertSame( $components, $_beans_uikit_enqueued_items['components']['add-ons'] );
+	}
+
+	/**
+	 * Test beans_uikit_enqueue_components() should add the given core components and each (autoload) dependency into
+	 * the registry.
+	 */
+	public function test_should_add_given_core_components_and_each_dependency_into_registry() {
+		global $_beans_uikit_enqueued_items;
+		$components = [
+			'alert',
+			'button',
+			'overlay',
+			'tab',
+		];
+		Monkey\Functions\expect( '_beans_uikit_autoload_dependencies' )
+			->once()
+			->with( $components )
+			->andReturnUsing( function() {
+				global $_beans_uikit_enqueued_items;
+				$_beans_uikit_enqueued_items['components']['core'] = [ 'flex', 'switcher' ];
+
+				return [ 'flex', 'switcher' ];
+			} );
+
+		beans_uikit_enqueue_components( $components, 'core', true );
+		$expected = array_merge( [ 'flex', 'switcher' ], $components );
+		$this->assertSame( $expected, $_beans_uikit_enqueued_items['components']['core'] );
+	}
+
+	/**
+	 * Test beans_uikit_enqueue_components() should add the given add-ons components and each (autoload) dependency into
+	 * the registry.
+	 */
+	public function test_should_add_given_addons_components_and_each_dependency_into_registry() {
+		global $_beans_uikit_enqueued_items;
+		$components = [ 'accordion', 'autocomplete', 'slideset' ];
+		Monkey\Functions\expect( '_beans_uikit_autoload_dependencies' )
+			->once()
+			->with( $components )
+			->andReturnUsing( function() {
+				global $_beans_uikit_enqueued_items;
+				$_beans_uikit_enqueued_items['components']['add-ons'] = [ 'dotnav' ];
+
+				return [ 'dotnav' ];
+			} );
+
+		beans_uikit_enqueue_components( $components, 'add-ons', true );
+		$expected = array_merge( [ 'dotnav' ], $components );
+		$this->assertSame( $expected, $_beans_uikit_enqueued_items['components']['add-ons'] );
 	}
 }

--- a/tests/phpunit/unit/api/uikit/beansUikitEnqueueComponents.php
+++ b/tests/phpunit/unit/api/uikit/beansUikitEnqueueComponents.php
@@ -110,4 +110,54 @@ class Tests_BeansUikitEnqueueComponents extends UIkit_Test_Case {
 		$expected = array_merge( $components, [ 'notify' ] );
 		$this->assertSame( $expected, $_beans_uikit_enqueued_items['components']['add-ons'] );
 	}
+
+	/**
+	 * Test beans_uikit_enqueue_components() should not add duplicates into the registry.
+	 */
+	public function test_should_not_add_duplicates_into_registry() {
+		global $_beans_uikit_enqueued_items;
+
+		$core                                      = [
+			'alert',
+			'button',
+			'overlay',
+		];
+		$addons                                    = [
+			'accordion',
+			'autocomplete',
+			'datepicker',
+			'sticky',
+			'tooltip',
+		];
+		$_beans_uikit_enqueued_items['components'] = [
+			'core'    => $core,
+			'add-ons' => $addons,
+		];
+
+		// Check the core components.
+		beans_uikit_enqueue_components( 'alert', 'core', false );
+		$this->assertCount( 3, $_beans_uikit_enqueued_items['components']['core'] );
+		$this->assertSame( $core, $_beans_uikit_enqueued_items['components']['core'] );
+
+		// Check when duplicates are in different order.
+		beans_uikit_enqueue_components( [ 'overlay', 'alert', 'button' ], 'core', false );
+		$this->assertCount( 3, $_beans_uikit_enqueued_items['components']['core'] );
+		$this->assertSame( $core, $_beans_uikit_enqueued_items['components']['core'] );
+
+		// Check the add-ons components.
+		beans_uikit_enqueue_components( 'accordion', 'add-ons', false );
+		$this->assertCount( 5, $_beans_uikit_enqueued_items['components']['add-ons'] );
+		$this->assertSame( $addons, $_beans_uikit_enqueued_items['components']['add-ons'] );
+
+		// Check when duplicates are in different order.
+		beans_uikit_enqueue_components( [
+			'datepicker',
+			'sticky',
+			'tooltip',
+			'autocomplete',
+			'accordion',
+		], 'add-ons', false );
+		$this->assertCount( 5, $_beans_uikit_enqueued_items['components']['add-ons'] );
+		$this->assertSame( $addons, $_beans_uikit_enqueued_items['components']['add-ons'] );
+	}
 }

--- a/tests/phpunit/unit/api/uikit/beansUikitGetAllComponents.php
+++ b/tests/phpunit/unit/api/uikit/beansUikitGetAllComponents.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Tests for beans_uikit_get_all_components().
+ *
+ * @package Beans\Framework\Tests\Unit\API\UIkit
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Unit\API\UIkit;
+
+use Beans\Framework\Tests\Unit\API\UIkit\Includes\UIkit_Test_Case;
+
+require_once __DIR__ . '/includes/class-uikit-test-case.php';
+
+/**
+ * Class Tests_BeansUikitGetAllComponents
+ *
+ * @package Beans\Framework\Tests\Unit\API\UIkit
+ * @group   api
+ * @group   api-uikit
+ */
+class Tests_BeansUikitGetAllComponents extends UIkit_Test_Case {
+
+	/**
+	 * Test beans_uikit_get_all_components() should not return duplicate core components.
+	 */
+	public function test_should_not_return_duplicate_core_components() {
+		$actual = beans_uikit_get_all_components( 'core' );
+
+		// Get the number of times each component appears in the array.
+		$num_times_component_in_array = array_count_values( $actual );
+
+		// Spot check the common components that are in both JS and LESS directories, meaning they could be duplicated.
+		$this->assertEquals( 1, $num_times_component_in_array['alert'] );
+		$this->assertEquals( 1, $num_times_component_in_array['button'] );
+		$this->assertEquals( 1, $num_times_component_in_array['cover'] );
+		$this->assertEquals( 1, $num_times_component_in_array['tab'] );
+
+		// By flipping the array, we should only have 1 element when there are no duplicates.
+		$this->assertCount( 1, array_flip( $num_times_component_in_array ) );
+	}
+
+	/**
+	 * Test beans_uikit_get_all_components() should not return duplicate add-ons components.
+	 */
+	public function test_should_not_return_duplicate_add_ons_components() {
+		$actual = beans_uikit_get_all_components( 'add-ons' );
+
+		// Get the number of times each component appears in the array.
+		$num_times_component_in_array = array_count_values( $actual );
+
+		// Spot check the common components that are in both JS and LESS directories, meaning they could be duplicated.
+		$this->assertEquals( 1, $num_times_component_in_array['accordion'] );
+		$this->assertEquals( 1, $num_times_component_in_array['autocomplete'] );
+		$this->assertEquals( 1, $num_times_component_in_array['datepicker'] );
+		$this->assertEquals( 1, $num_times_component_in_array['sticky'] );
+		$this->assertEquals( 1, $num_times_component_in_array['tooltip'] );
+
+		// By flipping the array, we should only have 1 element when there are no duplicates.
+		$this->assertCount( 1, array_flip( $num_times_component_in_array ) );
+	}
+
+	/**
+	 * Test beans_uikit_get_all_components() should return all core components.
+	 */
+	public function test_should_return_all_core_components() {
+		$actual = beans_uikit_get_all_components( 'core' );
+		$this->assertCount( 42, $actual );
+
+		// Check common components.
+		$this->assertContains( 'alert', $actual );
+		$this->assertContains( 'button', $actual );
+		$this->assertContains( 'cover', $actual );
+		$this->assertContains( 'grid', $actual );
+		$this->assertContains( 'nav', $actual );
+		$this->assertContains( 'offcanvas', $actual );
+		$this->assertContains( 'tab', $actual );
+		$this->assertContains( 'utility', $actual );
+
+		// Spot check the unique LESS components.
+		$this->assertContains( 'base', $actual );
+		$this->assertContains( 'close', $actual );
+		$this->assertContains( 'column', $actual );
+		$this->assertContains( 'description-list', $actual );
+		$this->assertContains( 'thumbnail', $actual );
+		$this->assertContains( 'variables', $actual );
+
+		// Spot check the unique JS components.
+		$this->assertContains( 'core', $actual );
+		$this->assertContains( 'scrollspy', $actual );
+		$this->assertContains( 'smooth-scroll', $actual );
+		$this->assertContains( 'toggle', $actual );
+		$this->assertContains( 'touch', $actual );
+
+		// Check the components do not contain add-ons.
+		$this->assertNotContains( 'accordion', $actual );
+		$this->assertNotContains( 'datepicker', $actual );
+		$this->assertNotContains( 'notify', $actual );
+		$this->assertNotContains( 'progress', $actual );
+	}
+
+	/**
+	 * Test beans_uikit_get_all_components() should return all add-ons components.
+	 */
+	public function test_should_return_all_add_ons_components() {
+		$actual = beans_uikit_get_all_components( 'add-ons' );
+		$this->assertCount( 29, $actual );
+
+		// Check common components.
+		$this->assertContains( 'accordion', $actual );
+		$this->assertContains( 'autocomplete', $actual );
+		$this->assertContains( 'datepicker', $actual );
+		$this->assertContains( 'form-password', $actual );
+		$this->assertContains( 'search', $actual );
+		$this->assertContains( 'sticky', $actual );
+		$this->assertContains( 'tooltip', $actual );
+		$this->assertContains( 'upload', $actual );
+
+		// Spot check the unique LESS components.
+		$this->assertContains( 'dotnav', $actual );
+		$this->assertContains( 'form-advanced', $actual );
+		$this->assertContains( 'htmleditor', $actual );
+
+		// Spot check the unique JS components.
+		$this->assertContains( 'parallax', $actual );
+		$this->assertContains( 'lightbox', $actual );
+		$this->assertContains( 'slideshow-fx', $actual );
+		$this->assertContains( 'timepicker', $actual );
+
+		// Check the components do not contain add-ons.
+		$this->assertNotContains( 'alert', $actual );
+		$this->assertNotContains( 'badge', $actual );
+		$this->assertNotContains( 'base', $actual );
+		$this->assertNotContains( 'close', $actual );
+	}
+}

--- a/tests/phpunit/unit/api/uikit/beansUikitGetAllDependencies.php
+++ b/tests/phpunit/unit/api/uikit/beansUikitGetAllDependencies.php
@@ -1,0 +1,261 @@
+<?php
+/**
+ * Tests for beans_uikit_get_all_dependencies().
+ *
+ * @package Beans\Framework\Tests\Unit\API\UIkit
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Unit\API\UIkit;
+
+use Beans\Framework\Tests\Unit\API\UIkit\Includes\UIkit_Test_Case;
+
+require_once __DIR__ . '/includes/class-uikit-test-case.php';
+
+/**
+ * Class Tests_BeansUikitGetAllDependencies
+ *
+ * @package Beans\Framework\Tests\Unit\API\UIkit
+ * @group   api
+ * @group   api-uikit
+ */
+class Tests_BeansUikitGetAllDependencies extends UIkit_Test_Case {
+
+	/**
+	 * Test beans_uikit_get_all_dependencies() should return empty arrays when the given components have no
+	 * dependencies.
+	 */
+	public function test_should_return_empty_arrays_when_given_components_have_no_dependencies() {
+		$components = [
+			'alert',
+			'badge',
+			'article',
+			'close',
+			'dropdown',
+		];
+
+		$this->assertSame( [
+			'core'    => [],
+			'add-ons' => [],
+		], beans_uikit_get_all_dependencies( $components ) );
+	}
+
+	/**
+	 * Test beans_uikit_get_all_dependencies() should return dependencies for the panel.
+	 */
+	public function test_should_return_dependencies_for_panel() {
+		$expected = [
+			'core'    => [ 'badge' ],
+			'add-ons' => [],
+		];
+		$this->assertSame( $expected, beans_uikit_get_all_dependencies( [ 'panel' ] ) );
+	}
+
+	/**
+	 * Test beans_uikit_get_all_dependencies() should return dependencies for the cover.
+	 */
+	public function test_should_return_dependencies_for_cover() {
+		$expected = [
+			'core'    => [ 'flex' ],
+			'add-ons' => [],
+		];
+		$this->assertSame( $expected, beans_uikit_get_all_dependencies( [ 'cover' ] ) );
+	}
+
+	/**
+	 * Test beans_uikit_get_all_dependencies() should return dependencies for the overlay.
+	 */
+	public function test_should_return_dependencies_for_overlay() {
+		$expected = [
+			'core'    => [ 'flex' ],
+			'add-ons' => [],
+		];
+		$this->assertSame( $expected, beans_uikit_get_all_dependencies( [ 'overlay' ] ) );
+	}
+
+	/**
+	 * Test beans_uikit_get_all_dependencies() should return dependencies for the tab.
+	 */
+	public function test_should_return_dependencies_for_tab() {
+		$expected = [
+			'core'    => [ 'switcher' ],
+			'add-ons' => [],
+		];
+		$this->assertSame( $expected, beans_uikit_get_all_dependencies( [ 'tab' ] ) );
+	}
+
+	/**
+	 * Test beans_uikit_get_all_dependencies() should return dependencies for the modal.
+	 */
+	public function test_should_return_dependencies_for_modal() {
+		$expected = [
+			'core'    => [ 'close' ],
+			'add-ons' => [],
+		];
+		$this->assertSame( $expected, beans_uikit_get_all_dependencies( [ 'modal' ] ) );
+	}
+
+	/**
+	 * Test beans_uikit_get_all_dependencies() should return dependencies for the scrollspy.
+	 */
+	public function test_should_return_dependencies_for_scrollspy() {
+		$expected = [
+			'core'    => [ 'animation' ],
+			'add-ons' => [],
+		];
+		$this->assertSame( $expected, beans_uikit_get_all_dependencies( [ 'scrollspy' ] ) );
+	}
+
+	/**
+	 * Test beans_uikit_get_all_dependencies() should return dependencies for the lightbox.
+	 */
+	public function test_should_return_dependencies_for_lightbox() {
+		$expected = [
+			'core'    => [
+				'animation',
+				'flex',
+				'close',
+				'modal',
+				'overlay',
+			],
+			'add-ons' => [
+				'slidenav',
+			],
+		];
+		$this->assertSame( $expected, beans_uikit_get_all_dependencies( [ 'lightbox' ] ) );
+	}
+
+	/**
+	 * Test beans_uikit_get_all_dependencies() should return dependencies for the slider.
+	 */
+	public function test_should_return_dependencies_for_slider() {
+		$expected = [
+			'core'    => [],
+			'add-ons' => [ 'slidenav' ],
+		];
+		$this->assertSame( $expected, beans_uikit_get_all_dependencies( [ 'slider' ] ) );
+	}
+
+	/**
+	 * Test beans_uikit_get_all_dependencies() should return dependencies for the slideset.
+	 */
+	public function test_should_return_dependencies_for_slideset() {
+		$expected = [
+			'core'    => [
+				'animation',
+				'flex',
+			],
+			'add-ons' => [
+				'dotnav',
+				'slidenav',
+			],
+		];
+		$this->assertSame( $expected, beans_uikit_get_all_dependencies( [ 'slideset' ] ) );
+	}
+
+	/**
+	 * Test beans_uikit_get_all_dependencies() should return dependencies for the slideshow.
+	 */
+	public function test_should_return_dependencies_for_slideshow() {
+		$expected = [
+			'core'    => [
+				'animation',
+				'flex',
+			],
+			'add-ons' => [
+				'dotnav',
+				'slidenav',
+			],
+		];
+		$this->assertSame( $expected, beans_uikit_get_all_dependencies( [ 'slideshow' ] ) );
+	}
+
+	/**
+	 * Test beans_uikit_get_all_dependencies() should return dependencies for the parallax.
+	 */
+	public function test_should_return_dependencies_for_parallax() {
+		$expected = [
+			'core'    => [ 'flex' ],
+			'add-ons' => [],
+		];
+		$this->assertSame( $expected, beans_uikit_get_all_dependencies( [ 'parallax' ] ) );
+	}
+
+	/**
+	 * Test beans_uikit_get_all_dependencies() should return dependencies for the notify.
+	 */
+	public function test_should_return_dependencies_for_notify() {
+		$expected = [
+			'core'    => [ 'close' ],
+			'add-ons' => [],
+		];
+		$this->assertSame( $expected, beans_uikit_get_all_dependencies( [ 'notify' ] ) );
+	}
+
+	/**
+	 * Test beans_uikit_get_all_dependencies() should return all dependencies for the given components.
+	 */
+	public function test_should_return_all_dependencies_for_given_components() {
+		$expected = [
+			'core'    => [
+				'badge',
+				'flex',
+			],
+			'add-ons' => [],
+		];
+		$this->assertSame( $expected, beans_uikit_get_all_dependencies( [
+			'panel',
+			'overlay',
+		] ) );
+
+		$expected = [
+			'core'    => [ 'switcher' ],
+			'add-ons' => [ 'slidenav' ],
+		];
+		$this->assertSame( $expected, beans_uikit_get_all_dependencies( [
+			'tab',
+			'slider',
+		] ) );
+
+		$expected = [
+			'core'    => [
+				'close',
+				'animation',
+				'flex',
+			],
+			'add-ons' => [
+				'dotnav',
+				'slidenav',
+			],
+		];
+		$this->assertSame( $expected, beans_uikit_get_all_dependencies( [
+			'modal',
+			'slideshow',
+			'notify',
+		] ) );
+
+		$expected = [
+			'core'    => [
+				'animation',
+				'flex',
+				'close',
+				'modal',
+				'overlay',
+				'badge',
+				'switcher',
+			],
+			'add-ons' => [
+				'slidenav',
+				'dotnav',
+			],
+		];
+		$this->assertSame( $expected, beans_uikit_get_all_dependencies( [
+			'lightbox',
+			'notify',
+			'panel',
+			'slideshow',
+			'tab',
+		] ) );
+	}
+}

--- a/tests/phpunit/unit/api/utilities/beansArrayUnique.php
+++ b/tests/phpunit/unit/api/utilities/beansArrayUnique.php
@@ -31,7 +31,7 @@ class Tests_BeansArrayUnique extends Test_Case {
 	}
 
 	/**
-	 * Test beans_array_unique() should return original array when no duplicates are found.
+	 * Test beans_array_unique() should return the original array when no duplicates are found.
 	 */
 	public function test_should_return_original_array_when_no_duplicates() {
 		$array = [ 'foo', 5, 'bar', 47 ];
@@ -42,9 +42,9 @@ class Tests_BeansArrayUnique extends Test_Case {
 	}
 
 	/**
-	 * Test beans_array_unique() should re-indexed the original array.
+	 * Test beans_array_unique() should re-index the original array.
 	 */
-	public function test_should_reindexed_original_array() {
+	public function test_should_reindex_original_array() {
 		$actual = [
 			'foo',
 			5  => 5,

--- a/tests/phpunit/unit/api/utilities/beansArrayUnique.php
+++ b/tests/phpunit/unit/api/utilities/beansArrayUnique.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Tests for beans_array_unique().
+ *
+ * @package Beans\Framework\Tests\Unit\API\Utilities
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Unit\API\Utilities;
+
+use Beans\Framework\Tests\Unit\Test_Case;
+
+/**
+ * Class Tests_BeansArrayUnique
+ *
+ * @package Beans\Framework\Tests\Unit\API\Utilities
+ * @group   api
+ * @group   api-utilities
+ * @group   api-uikit
+ */
+class Tests_BeansArrayUnique extends Test_Case {
+
+	/**
+	 * Prepares the test environment before each test.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		require_once BEANS_TESTS_LIB_DIR . 'api/utilities/functions.php';
+	}
+
+	/**
+	 * Test beans_array_unique() should return original array when no duplicates are found.
+	 */
+	public function test_should_return_original_array_when_no_duplicates() {
+		$array = [ 'foo', 5, 'bar', 47 ];
+		$this->assertSame( $array, beans_array_unique( $array ) );
+
+		$array = [ 'foo', 'bar', 'Beans', 'WordPress' ];
+		$this->assertSame( $array, beans_array_unique( $array ) );
+	}
+
+	/**
+	 * Test beans_array_unique() should re-indexed the original array.
+	 */
+	public function test_should_reindexed_original_array() {
+		$actual = [
+			'foo',
+			5  => 5,
+			10 => 'bar',
+			15 => 47,
+		];
+		$this->assertSame( [ 'foo', 5, 'bar', 47 ], beans_array_unique( $actual ) );
+
+		$actual   = [
+			'oof'   => 'foo',
+			'rab'   => 'bar',
+			'beans' => 'Beans',
+			'wp'    => 'WordPress',
+		];
+		$expected = [ 'foo', 'bar', 'Beans', 'WordPress' ];
+		$this->assertSame( $expected, beans_array_unique( $actual ) );
+	}
+
+	/**
+	 * Test beans_array_unique() should remove duplicates and re-index the array.
+	 */
+	public function test_should_remove_duplicates_and_reindex_array() {
+		$actual = [
+			'foo',
+			5  => 5,
+			10 => 'bar',
+			'foo',
+			15 => 47,
+			'bar',
+			5,
+		];
+		$this->assertSame( [ 'foo', 5, 'bar', 47 ], beans_array_unique( $actual ) );
+
+		$actual   = [
+			'oof'   => 'foo',
+			'rab'   => 'bar',
+			'beans' => 'Beans',
+			'bar',
+			'foo',
+			'wp'    => 'WordPress',
+			'Beans',
+			'foo',
+			'foo'   => 'bar',
+		];
+		$expected = [ 'foo', 'bar', 'Beans', 'WordPress' ];
+		$this->assertSame( $expected, beans_array_unique( $actual ) );
+	}
+}

--- a/tests/phpunit/unit/api/utilities/beansJoinArraysClean.php
+++ b/tests/phpunit/unit/api/utilities/beansJoinArraysClean.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Tests for beans_join_arrays_clean().
+ *
+ * @package Beans\Framework\Tests\Unit\API\Utilities
+ *
+ * @since   1.5.0
+ */
+
+namespace Beans\Framework\Tests\Unit\API\Utilities;
+
+use Beans\Framework\Tests\Unit\Test_Case;
+
+/**
+ * Class Tests_BeansJoinArraysClean
+ *
+ * @package Beans\Framework\Tests\Unit\API\Utilities
+ * @group   api
+ * @group   api-utilities
+ * @group   api-uikit
+ */
+class Tests_BeansJoinArraysClean extends Test_Case {
+
+	/**
+	 * Prepares the test environment before each test.
+	 */
+	protected function setUp() {
+		parent::setUp();
+
+		require_once BEANS_TESTS_LIB_DIR . 'api/utilities/functions.php';
+	}
+
+	/**
+	 * Test beans_join_arrays_clean() should do nothing when both arrays are empty.
+	 */
+	public function test_should_do_nothing_when_both_arrays_are_empty() {
+		$array1 = [];
+		$array2 = [];
+		$this->assertSame( [], beans_join_arrays_clean( $array1, $array2 ) );
+	}
+
+	/**
+	 * Test beans_join_arrays_clean() should return clean array1 when array 2 is empty.
+	 */
+	public function test_should_clean_array1_when_array2_is_empty() {
+		$array1 = [
+			'post_type'       => 'foo',
+			''                => '',
+			'number_of_posts' => 5,
+			'',
+		];
+		$array2 = [];
+		$this->assertSame( [ 'foo', 5 ], beans_join_arrays_clean( $array1, $array2 ) );
+		$this->assertSame( [
+			'post_type'       => 'foo',
+			'number_of_posts' => 5,
+		], beans_join_arrays_clean( $array1, $array2, false ) );
+
+		$array1 = [ '', 'foo', 'bar', '', 'baz' ];
+		$array2 = [];
+		$this->assertSame( [ 'foo', 'bar', 'baz' ], beans_join_arrays_clean( $array1, $array2 ) );
+		$this->assertSame( [
+			1 => 'foo',
+			2 => 'bar',
+			4 => 'baz',
+		], beans_join_arrays_clean( $array1, $array2, false ) );
+
+	}
+
+	/**
+	 * Test beans_join_arrays_clean() should clean array2 when array1 is empty.
+	 */
+	public function test_should_clean_array2_when_array1_is_empty() {
+		// Check with associative array.
+		$array1 = [];
+		$array2 = [
+			'post_type'       => 'foo',
+			''                => '',
+			'number_of_posts' => 5,
+			'bar'             => null,
+		];
+		$this->assertSame( [ 'foo', 5 ], beans_join_arrays_clean( $array1, $array2 ) );
+		$this->assertSame( [
+			'post_type'       => 'foo',
+			'number_of_posts' => 5,
+		], beans_join_arrays_clean( $array1, $array2, false ) );
+
+		// Check with indexed array.
+		$array1 = [];
+		$array2 = [ '', 'foo', 'bar', '', 'baz' ];
+		$this->assertSame( [ 'foo', 'bar', 'baz' ], beans_join_arrays_clean( $array1, $array2 ) );
+		$this->assertSame( [
+			1 => 'foo',
+			2 => 'bar',
+			4 => 'baz',
+		], beans_join_arrays_clean( $array1, $array2, false ) );
+	}
+
+	/**
+	 * Test beans_join_arrays_clean() should join and clean the arrays when both are not empty.
+	 */
+	public function test_should_join_and_clean_the_arrays_when_both_are_not_empty() {
+		$array1 = [
+			'foo'             => 0,
+			'baz'             => '',
+			'post_type'       => 'foo',
+			3                 => '',
+			'bar'             => null,
+			'number_of_posts' => 5,
+			5                 => 0,
+		];
+		$array2 = [
+			'foo' => 'bar',
+			'baz' => 'Hello',
+		];
+		$this->assertSame( [ 'bar', 'Hello', 'foo', 5 ], beans_join_arrays_clean( $array1, $array2 ) );
+		$this->assertSame( [
+			'foo'             => 'bar',
+			'baz'             => 'Hello',
+			'post_type'       => 'foo',
+			'number_of_posts' => 5,
+		], beans_join_arrays_clean( $array1, $array2, false ) );
+	}
+}

--- a/tests/phpunit/unit/api/utilities/beansJoinArraysClean.php
+++ b/tests/phpunit/unit/api/utilities/beansJoinArraysClean.php
@@ -64,7 +64,6 @@ class Tests_BeansJoinArraysClean extends Test_Case {
 			2 => 'bar',
 			4 => 'baz',
 		], beans_join_arrays_clean( $array1, $array2, false ) );
-
 	}
 
 	/**


### PR DESCRIPTION
This PR does several things:

1. Creates 2 new utility array functions for reuse: `beans_array_unique` and `beans_join_arrays_clean`. In doing so, we've eliminated redundant code.
2. Removes duplicates and empties from the enqueued components. Why? 
     - Run faster when iterating through the components, as there are less to loop through.
     - Re-indexing & less elements uses less memory.
3. Added 3 new functions to the UIkit API:
     - `beans_uikit_get_all_components()`
     - `beans_uikit_get_all_dependencies()`
     - `_beans_uikit_autoload_dependencies()`
These changes give plugin and theme developers access to all of the private functionality of `_Beans_Uikit`.  It also eliminates redundant code.  And it's more readable and understandable.