### PR TITLE
Updated array syntax in tests for api actions

### DIFF
--- a/tests/phpunit/integration/api/actions/beansAddAction.php
+++ b/tests/phpunit/integration/api/actions/beansAddAction.php
@@ -66,10 +66,10 @@ class Tests_BeansAddAction extends Actions_Test_Case {
 	 * Test beans_add_action() should use the action configuration in "replaced" status, when it's available.
 	 */
 	public function test_should_use_replaced_action_when_available() {
-		$replaced_action = array(
+		$replaced_action = [
 			'callback' => 'my_new_callback',
 			'priority' => 47,
-		);
+		];
 
 		foreach ( static::$test_actions as $beans_id => $original_action ) {
 			// We want to store the "replaced" action first, before we add the original action.
@@ -96,12 +96,12 @@ class Tests_BeansAddAction extends Actions_Test_Case {
 	 * Test beans_add_action() should return false when the ID is registered to the "removed" status.
 	 */
 	public function test_should_return_false_when_removed() {
-		$empty_action = array(
+		$empty_action = [
 			'hook'     => null,
 			'callback' => null,
 			'priority' => null,
 			'args'     => null,
-		);
+		];
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
 			// Store the "removed" action before we call beans_add_action().
@@ -122,10 +122,10 @@ class Tests_BeansAddAction extends Actions_Test_Case {
 	 * Test beans_add_action() should merge the "modified" action configuration parameters.
 	 */
 	public function test_should_merge_modified_action_parameters() {
-		$modified_action = array(
+		$modified_action = [
 			'callback' => 'foo',
 			'priority' => 17,
-		);
+		];
 
 		foreach ( static::$test_actions as $beans_id => $original_action ) {
 			// We want to store the "modified" action first, before we add the original action.

--- a/tests/phpunit/integration/api/actions/beansAddAnonymousAction.php
+++ b/tests/phpunit/integration/api/actions/beansAddAnonymousAction.php
@@ -25,7 +25,7 @@ class Tests_BeansAddAnonymousAction extends WP_UnitTestCase {
 	 * Test _beans_add_anonymous_action() should register callback to the given hook.
 	 */
 	public function test_should_register_callback_to_hook() {
-		_beans_add_anonymous_action( 'do_foo', array( 'foo_test_callback', array( 'foo' ) ) );
+		_beans_add_anonymous_action( 'do_foo', [ 'foo_test_callback', [ 'foo' ] ] );
 
 		$this->assertTrue( has_action( 'do_foo' ) );
 	}
@@ -34,7 +34,7 @@ class Tests_BeansAddAnonymousAction extends WP_UnitTestCase {
 	 * Test _beans_add_anonymous_action() should call callback on the given hook.
 	 */
 	public function test_should_call_callback() {
-		_beans_add_anonymous_action( 'beans_test_do_foo', array( 'foo_test_callback', array( 'foo' ) ) );
+		_beans_add_anonymous_action( 'beans_test_do_foo', [ 'foo_test_callback', [ 'foo' ] ] );
 
 		Functions\when( 'foo_test_callback' )
 			->justReturn( 'foo' );

--- a/tests/phpunit/integration/api/actions/beansGetCurrentAction.php
+++ b/tests/phpunit/integration/api/actions/beansGetCurrentAction.php
@@ -75,11 +75,11 @@ class Tests_BeansGetCurrentAction extends Actions_Test_Case {
 	public function test_should_return_merged_added_and_modified_action() {
 		global $_beans_registered_actions;
 
-		$modified_action = array(
+		$modified_action = [
 			'callback' => 'callback',
 			'priority' => 27,
 			'args'     => 14,
-		);
+		];
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
 			// Store the action in the registry.

--- a/tests/phpunit/integration/api/actions/beansMergeAction.php
+++ b/tests/phpunit/integration/api/actions/beansMergeAction.php
@@ -27,7 +27,7 @@ class Tests_BeansMergeAction extends Actions_Test_Case {
 	 *
 	 * @var array
 	 */
-	protected $statuses = array( 'added', 'modified', 'removed', 'replaced' );
+	protected $statuses = [ 'added', 'modified', 'removed', 'replaced' ];
 
 	/**
 	 * Test _beans_set_action() should merge the new action's configuration with the registered one and then return it.
@@ -35,9 +35,9 @@ class Tests_BeansMergeAction extends Actions_Test_Case {
 	public function test_should_merge_and_return() {
 		global $_beans_registered_actions;
 
-		$modified_action = array(
+		$modified_action = [
 			'priority' => 29,
-		);
+		];
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
 			$merged_action = array_merge( $action, $modified_action );

--- a/tests/phpunit/integration/api/actions/beansModifyAction.php
+++ b/tests/phpunit/integration/api/actions/beansModifyAction.php
@@ -68,9 +68,9 @@ class Tests_BeansModifyAction extends Actions_Test_Case {
 	 * Test beans_modify_action() should modify the registered action's hook.
 	 */
 	public function test_should_modify_the_action_hook() {
-		$modified_action = array(
+		$modified_action = [
 			'hook' => 'foo',
-		);
+		];
 
 		$this->go_to_post();
 
@@ -97,9 +97,9 @@ class Tests_BeansModifyAction extends Actions_Test_Case {
 	 * Test beans_modify_action() should modify the registered action's callback.
 	 */
 	public function test_should_modify_the_action_callback() {
-		$modified_action = array(
+		$modified_action = [
 			'callback' => 'my_callback',
-		);
+		];
 
 		$this->go_to_post();
 
@@ -128,19 +128,19 @@ class Tests_BeansModifyAction extends Actions_Test_Case {
 	public function test_should_modify_the_action_priority() {
 		global $wp_filter;
 
-		$modified_action = array(
+		$modified_action = [
 			'priority' => 20,
-		);
+		];
 
 		$this->go_to_post();
 
 		foreach ( static::$test_actions as $beans_id => $original_action ) {
 			// Check the starting state.
 			$this->assertEquals(
-				array(
+				[
 					'function'      => $original_action['callback'],
 					'accepted_args' => $original_action['args'],
-				),
+				],
 				$wp_filter[ $original_action['hook'] ]->callbacks[ $original_action['priority'] ][ $original_action['callback'] ]
 			);
 
@@ -160,10 +160,10 @@ class Tests_BeansModifyAction extends Actions_Test_Case {
 
 			// Check that the action's priority was modified in WordPress.
 			$this->assertEquals(
-				array(
+				[
 					'function'      => $original_action['callback'],
 					'accepted_args' => $original_action['args'],
-				),
+				],
 				$callbacks_in_wp[ $modified_action['priority'] ][ $original_action['callback'] ]
 			);
 		}
@@ -175,9 +175,9 @@ class Tests_BeansModifyAction extends Actions_Test_Case {
 	public function test_should_modify_the_action_args() {
 		global $wp_filter;
 
-		$modified_action = array(
+		$modified_action = [
 			'args' => 7,
-		);
+		];
 
 		$this->go_to_post();
 

--- a/tests/phpunit/integration/api/actions/beansModifyActionArguments.php
+++ b/tests/phpunit/integration/api/actions/beansModifyActionArguments.php
@@ -28,12 +28,12 @@ class Tests_BeansModifyActionArguments extends Actions_Test_Case {
 	public function test_should_return_false_when_args_is_non_integer() {
 		global $wp_filter;
 
-		$arguments = array(
+		$arguments = [
 			null,
-			array( 10 ),
+			[ 10 ],
 			false,
 			'',
-		);
+		];
 
 		$this->go_to_post();
 
@@ -66,7 +66,7 @@ class Tests_BeansModifyActionArguments extends Actions_Test_Case {
 	public function test_should_modify_action_when_args_is_zero() {
 		global $wp_filter;
 
-		$arguments = array( 0, 0.0, '0', '0.0' );
+		$arguments = [ 0, 0.0, '0', '0.0' ];
 
 		$this->go_to_post();
 
@@ -82,7 +82,7 @@ class Tests_BeansModifyActionArguments extends Actions_Test_Case {
 				$this->assertTrue( beans_modify_action_arguments( $beans_id, $number_of_args ) );
 
 				// Check that the modified action is registered as "modified" in Beans.
-				$this->assertEquals( array( 'args' => (int) $number_of_args ), _beans_get_action( $beans_id, 'modified' ) );
+				$this->assertEquals( [ 'args' => (int) $number_of_args ], _beans_get_action( $beans_id, 'modified' ) );
 
 				// Check that the action's number of arguments was modified in WordPress.
 				$this->assertEquals(
@@ -107,7 +107,7 @@ class Tests_BeansModifyActionArguments extends Actions_Test_Case {
 			$this->assertFalse( beans_modify_action_arguments( $beans_id, $action['args'] ) );
 
 			// Check that the modified action is registered as "modified" in Beans.
-			$this->assertEquals( array( 'args' => $action['args'] ), _beans_get_action( $beans_id, 'modified' ) );
+			$this->assertEquals( [ 'args' => $action['args'] ], _beans_get_action( $beans_id, 'modified' ) );
 
 			// Check that the action was not added in WordPress.
 			$this->assertFalse( has_action( $action['hook'], $action['callback'] ) );
@@ -120,9 +120,9 @@ class Tests_BeansModifyActionArguments extends Actions_Test_Case {
 	public function test_should_modify_the_action_args() {
 		global $wp_filter;
 
-		$modified_action = array(
+		$modified_action = [
 			'args' => 7,
-		);
+		];
 
 		$this->go_to_post();
 

--- a/tests/phpunit/integration/api/actions/beansModifyActionCallback.php
+++ b/tests/phpunit/integration/api/actions/beansModifyActionCallback.php
@@ -26,11 +26,11 @@ class Tests_BeansModifyActionCallback extends Actions_Test_Case {
 	 * Test beans_modify_action_callback() should not modify when the callback is invalid.
 	 */
 	public function test_should_not_modify_when_invalid_callback() {
-		$callbacks = array(
+		$callbacks = [
 			null,
 			false,
 			'',
-		);
+		];
 
 		$this->go_to_post();
 
@@ -65,7 +65,7 @@ class Tests_BeansModifyActionCallback extends Actions_Test_Case {
 			$this->assertFalse( beans_modify_action_callback( $beans_id, $action['callback'] ) );
 
 			// Check that it did register as "modified" in Beans.
-			$this->assertEquals( array( 'callback' => $action['callback'] ), _beans_get_action( $beans_id, 'modified' ) );
+			$this->assertEquals( [ 'callback' => $action['callback'] ], _beans_get_action( $beans_id, 'modified' ) );
 
 			// Check that the action was not added in WordPress.
 			$this->assertFalse( has_action( $action['hook'], $action['callback'] ) );
@@ -76,9 +76,9 @@ class Tests_BeansModifyActionCallback extends Actions_Test_Case {
 	 * Test beans_modify_action_callback() should modify the registered action's callback.
 	 */
 	public function test_should_modify_the_action_callback() {
-		$modified_action = array(
+		$modified_action = [
 			'callback' => 'my_callback',
-		);
+		];
 
 		$this->go_to_post();
 

--- a/tests/phpunit/integration/api/actions/beansModifyActionHook.php
+++ b/tests/phpunit/integration/api/actions/beansModifyActionHook.php
@@ -26,15 +26,15 @@ class Tests_BeansModifyActionHook extends Actions_Test_Case {
 	 * Test beans_modify_action_hook() should not modify the action when the hook is invalid.
 	 */
 	public function test_should_not_modify_when_invalid_hook() {
-		$hooks = array(
+		$hooks = [
 			null,
 			false,
-			array( 'foo' ),
+			[ 'foo' ],
 			'',
 			0,
 			0.0,
 			'0',
-		);
+		];
 
 		$this->go_to_post();
 
@@ -69,7 +69,7 @@ class Tests_BeansModifyActionHook extends Actions_Test_Case {
 			$this->assertFalse( beans_modify_action_hook( $beans_id, $action['hook'] ) );
 
 			// Check that it did register as "modified" in Beans.
-			$this->assertEquals( array( 'hook' => $action['hook'] ), _beans_get_action( $beans_id, 'modified' ) );
+			$this->assertEquals( [ 'hook' => $action['hook'] ], _beans_get_action( $beans_id, 'modified' ) );
 
 			// Check that the action was not added in WordPress.
 			$this->assertFalse( has_action( $action['hook'], $action['callback'] ) );
@@ -80,9 +80,9 @@ class Tests_BeansModifyActionHook extends Actions_Test_Case {
 	 * Test beans_modify_action_hook() should modify the registered action's hook.
 	 */
 	public function test_should_modify_the_action_hook() {
-		$modified_action = array(
+		$modified_action = [
 			'hook' => 'foo',
-		);
+		];
 
 		$this->go_to_post();
 

--- a/tests/phpunit/integration/api/actions/beansModifyActionPriority.php
+++ b/tests/phpunit/integration/api/actions/beansModifyActionPriority.php
@@ -28,22 +28,22 @@ class Tests_BeansModifyActionPriority extends Actions_Test_Case {
 	public function test_should_return_false_when_priority_is_non_integer() {
 		global $wp_filter;
 
-		$priorities = array(
+		$priorities = [
 			null,
-			array( 10 ),
+			[ 10 ],
 			false,
 			'',
-		);
+		];
 
 		$this->go_to_post();
 
 		foreach ( static::$test_actions as $beans_id => $original_action ) {
 			// Check the starting state.
 			$this->assertEquals(
-				array(
+				[
 					'function'      => $original_action['callback'],
 					'accepted_args' => $original_action['args'],
-				),
+				],
 				$wp_filter[ $original_action['hook'] ]->callbacks[ $original_action['priority'] ][ $original_action['callback'] ]
 			);
 
@@ -56,10 +56,10 @@ class Tests_BeansModifyActionPriority extends Actions_Test_Case {
 
 				// Check that the priority did not change in WordPress.
 				$this->assertEquals(
-					array(
+					[
 						'function'      => $original_action['callback'],
 						'accepted_args' => $original_action['args'],
-					),
+					],
 					$wp_filter[ $original_action['hook'] ]->callbacks[ $original_action['priority'] ][ $original_action['callback'] ]
 				);
 			}
@@ -72,17 +72,17 @@ class Tests_BeansModifyActionPriority extends Actions_Test_Case {
 	public function test_should_modify_action_when_priority_is_zero() {
 		global $wp_filter;
 
-		$priorities = array( 0, 0.0, '0', '0.0' );
+		$priorities = [ 0, 0.0, '0', '0.0' ];
 
 		$this->go_to_post();
 
 		foreach ( static::$test_actions as $beans_id => $original_action ) {
 			// Check the starting state.
 			$this->assertEquals(
-				array(
+				[
 					'function'      => $original_action['callback'],
 					'accepted_args' => $original_action['args'],
-				),
+				],
 				$wp_filter[ $original_action['hook'] ]->callbacks[ $original_action['priority'] ][ $original_action['callback'] ]
 			);
 
@@ -91,7 +91,7 @@ class Tests_BeansModifyActionPriority extends Actions_Test_Case {
 				$this->assertTrue( beans_modify_action_priority( $beans_id, $priority ) );
 
 				// Check that the modified action is registered as "modified" in Beans.
-				$this->assertEquals( array( 'priority' => (int) $priority ), _beans_get_action( $beans_id, 'modified' ) );
+				$this->assertEquals( [ 'priority' => (int) $priority ], _beans_get_action( $beans_id, 'modified' ) );
 
 				// Check that the priority did change in WordPress.
 				$this->check_modified_in_wp( $original_action, (int) $priority );
@@ -113,7 +113,7 @@ class Tests_BeansModifyActionPriority extends Actions_Test_Case {
 			$this->assertFalse( beans_modify_action_priority( $beans_id, $action['priority'] ) );
 
 			// Check that it did register as "modified" in Beans.
-			$this->assertEquals( array( 'priority' => $action['priority'] ), _beans_get_action( $beans_id, 'modified' ) );
+			$this->assertEquals( [ 'priority' => $action['priority'] ], _beans_get_action( $beans_id, 'modified' ) );
 
 			// Check that the action was not added in WordPress.
 			$this->assertFalse( has_action( $action['hook'], $action['callback'] ) );
@@ -126,19 +126,19 @@ class Tests_BeansModifyActionPriority extends Actions_Test_Case {
 	public function test_should_modify_the_action_priority() {
 		global $wp_filter;
 
-		$modified_action = array(
+		$modified_action = [
 			'priority' => 20,
-		);
+		];
 
 		$this->go_to_post();
 
 		foreach ( static::$test_actions as $beans_id => $original_action ) {
 			// Check the starting state.
 			$this->assertEquals(
-				array(
+				[
 					'function'      => $original_action['callback'],
 					'accepted_args' => $original_action['args'],
-				),
+				],
 				$wp_filter[ $original_action['hook'] ]->callbacks[ $original_action['priority'] ][ $original_action['callback'] ]
 			);
 
@@ -177,10 +177,10 @@ class Tests_BeansModifyActionPriority extends Actions_Test_Case {
 
 		// Check that the action's priority was modified in WordPress.
 		$this->assertEquals(
-			array(
+			[
 				'function'      => $original_action['callback'],
 				'accepted_args' => $original_action['args'],
-			),
+			],
 			$callbacks_in_wp[ $new_priority ][ $original_action['callback'] ]
 		);
 	}

--- a/tests/phpunit/integration/api/actions/beansRemoveAction.php
+++ b/tests/phpunit/integration/api/actions/beansRemoveAction.php
@@ -29,12 +29,12 @@ class Tests_BeansRemoveAction extends Actions_Test_Case {
 	 * Intent: We are testing to ensure Beans is "load order" agnostic.
 	 */
 	public function test_should_store_when_action_is_not_registered() {
-		$empty_action = array(
+		$empty_action = [
 			'hook'     => null,
 			'callback' => null,
 			'priority' => null,
 			'args'     => null,
-		);
+		];
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
 			// Test that the original action has not yet been added.

--- a/tests/phpunit/integration/api/actions/beansReplaceAction.php
+++ b/tests/phpunit/integration/api/actions/beansReplaceAction.php
@@ -30,7 +30,7 @@ class Tests_BeansReplaceAction extends Replace_Action_Test_Case {
 	 */
 	public function test_should_store_when_action_is_not_registered() {
 		$replaced_callback = 'my_replaced_callback';
-		$replaced_action   = array( 'callback' => $replaced_callback );
+		$replaced_action   = [ 'callback' => $replaced_callback ];
 
 		foreach ( static::$test_ids as $beans_id ) {
 			// Test that the original action has not yet been added.
@@ -55,7 +55,7 @@ class Tests_BeansReplaceAction extends Replace_Action_Test_Case {
 	 */
 	public function test_should_store_and_then_replace_action() {
 		$replaced_callback = 'my_replaced_callback';
-		$replaced_action   = array( 'callback' => $replaced_callback );
+		$replaced_action   = [ 'callback' => $replaced_callback ];
 
 		// Store the "replaced" action.
 		foreach ( static::$test_ids as $beans_id ) {
@@ -103,9 +103,9 @@ class Tests_BeansReplaceAction extends Replace_Action_Test_Case {
 	 * Test beans_replace_action() should replace the registered action's hook.
 	 */
 	public function test_should_replace_the_action_hook() {
-		$replaced_action = array(
+		$replaced_action = [
 			'hook' => 'foo',
-		);
+		];
 
 		$this->go_to_post();
 
@@ -134,9 +134,9 @@ class Tests_BeansReplaceAction extends Replace_Action_Test_Case {
 	 * Test beans_replace_action() should replace the registered action's callback.
 	 */
 	public function test_should_replace_the_action_callback() {
-		$replaced_action = array(
+		$replaced_action = [
 			'callback' => 'foo',
-		);
+		];
 
 		$this->go_to_post();
 
@@ -165,9 +165,9 @@ class Tests_BeansReplaceAction extends Replace_Action_Test_Case {
 	 * Test beans_replace_action() should replace the registered action's priority level.
 	 */
 	public function test_should_replace_the_action_priority() {
-		$replaced_action = array(
+		$replaced_action = [
 			'priority' => 52,
-		);
+		];
 
 		$this->go_to_post();
 
@@ -196,9 +196,9 @@ class Tests_BeansReplaceAction extends Replace_Action_Test_Case {
 	 * Test beans_replace_action() should replace the registered action's number of arguments.
 	 */
 	public function test_should_replace_the_action_args() {
-		$replaced_action = array(
+		$replaced_action = [
 			'args' => 6,
-		);
+		];
 
 		$this->go_to_post();
 
@@ -227,12 +227,12 @@ class Tests_BeansReplaceAction extends Replace_Action_Test_Case {
 	 * Test beans_replace_action() should replace the original registered action.
 	 */
 	public function test_should_replace_the_action() {
-		$replaced_action = array(
+		$replaced_action = [
 			'hook'     => 'new_hook',
 			'callback' => 'new_callback',
 			'priority' => 99,
 			'args'     => 10,
-		);
+		];
 
 		$this->go_to_post();
 

--- a/tests/phpunit/integration/api/actions/beansReplaceActionArguments.php
+++ b/tests/phpunit/integration/api/actions/beansReplaceActionArguments.php
@@ -29,9 +29,9 @@ class Tests_BeansReplaceActionArguments extends Replace_Action_Test_Case {
 	 * Intent: We are testing to ensure Beans is "load order" agnostic.
 	 */
 	public function test_should_store_when_action_is_not_registered() {
-		$replaced_action = array(
+		$replaced_action = [
 			'args' => 10,
-		);
+		];
 
 		// Store the "replaced" action.
 		foreach ( static::$test_ids as $beans_id ) {
@@ -53,9 +53,9 @@ class Tests_BeansReplaceActionArguments extends Replace_Action_Test_Case {
 	 * Intent: We are testing to ensure Beans is "load order" agnostic.
 	 */
 	public function test_should_store_and_then_replace_the_args() {
-		$replaced_action = array(
+		$replaced_action = [
 			'args' => 10,
-		);
+		];
 
 		// Now replace the actions.
 		foreach ( static::$test_ids as $beans_id ) {
@@ -101,9 +101,9 @@ class Tests_BeansReplaceActionArguments extends Replace_Action_Test_Case {
 	 * Test beans_replace_action_arguments() should replace the registered action's args.
 	 */
 	public function test_should_replace_the_action_args() {
-		$replaced_action = array(
+		$replaced_action = [
 			'args' => 14,
-		);
+		];
 
 		$this->go_to_post();
 

--- a/tests/phpunit/integration/api/actions/beansReplaceActionCallback.php
+++ b/tests/phpunit/integration/api/actions/beansReplaceActionCallback.php
@@ -29,9 +29,9 @@ class Tests_BeansReplaceActionCallback extends Replace_Action_Test_Case {
 	 * Intent: We are testing to ensure Beans is "load order" agnostic.
 	 */
 	public function test_should_store_when_action_is_not_registered() {
-		$replaced_action = array(
+		$replaced_action = [
 			'callback' => 'my_new_callback',
-		);
+		];
 
 		foreach ( static::$test_ids as $beans_id ) {
 			// Test that the original action has not yet been added.
@@ -52,9 +52,9 @@ class Tests_BeansReplaceActionCallback extends Replace_Action_Test_Case {
 	 * Intent: We are testing to ensure Beans is "load order" agnostic.
 	 */
 	public function test_should_store_and_then_replace_the_callback() {
-		$replaced_action = array(
+		$replaced_action = [
 			'callback' => 'foo',
-		);
+		];
 
 		// Now replace the actions.
 		foreach ( static::$test_ids as $beans_id ) {
@@ -100,9 +100,9 @@ class Tests_BeansReplaceActionCallback extends Replace_Action_Test_Case {
 	 * Test beans_replace_action_callback() should replace the registered action's callback.
 	 */
 	public function test_should_replace_the_action_callback() {
-		$replaced_action = array(
+		$replaced_action = [
 			'callback' => 'beans_foo',
-		);
+		];
 
 		$this->go_to_post();
 

--- a/tests/phpunit/integration/api/actions/beansReplaceActionHook.php
+++ b/tests/phpunit/integration/api/actions/beansReplaceActionHook.php
@@ -29,9 +29,9 @@ class Tests_BeansReplaceActionHook extends Replace_Action_Test_Case {
 	 * Intent: We are testing to ensure Beans is "load order" agnostic.
 	 */
 	public function test_should_store_when_action_is_not_registered() {
-		$replaced_action = array(
+		$replaced_action = [
 			'hook' => 'my_new_hook',
-		);
+		];
 
 		foreach ( static::$test_ids as $beans_id ) {
 			// Test that the original action has not yet been added.
@@ -52,9 +52,9 @@ class Tests_BeansReplaceActionHook extends Replace_Action_Test_Case {
 	 * Intent: We are testing to ensure Beans is "load order" agnostic.
 	 */
 	public function test_should_store_and_then_replace_the_hook() {
-		$replaced_action = array(
+		$replaced_action = [
 			'hook' => 'foo',
-		);
+		];
 
 		// Now replace the actions.
 		foreach ( static::$test_ids as $beans_id ) {
@@ -110,9 +110,9 @@ class Tests_BeansReplaceActionHook extends Replace_Action_Test_Case {
 			$this->assertEquals( $action_config['hook'], $original_action['hook'] );
 
 			// Set up what will get stored in Beans.
-			$replaced_action = array(
+			$replaced_action = [
 				'hook' => 'beans_foo',
-			);
+			];
 
 			// Run the replace.
 			$this->assertTrue( beans_replace_action_hook( $beans_id, $replaced_action['hook'] ) );

--- a/tests/phpunit/integration/api/actions/beansReplaceActionPriority.php
+++ b/tests/phpunit/integration/api/actions/beansReplaceActionPriority.php
@@ -29,9 +29,9 @@ class Tests_BeansReplaceActionPriority extends Replace_Action_Test_Case {
 	 * Intent: We are testing to ensure Beans is "load order" agnostic.
 	 */
 	public function test_should_store_when_action_is_not_registered() {
-		$replaced_action = array(
+		$replaced_action = [
 			'priority' => 99,
-		);
+		];
 
 		foreach ( static::$test_ids as $beans_id ) {
 			// Test that the original action has not yet been added.
@@ -52,9 +52,9 @@ class Tests_BeansReplaceActionPriority extends Replace_Action_Test_Case {
 	 * Intent: We are testing to ensure Beans is "load order" agnostic.
 	 */
 	public function test_should_store_and_then_replace_the_priority() {
-		$replaced_action = array(
+		$replaced_action = [
 			'priority' => 10000,
-		);
+		];
 
 		// Now replace the actions.
 		foreach ( static::$test_ids as $beans_id ) {
@@ -100,9 +100,9 @@ class Tests_BeansReplaceActionPriority extends Replace_Action_Test_Case {
 	 * Test beans_replace_action_priority() should replace the registered action's priority.
 	 */
 	public function test_should_replace_the_action_priority() {
-		$replaced_action = array(
+		$replaced_action = [
 			'priority' => 999,
-		);
+		];
 
 		$this->go_to_post();
 

--- a/tests/phpunit/integration/api/actions/beansResetAction.php
+++ b/tests/phpunit/integration/api/actions/beansResetAction.php
@@ -63,9 +63,9 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 	 * Test beans_reset_action() should reset the original action's hook after it was "modified".
 	 */
 	public function test_should_reset_after_modifying_the_hook() {
-		$modified_action = array(
+		$modified_action = [
 			'hook' => 'foo',
-		);
+		];
 
 		$this->go_to_post();
 
@@ -97,9 +97,9 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 	public function test_should_reset_after_modifying_the_callback() {
 		global $wp_filter;
 
-		$modified_action = array(
+		$modified_action = [
 			'callback' => 'my_callback',
-		);
+		];
 
 		$this->go_to_post();
 
@@ -132,9 +132,9 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 	public function test_should_reset_after_modifying_the_priority() {
 		global $wp_filter;
 
-		$modified_action = array(
+		$modified_action = [
 			'priority' => 9999,
-		);
+		];
 
 		$this->go_to_post();
 
@@ -170,9 +170,9 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 	public function test_should_reset_after_modifying_the_args() {
 		global $wp_filter;
 
-		$modified_action = array(
+		$modified_action = [
 			'args' => 14,
-		);
+		];
 
 		$this->go_to_post();
 
@@ -210,10 +210,10 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 
 		$this->go_to_post();
 
-		$modified_action = array(
+		$modified_action = [
 			'callback' => 'my_callback',
 			'args'     => 14,
-		);
+		];
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
 			// Before we start, check that the action is registered.
@@ -227,10 +227,10 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 			$this->assertFalse( has_action( $action['hook'], $action['callback'] ) );
 			$this->assertTrue( has_action( $action['hook'], $modified_action['callback'] ) !== false );
 			$this->assertEquals(
-				array(
+				[
 					'function'      => $modified_action['callback'],
 					'accepted_args' => $modified_action['args'],
-				),
+				],
 				$wp_filter[ $action['hook'] ]->callbacks[ $action['priority'] ][ $modified_action['callback'] ]
 			);
 
@@ -251,10 +251,10 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 
 		$this->go_to_post();
 
-		$modified_action = array(
+		$modified_action = [
 			'priority' => 79,
 			'args'     => 14,
-		);
+		];
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
 			// Before we start, check that the action is registered.
@@ -266,10 +266,10 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 			// Check that the action was modified.
 			$this->assertSame( $modified_action, _beans_get_action( $beans_id, 'modified' ) );
 			$this->assertEquals(
-				array(
+				[
 					'function'      => $action['callback'],
 					'accepted_args' => $modified_action['args'],
-				),
+				],
 				$wp_filter[ $action['hook'] ]->callbacks[ $modified_action['priority'] ][ $action['callback'] ]
 			);
 
@@ -290,10 +290,10 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 
 		$this->go_to_post();
 
-		$modified_action = array(
+		$modified_action = [
 			'callback' => 'foo',
 			'priority' => 39,
-		);
+		];
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
 			// Before we start, check that the action is registered.
@@ -305,10 +305,10 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 			// Check that the action was modified.
 			$this->assertSame( $modified_action, _beans_get_action( $beans_id, 'modified' ) );
 			$this->assertEquals(
-				array(
+				[
 					'function'      => $modified_action['callback'],
 					'accepted_args' => $action['args'],
-				),
+				],
 				$wp_filter[ $action['hook'] ]->callbacks[ $modified_action['priority'] ][ $modified_action['callback'] ]
 			);
 
@@ -330,11 +330,11 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 
 		$this->go_to_post();
 
-		$modified_action = array(
+		$modified_action = [
 			'callback' => 'foo',
 			'priority' => 39,
 			'args'     => 24,
-		);
+		];
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
 			// Before we start, check that the action is registered.
@@ -346,10 +346,10 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 			// Check that the action was modified.
 			$this->assertSame( $modified_action, _beans_get_action( $beans_id, 'modified' ) );
 			$this->assertEquals(
-				array(
+				[
 					'function'      => $modified_action['callback'],
 					'accepted_args' => $modified_action['args'],
-				),
+				],
 				$wp_filter[ $action['hook'] ]->callbacks[ $modified_action['priority'] ][ $modified_action['callback'] ]
 			);
 
@@ -429,10 +429,10 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 		foreach ( static::$test_actions as $beans_id => $action ) {
 			// Before we start, do a hard check to ensure the original priority is registered.
 			$this->assertEquals(
-				array(
+				[
 					'function'      => $action['callback'],
 					'accepted_args' => $action['args'],
-				),
+				],
 				$wp_filter[ $action['hook'] ]->callbacks[ $action['priority'] ][ $action['callback'] ]
 			);
 
@@ -444,10 +444,10 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 
 			// Check that the action was not reset.
 			$this->assertEquals(
-				array(
+				[
 					'function'      => $action['callback'],
 					'accepted_args' => $action['args'],
-				),
+				],
 				$wp_filter[ $action['hook'] ]->callbacks[ $priority ][ $action['callback'] ]
 			);
 		}
@@ -503,10 +503,10 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 		$this->assertTrue( has_action( $action['hook'], $action['callback'] ) !== false );
 
 		$this->assertEquals(
-			array(
+			[
 				'function'      => $action['callback'],
 				'accepted_args' => $action['args'],
-			),
+			],
 			$wp_filter[ $action['hook'] ]->callbacks[ $action['priority'] ][ $action['callback'] ]
 		);
 	}

--- a/tests/phpunit/integration/api/actions/beansSetAction.php
+++ b/tests/phpunit/integration/api/actions/beansSetAction.php
@@ -27,7 +27,7 @@ class Tests_BeansSetAction extends Actions_Test_Case {
 	 *
 	 * @var array
 	 */
-	protected $statuses = array( 'added', 'modified', 'removed', 'replaced' );
+	protected $statuses = [ 'added', 'modified', 'removed', 'replaced' ];
 
 	/**
 	 * Test _beans_set_action() should set (registered) the action and then return it.
@@ -56,12 +56,12 @@ class Tests_BeansSetAction extends Actions_Test_Case {
 	public function test_should_not_overwrite_existing_registered_action() {
 		global $_beans_registered_actions;
 
-		$new_action = array(
+		$new_action = [
 			'hook'     => 'bar',
 			'callback' => 'callback_bar',
 			'priority' => 20,
 			'args'     => 2,
-		);
+		];
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
 
@@ -84,12 +84,12 @@ class Tests_BeansSetAction extends Actions_Test_Case {
 	public function test_should_overwrite_existing_registered_action() {
 		global $_beans_registered_actions;
 
-		$new_action = array(
+		$new_action = [
 			'hook'     => 'bar',
 			'callback' => 'callback_bar',
 			'priority' => 20,
 			'args'     => 2,
-		);
+		];
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
 

--- a/tests/phpunit/integration/api/actions/beansUnsetAction.php
+++ b/tests/phpunit/integration/api/actions/beansUnsetAction.php
@@ -27,7 +27,7 @@ class Tests_BeansUnsetAction extends Actions_Test_Case {
 	 *
 	 * @var array
 	 */
-	protected $statuses = array( 'added', 'modified', 'removed', 'replaced' );
+	protected $statuses = [ 'added', 'modified', 'removed', 'replaced' ];
 
 	/**
 	 * Test _beans_unset_action() should return false when action is not registered.

--- a/tests/phpunit/integration/api/actions/fixtures/test-actions.php
+++ b/tests/phpunit/integration/api/actions/fixtures/test-actions.php
@@ -7,23 +7,23 @@
  * @since   1.5.0
  */
 
-return array(
-	'beans_post_meta'          => array(
+return [
+	'beans_post_meta'          => [
 		'hook'     => 'beans_post_header',
 		'callback' => 'beans_post_meta',
 		'priority' => 15,
 		'args'     => 1,
-	),
-	'beans_post_image'         => array(
+	],
+	'beans_post_image'         => [
 		'hook'     => 'beans_post_body',
 		'callback' => 'beans_post_image',
 		'priority' => 5,
 		'args'     => 1,
-	),
-	'beans_previous_post_link' => array(
+	],
+	'beans_previous_post_link' => [
 		'hook'     => 'previous_post_link',
 		'callback' => 'beans_previous_post_link',
 		'priority' => 10,
 		'args'     => 4,
-	),
-);
+	],
+];

--- a/tests/phpunit/integration/api/actions/includes/class-actions-test-case.php
+++ b/tests/phpunit/integration/api/actions/includes/class-actions-test-case.php
@@ -56,12 +56,12 @@ abstract class Actions_Test_Case extends WP_UnitTestCase {
 		parent::tearDownAfterClass();
 
 		global $_beans_registered_actions;
-		$_beans_registered_actions = array(
-			'added'    => array(),
-			'modified' => array(),
-			'removed'  => array(),
-			'replaced' => array(),
-		);
+		$_beans_registered_actions = [
+			'added'    => [],
+			'modified' => [],
+			'removed'  => [],
+			'replaced' => [],
+		];
 
 		// Remove the test actions.
 		foreach ( static::$test_actions as $beans_id => $action ) {
@@ -82,12 +82,12 @@ abstract class Actions_Test_Case extends WP_UnitTestCase {
 		}
 
 		global $_beans_registered_actions;
-		$_beans_registered_actions = array(
-			'added'    => array(),
-			'modified' => array(),
-			'removed'  => array(),
-			'replaced' => array(),
-		);
+		$_beans_registered_actions = [
+			'added'    => [],
+			'modified' => [],
+			'removed'  => [],
+			'replaced' => [],
+		];
 
 		parent::tearDown();
 	}
@@ -174,12 +174,12 @@ abstract class Actions_Test_Case extends WP_UnitTestCase {
 	 * @return array
 	 */
 	protected function setup_original_action( $id = 'foo' ) {
-		$action = array(
+		$action = [
 			'hook'     => "{$id}_hook",
 			'callback' => "callback_{$id}",
 			'priority' => 10,
 			'args'     => 1,
-		);
+		];
 
 		$this->check_not_added( $id, $action['hook'] );
 
@@ -208,7 +208,7 @@ abstract class Actions_Test_Case extends WP_UnitTestCase {
 			$this->restore_original( $beans_id );
 		}
 
-		$post_id = self::factory()->post->create( array( 'post_title' => 'Hello Beans' ) );
+		$post_id = self::factory()->post->create( [ 'post_title' => 'Hello Beans' ] );
 		$this->go_to( get_permalink( $post_id ) );
 		do_action( 'template_redirect' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Valid use case as we need to fire this action as part of our tests.
 	}

--- a/tests/phpunit/integration/api/actions/includes/class-replace-action-test-case.php
+++ b/tests/phpunit/integration/api/actions/includes/class-replace-action-test-case.php
@@ -80,12 +80,12 @@ abstract class Replace_Action_Test_Case extends Actions_Test_Case {
 	 */
 	protected function merge_action_with_defaults( array $action ) {
 		return array_merge(
-			array(
+			[
 				'hook'     => null,
 				'callback' => null,
 				'priority' => null,
 				'args'     => null,
-			),
+			],
 			$action
 		);
 	}

--- a/tests/phpunit/unit/api/actions/beans-anonymous-action/__construct.php
+++ b/tests/phpunit/unit/api/actions/beans-anonymous-action/__construct.php
@@ -36,24 +36,24 @@ class Tests_BeansAnonymousAction_Construct extends Actions_Test_Case {
 	 * Test __construct() should set the callback and arguments.
 	 */
 	public function test_should_set_callback_and_arguments() {
-		$anonymous_action = new _Beans_Anonymous_Action( 'beans_test_do_foo', array(
+		$anonymous_action = new _Beans_Anonymous_Action( 'beans_test_do_foo', [
 			'foo_test_callback',
-			array( 'foo', 'bar', 'baz' ),
-		) );
+			[ 'foo', 'bar', 'baz' ],
+		] );
 
 		$this->assertSame( 'foo_test_callback', $anonymous_action->callback[0] );
-		$this->assertSame( array( 'foo', 'bar', 'baz' ), $anonymous_action->callback[1] );
+		$this->assertSame( [ 'foo', 'bar', 'baz' ], $anonymous_action->callback[1] );
 	}
 
 	/**
 	 * Test __construct() should add the action's hook.
 	 */
 	public function test_should_add_action_hook() {
-		$anonymous_action = new _Beans_Anonymous_Action( 'beans_test_do_foo', array(
+		$anonymous_action = new _Beans_Anonymous_Action( 'beans_test_do_foo', [
 			'foo_test_callback',
-			array( 'foo' ),
-		), 50, 3 );
+			[ 'foo' ],
+		], 50, 3 );
 
-		$this->assertTrue( has_action( 'beans_test_do_foo', array( $anonymous_action, 'callback' ) ) );
+		$this->assertTrue( has_action( 'beans_test_do_foo', [ $anonymous_action, 'callback' ] ) );
 	}
 }

--- a/tests/phpunit/unit/api/actions/beans-anonymous-action/callback.php
+++ b/tests/phpunit/unit/api/actions/beans-anonymous-action/callback.php
@@ -37,10 +37,10 @@ class Tests_BeansAnonymousAction_Callback extends Actions_Test_Case {
 	 * Test _Beans_Anonymous_Action::callback() should invoke the given callback, passing the arguments to it.
 	 */
 	public function test_should_invoke_callback() {
-		$anonymous_action = new _Beans_Anonymous_Action( 'beans_test_do_foo', array(
+		$anonymous_action = new _Beans_Anonymous_Action( 'beans_test_do_foo', [
 			'foo_test_callback',
-			array( 'foo', 'bar' ),
-		), 20, 2 );
+			[ 'foo', 'bar' ],
+		], 20, 2 );
 
 		// Check that the callback is invoked with each of its parameters.
 		Monkey\Functions\expect( 'foo_test_callback' )
@@ -60,9 +60,9 @@ class Tests_BeansAnonymousAction_Callback extends Actions_Test_Case {
 	 * Test _Beans_Anonymous_Action::callback() should echo the returned content.
 	 */
 	public function test_should_echo_returned_content() {
-		$anonymous_action = new _Beans_Anonymous_Action( 'beans_test_do_foo', array(
+		$anonymous_action = new _Beans_Anonymous_Action( 'beans_test_do_foo', [
 			'foo_test_callback',
-			array( 'Cool Beans!', 'It worked!' ),
+			[ 'Cool Beans!', 'It worked!' ],
 		) );
 
 		Monkey\Functions\when( 'foo_test_callback' )->alias( function( $arg1, $arg2 ) {

--- a/tests/phpunit/unit/api/actions/beans-anonymous-action/callback.php
+++ b/tests/phpunit/unit/api/actions/beans-anonymous-action/callback.php
@@ -63,7 +63,7 @@ class Tests_BeansAnonymousAction_Callback extends Actions_Test_Case {
 		$anonymous_action = new _Beans_Anonymous_Action( 'beans_test_do_foo', [
 			'foo_test_callback',
 			[ 'Cool Beans!', 'It worked!' ],
-		) );
+		] );
 
 		Monkey\Functions\when( 'foo_test_callback' )->alias( function( $arg1, $arg2 ) {
 			return "{$arg1} {$arg2}";

--- a/tests/phpunit/unit/api/actions/beansAddAction.php
+++ b/tests/phpunit/unit/api/actions/beansAddAction.php
@@ -109,10 +109,10 @@ class Tests_BeansAddAction extends Actions_Test_Case {
 	 */
 	public function test_should_use_replaced_action_when_available() {
 		global $_beans_registered_actions;
-		$replaced_action = array(
+		$replaced_action = [
 			'callback' => 'my_new_callback',
 			'priority' => 47,
-		);
+		];
 
 		foreach ( static::$test_actions as $beans_id => $original_action ) {
 			// Set up the mocks.
@@ -164,12 +164,12 @@ class Tests_BeansAddAction extends Actions_Test_Case {
 	 */
 	public function test_should_return_false_when_removed() {
 		global $_beans_registered_actions;
-		$empty_action = array(
+		$empty_action = [
 			'hook'     => null,
 			'callback' => null,
 			'priority' => null,
 			'args'     => null,
-		);
+		];
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
 			// Set up the mocks.
@@ -214,10 +214,10 @@ class Tests_BeansAddAction extends Actions_Test_Case {
 	 */
 	public function test_should_merge_modified_action_parameters() {
 		global $_beans_registered_actions;
-		$modified_action = array(
+		$modified_action = [
 			'callback' => 'foo',
 			'priority' => 17,
-		);
+		];
 
 		foreach ( static::$test_actions as $beans_id => $original_action ) {
 			// Set up the mocks.

--- a/tests/phpunit/unit/api/actions/beansGetCurrentAction.php
+++ b/tests/phpunit/unit/api/actions/beansGetCurrentAction.php
@@ -96,11 +96,11 @@ class Tests_BeansGetCurrentAction extends Actions_Test_Case {
 	 * Test _beans_get_current_action() should return the merged "added" and "modified" action.
 	 */
 	public function test_should_return_merged_added_and_modified_action() {
-		$modified_action = array(
+		$modified_action = [
 			'callback' => 'callback',
 			'priority' => 27,
 			'args'     => 14,
-		);
+		];
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
 			Monkey\Functions\expect( '_beans_get_action' )

--- a/tests/phpunit/unit/api/actions/beansMergeAction.php
+++ b/tests/phpunit/unit/api/actions/beansMergeAction.php
@@ -28,15 +28,15 @@ class Tests_BeansMergeAction extends Actions_Test_Case {
 	 *
 	 * @var array
 	 */
-	protected $statuses = array( 'added', 'modified', 'removed', 'replaced' );
+	protected $statuses = [ 'added', 'modified', 'removed', 'replaced' ];
 
 	/**
 	 * Test _beans_set_action() should merge the new action's configuration with the registered one and then return it.
 	 */
 	public function test_should_merge_and_return() {
-		$modified_action = array(
+		$modified_action = [
 			'priority' => 29,
-		);
+		];
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
 			$merged_action = array_merge( $action, $modified_action );

--- a/tests/phpunit/unit/api/actions/beansModifyAction.php
+++ b/tests/phpunit/unit/api/actions/beansModifyAction.php
@@ -97,8 +97,8 @@ class Tests_BeansModifyAction extends Actions_Test_Case {
 			// When called, return the modified action.
 			Monkey\Functions\expect( '_beans_merge_action' )
 				->once()
-				->with( $beans_id, array( 'hook' => $modified_hook ), 'modified' )
-				->andReturn( array( 'hook' => $modified_hook ) );
+				->with( $beans_id, [ 'hook' => $modified_hook ], 'modified' )
+				->andReturn( [ 'hook' => $modified_hook ] );
 
 			// Expect the modified hook is added, but not the original hook.
 			Monkey\Actions\expectAdded( $original_action['hook'] )->never();
@@ -131,8 +131,8 @@ class Tests_BeansModifyAction extends Actions_Test_Case {
 			// When called, return the modified action.
 			Monkey\Functions\expect( '_beans_merge_action' )
 				->once()
-				->with( $beans_id, array( 'callback' => $modified_callback ), 'modified' )
-				->andReturn( array( 'callback' => $modified_callback ) );
+				->with( $beans_id, [ 'callback' => $modified_callback ], 'modified' )
+				->andReturn( [ 'callback' => $modified_callback ] );
 
 			// Expect the original hook with the modified callback.
 			Monkey\Actions\expectAdded( $original_action['hook'] )
@@ -164,8 +164,8 @@ class Tests_BeansModifyAction extends Actions_Test_Case {
 			// When called, return the modified action.
 			Monkey\Functions\expect( '_beans_merge_action' )
 				->once()
-				->with( $beans_id, array( 'priority' => $modified_priority ), 'modified' )
-				->andReturn( array( 'priority' => $modified_priority ) );
+				->with( $beans_id, [ 'priority' => $modified_priority ], 'modified' )
+				->andReturn( [ 'priority' => $modified_priority ] );
 
 			// Expect the original hook with the modified callback.
 			Monkey\Actions\expectAdded( $original_action['hook'] )
@@ -198,8 +198,8 @@ class Tests_BeansModifyAction extends Actions_Test_Case {
 				// When called, return the modified action.
 				Monkey\Functions\expect( '_beans_merge_action' )
 					->once()
-					->with( $beans_id, array( 'args' => $modified_args ), 'modified' )
-					->andReturn( array( 'args' => $modified_args ) );
+					->with( $beans_id, [ 'args' => $modified_args ], 'modified' )
+					->andReturn( [ 'args' => $modified_args ] );
 
 				// Expect the original hook with the modified callback.
 				Monkey\Actions\expectAdded( $original_action['hook'] )

--- a/tests/phpunit/unit/api/actions/beansModifyActionHook.php
+++ b/tests/phpunit/unit/api/actions/beansModifyActionHook.php
@@ -32,7 +32,7 @@ class Tests_BeansModifyActionHook extends Actions_Test_Case {
 			Monkey\Functions\expect( 'beans_modify_action' )->never();
 
 			$this->assertFalse( beans_modify_action_hook( $beans_id, '' ) );
-			$this->assertFalse( beans_modify_action_hook( $beans_id, array( 'not-a-string' ) ) );
+			$this->assertFalse( beans_modify_action_hook( $beans_id, [ 'not-a-string' ] ) );
 		}
 	}
 

--- a/tests/phpunit/unit/api/actions/beansRemoveAction.php
+++ b/tests/phpunit/unit/api/actions/beansRemoveAction.php
@@ -29,12 +29,12 @@ class Tests_BeansRemoveAction extends Replace_Action_Test_Case {
 	 * Intent: We are testing to ensure Beans is "load order" agnostic.
 	 */
 	public function test_should_store_when_action_is_not_registered() {
-		$expected = array(
+		$expected = [
 			'hook'     => null,
 			'callback' => null,
 			'priority' => null,
 			'args'     => null,
-		);
+		];
 
 		foreach ( static::$test_actions as $beans_id => $original_action ) {
 			// Simulate that there is no "added" action.

--- a/tests/phpunit/unit/api/actions/beansRenderAction.php
+++ b/tests/phpunit/unit/api/actions/beansRenderAction.php
@@ -54,7 +54,7 @@ class Tests_BeansRenderAction extends Test_Case {
 			[ 'foo' ],
 			[ 'foo', 'bar' ],
 			[ 'foo', 'bar', 'baz' ],
-		);
+		];
 		$callback      = function() use ( $expected_args ) {
 			$args = func_get_args();
 			$this->assertTrue( doing_action( 'beans_stub' ) );

--- a/tests/phpunit/unit/api/actions/beansRenderAction.php
+++ b/tests/phpunit/unit/api/actions/beansRenderAction.php
@@ -38,7 +38,7 @@ class Tests_BeansRenderAction extends Test_Case {
 	public function test_should_return_false_when_a_callback_is_not_registered() {
 		$this->assertFalse( _beans_render_action( 'foo' ) );
 		$this->assertFalse( _beans_render_action( 'foo', 'bar' ) );
-		$this->assertFalse( _beans_render_action( 'foo', 'bar', array( 'baz' => 'zab' ) ) );
+		$this->assertFalse( _beans_render_action( 'foo', 'bar', [ 'baz' => 'zab' ] ) );
 		$this->assertFalse( _beans_render_action( 'foo_bar' ) );
 		$this->assertFalse( _beans_render_action( 'foo.bar' ) );
 		$this->assertFalse( _beans_render_action( 'beans_footer_before_markup' ) );
@@ -50,10 +50,10 @@ class Tests_BeansRenderAction extends Test_Case {
 	 */
 	public function test_should_return_after_calling_hook_with_no_subhook() {
 		// Testing with a closure.
-		$expected_args = array(
-			array( 'foo' ),
-			array( 'foo', 'bar' ),
-			array( 'foo', 'bar', 'baz' ),
+		$expected_args = [
+			[ 'foo' ],
+			[ 'foo', 'bar' ],
+			[ 'foo', 'bar', 'baz' ],
 		);
 		$callback      = function() use ( $expected_args ) {
 			$args = func_get_args();
@@ -73,16 +73,16 @@ class Tests_BeansRenderAction extends Test_Case {
 		// Testing with a stubbed method.
 		$stub    = new Actions_Stub();
 		$message = 'Beans rocks!';
-		add_action( 'beans_stub_with_object', array( $stub, 'echo_static' ) );
+		add_action( 'beans_stub_with_object', [ $stub, 'echo_static' ] );
 		$this->assertTrue( has_action( 'beans_stub_with_object' ) );
-		Actions\expectDone( 'beans_stub_with_object' )->whenHappen( array( $stub, 'echo_static' ) );
+		Actions\expectDone( 'beans_stub_with_object' )->whenHappen( [ $stub, 'echo_static' ] );
 		$this->assertEquals( $message, _beans_render_action( 'beans_stub_with_object', $message ) );
 
 		// Testing with a stubbed static method.
 		$stub = Actions_Stub::class;
-		add_action( 'beans_stub_with_static_method', array( $stub, 'echo_static' ) );
+		add_action( 'beans_stub_with_static_method', [ $stub, 'echo_static' ] );
 		$this->assertTrue( has_action( 'beans_stub_with_static_method' ) );
-		Actions\expectDone( 'beans_stub_with_static_method' )->times( 3 )->whenHappen( array( $stub, 'echo_static' ) );
+		Actions\expectDone( 'beans_stub_with_static_method' )->times( 3 )->whenHappen( [ $stub, 'echo_static' ] );
 
 		$message = 'Calling the static method...and Beans rocks!';
 		$this->assertEquals( $message, _beans_render_action( 'beans_stub_with_static_method', $message ) );
@@ -108,28 +108,28 @@ class Tests_BeansRenderAction extends Test_Case {
 		$stub = Actions_Stub::class;
 
 		// Test with a single sub-hook.
-		add_action( 'foo', array( $stub, 'echo_static' ) );
-		Actions\expectDone( 'foo' )->whenHappen( array( $stub, 'echo_static' ) );
+		add_action( 'foo', [ $stub, 'echo_static' ] );
+		Actions\expectDone( 'foo' )->whenHappen( [ $stub, 'echo_static' ] );
 		Actions\expectDone( 'bar' )->never();
 		$this->assertEquals( 'Called foo.', _beans_render_action( 'foo[bar]', 'Called foo.' ) );
 
 		// Test with a suffix.
-		add_action( 'foo_bar', array( $stub, 'echo_static' ) );
-		Actions\expectDone( 'foo_bar' )->whenHappen( array( $stub, 'echo_static' ) );
+		add_action( 'foo_bar', [ $stub, 'echo_static' ] );
+		Actions\expectDone( 'foo_bar' )->whenHappen( [ $stub, 'echo_static' ] );
 		Actions\expectDone( 'baz_bar' )->never();
 		$this->assertEquals( 'Called foo_bar.', _beans_render_action( 'foo[baz]_bar', 'Called foo_bar.' ) );
 
 		// Test with multiple sub-hooks.
-		add_action( 'beans_stub', array( $stub, 'echo_static' ) );
-		Actions\expectDone( 'beans_stub' )->whenHappen( array( $stub, 'echo_static' ) );
+		add_action( 'beans_stub', [ $stub, 'echo_static' ] );
+		Actions\expectDone( 'beans_stub' )->whenHappen( [ $stub, 'echo_static' ] );
 		Actions\expectDone( 'beans_stub[_pre]' )->never();
 		Actions\expectDone( 'beans_stub[_before]' )->never();
 		Actions\expectDone( 'beans_stub[_pre][_before]' )->never();
 		$this->assertEquals( 'Beans rocks!', _beans_render_action( 'beans_stub[_pre][_before]', 'Beans rocks!' ) );
 
 		// Test with multiple sub-hooks.
-		add_action( 'beans_stub_after', array( $stub, 'echo_static' ) );
-		Actions\expectDone( 'beans_stub_after' )->whenHappen( array( $stub, 'echo_static' ) );
+		add_action( 'beans_stub_after', [ $stub, 'echo_static' ] );
+		Actions\expectDone( 'beans_stub_after' )->whenHappen( [ $stub, 'echo_static' ] );
 		Actions\expectDone( 'beans_stub[_pre]_after' )->never();
 		Actions\expectDone( 'beans_stub[_before]_after' )->never();
 		Actions\expectDone( 'beans_stub[_pre][_before]_after' )->never();
@@ -145,13 +145,13 @@ class Tests_BeansRenderAction extends Test_Case {
 		$message = 'Called me. ';
 
 		// The root hook renders.
-		add_action( 'foo', array( $stub, 'echo_static' ) );
-		Actions\expectDone( 'foo' )->once()->whenHappen( array( $stub, 'echo_static' ) );
+		add_action( 'foo', [ $stub, 'echo_static' ] );
+		Actions\expectDone( 'foo' )->once()->whenHappen( [ $stub, 'echo_static' ] );
 		$expected = $message;
 
 		// The 1st sub-hook renders.
-		add_action( 'foo[bar]', array( $stub, 'echo_static' ) );
-		Actions\expectDone( 'foo[bar]' )->once()->whenHappen( array( $stub, 'echo_static' ) );
+		add_action( 'foo[bar]', [ $stub, 'echo_static' ] );
+		Actions\expectDone( 'foo[bar]' )->once()->whenHappen( [ $stub, 'echo_static' ] );
 		$expected .= $message;
 
 		// Run the test.
@@ -168,13 +168,13 @@ class Tests_BeansRenderAction extends Test_Case {
 		$message = 'Called me. ';
 
 		// The root hook renders.
-		add_action( 'foo', array( $stub, 'echo_static' ) );
-		Actions\expectDone( 'foo' )->once()->whenHappen( array( $stub, 'echo_static' ) );
+		add_action( 'foo', [ $stub, 'echo_static' ] );
+		Actions\expectDone( 'foo' )->once()->whenHappen( [ $stub, 'echo_static' ] );
 		$expected = $message;
 
 		// The 1st sub-hook renders.
-		add_action( 'foo[bar]', array( $stub, 'echo_static' ) );
-		Actions\expectDone( 'foo[bar]' )->once()->whenHappen( array( $stub, 'echo_static' ) );
+		add_action( 'foo[bar]', [ $stub, 'echo_static' ] );
+		Actions\expectDone( 'foo[bar]' )->once()->whenHappen( [ $stub, 'echo_static' ] );
 		$expected .= $message;
 
 		// These hooks will not render as they are not registered.
@@ -194,23 +194,23 @@ class Tests_BeansRenderAction extends Test_Case {
 		$message = 'Called me. ';
 
 		// The root hook renders.
-		add_action( 'foo', array( $stub, 'echo_static' ) );
-		Actions\expectDone( 'foo' )->once()->whenHappen( array( $stub, 'echo_static' ) );
+		add_action( 'foo', [ $stub, 'echo_static' ] );
+		Actions\expectDone( 'foo' )->once()->whenHappen( [ $stub, 'echo_static' ] );
 		$expected = $message;
 
 		// The 1st sub-hook renders.
-		add_action( 'foo[bar]', array( $stub, 'echo_static' ) );
-		Actions\expectDone( 'foo[bar]' )->once()->whenHappen( array( $stub, 'echo_static' ) );
+		add_action( 'foo[bar]', [ $stub, 'echo_static' ] );
+		Actions\expectDone( 'foo[bar]' )->once()->whenHappen( [ $stub, 'echo_static' ] );
 		$expected .= $message;
 
 		// The 2nd sub-hook renders.
-		add_action( 'foo[baz]', array( $stub, 'echo_static' ) );
-		Actions\expectDone( 'foo[baz]' )->once()->whenHappen( array( $stub, 'echo_static' ) );
+		add_action( 'foo[baz]', [ $stub, 'echo_static' ] );
+		Actions\expectDone( 'foo[baz]' )->once()->whenHappen( [ $stub, 'echo_static' ] );
 		$expected .= $message;
 
 		// The original hook renders.
-		add_action( 'foo[bar][baz]', array( $stub, 'echo_static' ) );
-		Actions\expectDone( 'foo[bar][baz]' )->once()->whenHappen( array( $stub, 'echo_static' ) );
+		add_action( 'foo[bar][baz]', [ $stub, 'echo_static' ] );
+		Actions\expectDone( 'foo[bar][baz]' )->once()->whenHappen( [ $stub, 'echo_static' ] );
 		$expected .= $message;
 
 		// Run the test.

--- a/tests/phpunit/unit/api/actions/beansReplaceAction.php
+++ b/tests/phpunit/unit/api/actions/beansReplaceAction.php
@@ -46,7 +46,7 @@ class Tests_BeansReplaceAction extends Replace_Action_Test_Case {
 	 */
 	public function test_should_store_when_action_is_not_registered() {
 		$replaced_callback = 'my_new_callback';
-		$replaced_action   = array( 'callback' => $replaced_callback );
+		$replaced_action   = [ 'callback' => $replaced_callback ];
 
 		foreach ( static::$test_ids as $beans_id ) {
 			Monkey\Functions\expect( '_beans_merge_action' )
@@ -75,7 +75,7 @@ class Tests_BeansReplaceAction extends Replace_Action_Test_Case {
 	 */
 	public function test_should_replace_the_action_hook() {
 		$replaced_hook   = 'foo';
-		$replaced_action = array( 'hook' => $replaced_hook );
+		$replaced_action = [ 'hook' => $replaced_hook ];
 
 		foreach ( static::$test_ids as $beans_id ) {
 			Monkey\Functions\expect( '_beans_merge_action' )
@@ -104,7 +104,7 @@ class Tests_BeansReplaceAction extends Replace_Action_Test_Case {
 	 */
 	public function test_should_replace_the_action_callback() {
 		$replaced_callback = 'my_replaced_callback';
-		$replaced_action   = array( 'callback' => $replaced_callback );
+		$replaced_action   = [ 'callback' => $replaced_callback ];
 
 		foreach ( static::$test_ids as $beans_id ) {
 			Monkey\Functions\expect( '_beans_merge_action' )
@@ -133,7 +133,7 @@ class Tests_BeansReplaceAction extends Replace_Action_Test_Case {
 	 */
 	public function test_should_replace_the_action_priority() {
 		$replaced_priority = - 2;
-		$replaced_action   = array( 'priority' => $replaced_priority );
+		$replaced_action   = [ 'priority' => $replaced_priority ];
 
 		foreach ( static::$test_ids as $beans_id ) {
 			Monkey\Functions\expect( '_beans_merge_action' )
@@ -162,7 +162,7 @@ class Tests_BeansReplaceAction extends Replace_Action_Test_Case {
 	 */
 	public function test_should_replace_the_action_args() {
 		$replaced_args   = 6;
-		$replaced_action = array( 'args' => $replaced_args );
+		$replaced_action = [ 'args' => $replaced_args ];
 
 		foreach ( static::$test_ids as $beans_id ) {
 			Monkey\Functions\expect( '_beans_merge_action' )

--- a/tests/phpunit/unit/api/actions/beansReplaceActionHook.php
+++ b/tests/phpunit/unit/api/actions/beansReplaceActionHook.php
@@ -32,7 +32,7 @@ class Tests_BeansReplaceActionHook extends Replace_Action_Test_Case {
 			Monkey\Functions\expect( 'beans_replace_action' )->never();
 
 			$this->assertFalse( beans_replace_action_hook( $beans_id, '' ) );
-			$this->assertFalse( beans_replace_action_hook( $beans_id, array( 'not-a-string' ) ) );
+			$this->assertFalse( beans_replace_action_hook( $beans_id, [ 'not-a-string' ] ) );
 		}
 	}
 

--- a/tests/phpunit/unit/api/actions/beansResetAction.php
+++ b/tests/phpunit/unit/api/actions/beansResetAction.php
@@ -81,10 +81,10 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 	public function test_should_reset_after_modifying_the_action() {
 		Monkey\Functions\when( '_beans_unset_action' );
 
-		$modified_action = array(
+		$modified_action = [
 			'callback' => 'my_new_callback',
 			'priority' => 47,
-		);
+		];
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
 			// Simulate modifying the action.
@@ -125,7 +125,7 @@ class Tests_BeansResetAction extends Actions_Test_Case {
 		Monkey\Functions\when( '_beans_unset_action' );
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
-			$replaced_action = array_merge( $action, array( 'hook' => 'replaced_hook' ) );
+			$replaced_action = array_merge( $action, [ 'hook' => 'replaced_hook' ] );
 
 			// Simulate that the replaced action is registered.
 			Monkey\Functions\expect( '_beans_get_action' )

--- a/tests/phpunit/unit/api/actions/beansSetAction.php
+++ b/tests/phpunit/unit/api/actions/beansSetAction.php
@@ -28,7 +28,7 @@ class Tests_BeansSetAction extends Actions_Test_Case {
 	 *
 	 * @var array
 	 */
-	protected $statuses = array( 'added', 'modified', 'removed', 'replaced' );
+	protected $statuses = [ 'added', 'modified', 'removed', 'replaced' ];
 
 	/**
 	 * Test _beans_set_action() should set (register) the action and then return it.
@@ -62,12 +62,12 @@ class Tests_BeansSetAction extends Actions_Test_Case {
 	public function test_should_not_overwrite_existing_registered_action() {
 		global $_beans_registered_actions;
 
-		$new_action = array(
+		$new_action = [
 			'hook'     => 'bar',
 			'callback' => 'callback_bar',
 			'priority' => 20,
 			'args'     => 2,
-		);
+		];
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
 
@@ -96,12 +96,12 @@ class Tests_BeansSetAction extends Actions_Test_Case {
 	public function test_should_overwrite_existing_registered_action() {
 		global $_beans_registered_actions;
 
-		$new_action = array(
+		$new_action = [
 			'hook'     => 'bar',
 			'callback' => 'callback_bar',
 			'priority' => 20,
 			'args'     => 2,
-		);
+		];
 
 		foreach ( static::$test_actions as $beans_id => $action ) {
 

--- a/tests/phpunit/unit/api/actions/beansUniqueActionId.php
+++ b/tests/phpunit/unit/api/actions/beansUniqueActionId.php
@@ -52,17 +52,17 @@ class Tests_BeansUniqueActionId extends Test_Case {
 	public function test_should_convert_static_method() {
 		$this->assertEquals(
 			'Foo::bar',
-			_beans_unique_action_id( array( 'Foo', 'bar' ) )
+			_beans_unique_action_id( [ 'Foo', 'bar' ] )
 		);
 		$this->assertEquals(
 			'Tests_BeansUniqueActionId::test_should_return_when_string',
-			_beans_unique_action_id( array( 'Tests_BeansUniqueActionId', 'test_should_return_when_string' ) )
+			_beans_unique_action_id( [ 'Tests_BeansUniqueActionId', 'test_should_return_when_string' ] )
 		);
 
 		$stub_classname = __NAMESPACE__ . '\Actions_Stub';
 		$this->assertEquals(
 			$stub_classname . '::dummy_static_method',
-			_beans_unique_action_id( array( $stub_classname, 'dummy_static_method' ) )
+			_beans_unique_action_id( [ $stub_classname, 'dummy_static_method' ] )
 		);
 		$this->assertEquals(
 			$stub_classname . '::dummy_static_method',
@@ -72,15 +72,15 @@ class Tests_BeansUniqueActionId extends Test_Case {
 		$stub = new Actions_Stub();
 		$this->assertNotEquals(
 			$stub_classname . '::dummy_static_method',
-			_beans_unique_action_id( array( $stub, 'dummy_static_method' ) )
+			_beans_unique_action_id( [ $stub, 'dummy_static_method' ] )
 		);
 		$this->assertStringEndsWith(
 			'dummy_static_method',
-			_beans_unique_action_id( array( $stub, 'dummy_static_method' ) )
+			_beans_unique_action_id( [ $stub, 'dummy_static_method' ] )
 		);
 		$this->assertEquals(
 			spl_object_hash( $stub ) . 'dummy_static_method',
-			_beans_unique_action_id( array( $stub, 'dummy_static_method' ) )
+			_beans_unique_action_id( [ $stub, 'dummy_static_method' ] )
 		);
 	}
 
@@ -96,7 +96,7 @@ class Tests_BeansUniqueActionId extends Test_Case {
 		$this->assertEquals( spl_object_hash( $stub ), _beans_unique_action_id( $stub ) );
 		$this->assertEquals(
 			spl_object_hash( $stub ) . 'dummy_method',
-			_beans_unique_action_id( array( $stub, 'dummy_method' ) )
+			_beans_unique_action_id( [ $stub, 'dummy_method' ] )
 		);
 	}
 

--- a/tests/phpunit/unit/api/actions/beansUnsetAction.php
+++ b/tests/phpunit/unit/api/actions/beansUnsetAction.php
@@ -28,7 +28,7 @@ class Tests_BeansUnsetAction extends Actions_Test_Case {
 	 *
 	 * @var array
 	 */
-	protected $statuses = array( 'added', 'modified', 'removed', 'replaced' );
+	protected $statuses = [ 'added', 'modified', 'removed', 'replaced' ];
 
 	/**
 	 * Test _beans_unset_action() should return false when action is not registered.

--- a/tests/phpunit/unit/api/actions/fixtures/test-actions.php
+++ b/tests/phpunit/unit/api/actions/fixtures/test-actions.php
@@ -7,23 +7,23 @@
  * @since   1.5.0
  */
 
-return array(
-	'beans_post_meta'          => array(
+return [
+	'beans_post_meta'          => [
 		'hook'     => 'beans_post_header',
 		'callback' => 'beans_post_meta',
 		'priority' => 15,
 		'args'     => 1,
-	),
-	'beans_post_image'         => array(
+	],
+	'beans_post_image'         => [
 		'hook'     => 'beans_post_body',
 		'callback' => 'beans_post_image',
 		'priority' => 5,
 		'args'     => 1,
-	),
-	'beans_previous_post_link' => array(
+	],
+	'beans_previous_post_link' => [
 		'hook'     => 'previous_post_link',
 		'callback' => 'beans_previous_post_link',
 		'priority' => 10,
 		'args'     => 4,
-	),
-);
+	],
+];

--- a/tests/phpunit/unit/api/actions/includes/class-actions-test-case.php
+++ b/tests/phpunit/unit/api/actions/includes/class-actions-test-case.php
@@ -50,12 +50,12 @@ abstract class Actions_Test_Case extends Test_Case {
 		parent::tearDownAfterClass();
 
 		global $_beans_registered_actions;
-		$_beans_registered_actions = array(
-			'added'    => array(),
-			'modified' => array(),
-			'removed'  => array(),
-			'replaced' => array(),
-		);
+		$_beans_registered_actions = [
+			'added'    => [],
+			'modified' => [],
+			'removed'  => [],
+			'replaced' => [],
+		];
 
 		// Remove the test actions.
 		foreach ( static::$test_actions as $beans_id => $action ) {
@@ -72,10 +72,10 @@ abstract class Actions_Test_Case extends Test_Case {
 	protected function setUp() {
 		parent::setUp();
 
-		$this->load_original_functions( array(
+		$this->load_original_functions( [
 			'api/actions/functions.php',
 			'api/utilities/functions.php',
-		) );
+		] );
 
 		Monkey\Functions\when( 'beans_get' )->alias( function ( $needle, $haystack ) {
 


### PR DESCRIPTION
Updated array syntax from array() to [] 
#254 

Covers only test for API 'actions' 
Unit and Integration tests