### PR TITLE
Fixed regression in Customizer preventing the logo to refresh.

### DIFF
--- a/lib/admin/wp-customize.php
+++ b/lib/admin/wp-customize.php
@@ -72,6 +72,7 @@ function beans_do_register_wp_customize_options() {
 			'label'       => __( 'Viewport Width - for Previewing Only', 'tm-beans' ),
 			'description' => __( 'Slide left or right to change the viewport width. Publishing will not change the width of your website.', 'tm-beans' ),
 			'type'        => 'group',
+			'transport'   => 'postMessage',
 			'fields'      => array(
 				array(
 					'id'      => 'beans_enable_viewport_width',
@@ -95,6 +96,7 @@ function beans_do_register_wp_customize_options() {
 			'label'       => __( 'Viewport Height - for Previewing Only', 'tm-beans' ),
 			'description' => __( 'Slide left or right to change the viewport height. Publishing will not change the height of your website.', 'tm-beans' ),
 			'type'        => 'group',
+			'transport'   => 'postMessage',
 			'fields'      => array(
 				array(
 					'id'      => 'beans_enable_viewport_height',

--- a/lib/api/wp-customize/class-beans-wp-customize.php
+++ b/lib/api/wp-customize/class-beans-wp-customize.php
@@ -143,7 +143,7 @@ final class _Beans_WP_Customize {
 		$defaults = array(
 			'db_type'    => 'theme_mod',
 			'capability' => 'edit_theme_options',
-			'transport'  => 'postMessage',
+			'transport'  => 'refresh',
 		);
 
 		$field = array_merge( $defaults, $field );


### PR DESCRIPTION
This reverts the default Customizer transport method back to `refresh` and adds `'transport' => 'postMessage'` to the preview tools config.
Fixes #293