### PR TITLE
Cleaned up security audit messages & escaping.

### DIFF
--- a/lib/templates/fragments/comments.php
+++ b/lib/templates/fragments/comments.php
@@ -95,7 +95,7 @@ function beans_comment_badges() {
 	if ( 'trackback' === $comment->comment_type ) {
 		beans_open_markup_e( 'beans_trackback_badge', 'span', array( 'class' => 'uk-badge uk-margin-small-left' ) );
 
-			beans_output_e( 'beans_trackback_text', __( 'Trackback', 'tm-beans' ) );
+			beans_output_e( 'beans_trackback_text', esc_html__( 'Trackback', 'tm-beans' ) );
 
 		beans_close_markup_e( 'beans_trackback_badge', 'span' );
 	}
@@ -104,7 +104,7 @@ function beans_comment_badges() {
 	if ( 'pingback' === $comment->comment_type ) {
 		beans_open_markup_e( 'beans_pingback_badge', 'span', array( 'class' => 'uk-badge uk-margin-small-left' ) );
 
-			beans_output_e( 'beans_pingback_text', __( 'Pingback', 'tm-beans' ) );
+			beans_output_e( 'beans_pingback_text', esc_html__( 'Pingback', 'tm-beans' ) );
 
 		beans_close_markup_e( 'beans_pingback_badge', 'span' );
 	}
@@ -113,7 +113,7 @@ function beans_comment_badges() {
 	if ( '0' === $comment->comment_approved ) {
 		beans_open_markup_e( 'beans_moderation_badge', 'span', array( 'class' => 'uk-badge uk-margin-small-left uk-badge-warning' ) );
 
-			beans_output_e( 'beans_moderation_text', __( 'Awaiting Moderation', 'tm-beans' ) );
+			beans_output_e( 'beans_moderation_text', esc_html__( 'Awaiting Moderation', 'tm-beans' ) );
 
 		beans_close_markup_e( 'beans_moderation_badge', 'span' );
 	}
@@ -122,7 +122,7 @@ function beans_comment_badges() {
 	if ( user_can( $comment->user_id, 'moderate_comments' ) ) {
 		beans_open_markup_e( 'beans_moderator_badge', 'span', array( 'class' => 'uk-badge uk-margin-small-left' ) );
 
-			beans_output_e( 'beans_moderator_text', __( 'Moderator', 'tm-beans' ) );
+			beans_output_e( 'beans_moderator_text', esc_html__( 'Moderator', 'tm-beans' ) );
 
 		beans_close_markup_e( 'beans_moderator_badge', 'span' );
 	}
@@ -212,7 +212,7 @@ function beans_comment_links() {
 				)
 			);
 
-				beans_output_e( 'beans_comment_edit_text', __( 'Edit', 'tm-beans' ) );
+				beans_output_e( 'beans_comment_edit_text', esc_html__( 'Edit', 'tm-beans' ) );
 
 			beans_close_markup_e( 'beans_comment_item_link[_edit]', 'a' );
 
@@ -230,7 +230,7 @@ endif;
 				)
 			);
 
-				beans_output_e( 'beans_comment_link_text', __( 'Link', 'tm-beans' ) );
+				beans_output_e( 'beans_comment_link_text', esc_html__( 'Link', 'tm-beans' ) );
 
 			beans_close_markup_e( 'beans_comment_item_link[_link]', 'a' );
 
@@ -250,7 +250,7 @@ beans_add_smart_action( 'beans_no_comment', 'beans_no_comment' );
 function beans_no_comment() {
 	beans_open_markup_e( 'beans_no_comment', 'p', 'class=uk-text-muted' );
 
-		beans_output_e( 'beans_no_comment_text', __( 'No comment yet, add your voice below!', 'tm-beans' ) );
+		beans_output_e( 'beans_no_comment_text', esc_html__( 'No comment yet, add your voice below!', 'tm-beans' ) );
 
 	beans_close_markup_e( 'beans_no_comment', 'p' );
 }
@@ -266,7 +266,7 @@ beans_add_smart_action( 'beans_comments_closed', 'beans_comments_closed' );
 function beans_comments_closed() {
 	beans_open_markup_e( 'beans_comments_closed', 'p', array( 'class' => 'uk-alert uk-alert-warning uk-margin-bottom-remove' ) );
 
-		beans_output_e( 'beans_comments_closed_text', __( 'Comments are closed for this article!', 'tm-beans' ) );
+		beans_output_e( 'beans_comments_closed_text', esc_html__( 'Comments are closed for this article!', 'tm-beans' ) );
 
 	beans_close_markup_e( 'beans_comments_closed', 'p' );
 }
@@ -387,12 +387,12 @@ function beans_comment_form() {
 		)
 	);
 
-		$submit .= beans_output( 'beans_comment_form_submit_text', __( 'Post Comment', 'tm-beans' ) );
+		$submit .= beans_output( 'beans_comment_form_submit_text', esc_html__( 'Post Comment', 'tm-beans' ) );
 
 	$submit .= beans_close_markup( 'beans_comment_form_submit', 'button' );
 
 	// WordPress, please make it easier for us.
-	echo preg_replace( '#<input[^>]+type="submit"[^>]+>#', $submit, $output ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Pending security audit.
+	echo preg_replace( '#<input[^>]+type="submit"[^>]+>#', $submit, $output ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Escaped above or as an attribute.
 }
 
 // Filter.
@@ -455,7 +455,7 @@ function beans_comment_form_comment() {
 
 		$output .= beans_open_markup( 'beans_comment_form_legend[_comment]', 'legend' );
 
-			$output .= beans_output( 'beans_comment_form_legend_text[_comment]', __( 'Comment *', 'tm-beans' ) );
+			$output .= beans_output( 'beans_comment_form_legend_text[_comment]', esc_html__( 'Comment *', 'tm-beans' ) );
 
 		$output .= beans_close_markup( 'beans_comment_form_legend[_comment]', 'legend' );
 	}
@@ -530,7 +530,7 @@ function beans_comment_form_fields( $fields ) {
 		if ( beans_apply_filters( 'beans_comment_form_legend[_name]', true ) ) {
 			$author .= beans_open_markup( 'beans_comment_form_legend[_name]', 'legend' );
 
-				$author .= beans_output( 'beans_comment_form_legend_text[_name]', __( 'Name *', 'tm-beans' ) );
+				$author .= beans_output( 'beans_comment_form_legend_text[_name]', esc_html__( 'Name *', 'tm-beans' ) );
 
 			$author .= beans_close_markup( 'beans_comment_form_legend[_name]', 'legend' );
 		}
@@ -599,7 +599,7 @@ function beans_comment_form_fields( $fields ) {
 		if ( beans_apply_filters( 'beans_comment_form_legend[_url]', true ) ) {
 			$url .= beans_open_markup( 'beans_comment_form_legend', 'legend' );
 
-				$url .= beans_output( 'beans_comment_form_legend_text[_url]', __( 'Website', 'tm-beans' ) );
+				$url .= beans_output( 'beans_comment_form_legend_text[_url]', esc_html__( 'Website', 'tm-beans' ) );
 
 			$url .= beans_close_markup( 'beans_comment_form_legend[_url]', 'legend' );
 		}

--- a/lib/templates/fragments/menu.php
+++ b/lib/templates/fragments/menu.php
@@ -93,7 +93,7 @@ function beans_primary_menu_offcanvas_button() {
 
 		beans_close_markup_e( 'beans_primary_menu_offcanvas_button_icon', 'span' );
 
-		beans_output_e( 'beans_offcanvas_menu_button', __( 'Menu', 'tm-beans' ) );
+		beans_output_e( 'beans_offcanvas_menu_button', esc_html__( 'Menu', 'tm-beans' ) );
 
 	beans_close_markup_e( 'beans_primary_menu_offcanvas_button', 'a' );
 }
@@ -155,7 +155,7 @@ function beans_primary_offcanvas_menu() {
 function beans_no_menu_notice() {
 	beans_open_markup_e( 'beans_no_menu_notice', 'p', array( 'class' => 'uk-alert uk-alert-warning' ) );
 
-		beans_output_e( 'beans_no_menu_notice_text', __( 'Whoops, your site does not have a menu!', 'tm-beans' ) );
+		beans_output_e( 'beans_no_menu_notice_text', esc_html__( 'Whoops, your site does not have a menu!', 'tm-beans' ) );
 
 	beans_close_markup_e( 'beans_no_menu_notice', 'p' );
 }

--- a/lib/templates/fragments/post-shortcodes.php
+++ b/lib/templates/fragments/post-shortcodes.php
@@ -16,7 +16,7 @@ beans_add_smart_action( 'beans_post_meta_date', 'beans_post_meta_date_shortcode'
  * @return void
  */
 function beans_post_meta_date_shortcode() {
-	beans_output_e( 'beans_post_meta_date_prefix', __( 'Posted on ', 'tm-beans' ) );
+	beans_output_e( 'beans_post_meta_date_prefix', esc_html__( 'Posted on ', 'tm-beans' ) );
 
 	beans_open_markup_e(
 		'beans_post_meta_date',
@@ -41,7 +41,7 @@ beans_add_smart_action( 'beans_post_meta_author', 'beans_post_meta_author_shortc
  * @return void
  */
 function beans_post_meta_author_shortcode() {
-	beans_output_e( 'beans_post_meta_author_prefix', __( 'By ', 'tm-beans' ) );
+	beans_output_e( 'beans_post_meta_author_prefix', esc_html__( 'By ', 'tm-beans' ) );
 
 	beans_open_markup_e(
 		'beans_post_meta_author',
@@ -78,29 +78,29 @@ beans_add_smart_action( 'beans_post_meta_comments', 'beans_post_meta_comments_sh
  * @return void
  */
 function beans_post_meta_comments_shortcode() {
-	global $post;
 
 	if ( post_password_required() || ! comments_open() ) {
 		return;
 	}
 
+	global $post;
 	$comments_number = (int) get_comments_number( $post->ID );
 
 	if ( $comments_number < 1 ) {
-		$comment_text = beans_output( 'beans_post_meta_empty_comment_text', __( 'Leave a comment', 'tm-beans' ) );
+		$comment_text = beans_output( 'beans_post_meta_empty_comment_text', esc_html__( 'Leave a comment', 'tm-beans' ) );
 	} elseif ( 1 === $comments_number ) {
-		$comment_text = beans_output( 'beans_post_meta_comments_text_singular', __( '1 comment', 'tm-beans' ) );
+		$comment_text = beans_output( 'beans_post_meta_comments_text_singular', esc_html__( '1 comment', 'tm-beans' ) );
 	} else {
 		$comment_text = beans_output(
 			'beans_post_meta_comments_text_plural',
-			// translators: Number of comments. Plural.
-			__( '%s comments', 'tm-beans' )
+			// translators: %s: Number of comments. Plural.
+			esc_html__( '%s comments', 'tm-beans' )
 		);
 	}
 
 	beans_open_markup_e( 'beans_post_meta_comments', 'a', array( 'href' => get_comments_link() ) ); // Automatically escaped.
 
-		printf( $comment_text, (int) get_comments_number( $post->ID ) ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Pending security audit.
+		printf( $comment_text, (int) get_comments_number( $post->ID ) ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Escaping handled prior to this printf.
 
 	beans_close_markup_e( 'beans_post_meta_comments', 'a' );
 }
@@ -114,14 +114,13 @@ beans_add_smart_action( 'beans_post_meta_tags', 'beans_post_meta_tags_shortcode'
  * @return void
  */
 function beans_post_meta_tags_shortcode() {
-
 	$tags = get_the_tag_list( null, ', ' );
 
 	if ( ! $tags || is_wp_error( $tags ) ) {
 		return;
 	}
 
-	printf( '%1$s%2$s', beans_output( 'beans_post_meta_tags_prefix', __( 'Tagged with: ', 'tm-beans' ) ), $tags ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Pending security audit.
+	printf( '%1$s%2$s', beans_output( 'beans_post_meta_tags_prefix', esc_html__( 'Tagged with: ', 'tm-beans' ) ), $tags ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Tags are escaped by WordPress.
 }
 
 beans_add_smart_action( 'beans_post_meta_categories', 'beans_post_meta_categories_shortcode' );
@@ -139,5 +138,5 @@ function beans_post_meta_categories_shortcode() {
 		return;
 	}
 
-	printf( '%1$s%2$s', beans_output( 'beans_post_meta_categories_prefix', __( 'Filed under: ', 'tm-beans' ) ), $categories ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Pending security audit.
+	printf( '%1$s%2$s', beans_output( 'beans_post_meta_categories_prefix', esc_html__( 'Filed under: ', 'tm-beans' ) ), $categories ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Categories are escaped by WordPress.
 }

--- a/lib/templates/fragments/post.php
+++ b/lib/templates/fragments/post.php
@@ -336,7 +336,7 @@ function beans_post_more_link() {
 		)
 	);
 
-		$output .= beans_output( 'beans_post_more_link_text', __( 'Continue reading', 'tm-beans' ) );
+		$output .= beans_output( 'beans_post_more_link_text', esc_html__( 'Continue reading', 'tm-beans' ) );
 
 		$output .= beans_open_markup(
 			'beans_next_icon[_more_link]',
@@ -388,7 +388,7 @@ function beans_post_meta_categories() {
 
 	beans_open_markup_e( 'beans_post_meta_categories', 'span', array( 'class' => 'uk-text-small uk-text-muted uk-clearfix' ) );
 
-		echo $categories; // // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Pending security audit.
+		echo $categories; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Shortcode's callback handles the escaping. See beans_post_meta_categories_shortcode().
 
 	beans_close_markup_e( 'beans_post_meta_categories', 'span' );
 }
@@ -408,7 +408,7 @@ function beans_post_meta_tags() {
 
 	beans_open_markup_e( 'beans_post_meta_tags', 'span', array( 'class' => 'uk-text-small uk-text-muted uk-clearfix' ) );
 
-		echo $tags; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Pending security audit.
+		echo $tags; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Shortcode's callback handles the escaping. See beans_post_meta_tags_shortcode().
 
 	beans_close_markup_e( 'beans_post_meta_tags', 'span' );
 }
@@ -540,7 +540,7 @@ function beans_post_navigation() {
 		'nav',
 		array(
 			'role'       => 'navigation',
-			'aria-label' => esc_attr__( 'Pagination Navigation', 'tm-beans' ),
+			'aria-label' => __( 'Pagination Navigation', 'tm-beans' ), // Attributes are automatically escaped.
 		)
 	);
 
@@ -616,7 +616,7 @@ function beans_posts_pagination() {
 		'nav',
 		array(
 			'role'       => 'navigation',
-			'aria-label' => esc_attr__( 'Posts Pagination Navigation', 'tm-beans' ),
+			'aria-label' => __( 'Posts Pagination Navigation', 'tm-beans' ), // Attributes are automatically escaped.
 		)
 	);
 
@@ -636,7 +636,7 @@ function beans_posts_pagination() {
 					'beans_previous_link[_posts_pagination]',
 					'a',
 					array(
-						'href' => previous_posts( false ), // Automatically escaped.
+						'href' => previous_posts( false ), // Attributes are automatically escaped.
 					),
 					$current
 				);
@@ -652,7 +652,7 @@ function beans_posts_pagination() {
 
 					beans_close_markup_e( 'beans_previous_icon[_posts_pagination]', 'span' );
 
-					beans_output_e( 'beans_previous_text[_posts_pagination]', __( 'Previous Page', 'tm-beans' ) );
+					beans_output_e( 'beans_previous_text[_posts_pagination]', esc_html__( 'Previous Page', 'tm-beans' ) );
 
 				beans_close_markup_e( 'beans_previous_link[_posts_pagination]', 'a' );
 
@@ -715,7 +715,7 @@ function beans_posts_pagination() {
 						'beans_posts_pagination_item_link',
 						'a',
 						array(
-							'href' => get_pagenum_link( $link ), // Automatically escaped.
+							'href' => get_pagenum_link( $link ), // Attributes are automatically escaped.
 						),
 						$link
 					);
@@ -736,12 +736,12 @@ function beans_posts_pagination() {
 					'beans_next_link[_posts_pagination]',
 					'a',
 					array(
-						'href' => next_posts( $count, false ), // Automatically escaped.
+						'href' => next_posts( $count, false ), // Attributes are automatically escaped.
 					),
 					$current
 				);
 
-					beans_output_e( 'beans_next_text[_posts_pagination]', __( 'Next Page', 'tm-beans' ) );
+					beans_output_e( 'beans_next_text[_posts_pagination]', esc_html__( 'Next Page', 'tm-beans' ) );
 
 					beans_open_markup_e(
 						'beans_next_icon[_posts_pagination]',
@@ -779,7 +779,7 @@ function beans_no_post() {
 
 			beans_open_markup_e( 'beans_post_title', 'h1', array( 'class' => 'uk-article-title' ) );
 
-				beans_output_e( 'beans_no_post_article_title_text', __( 'Whoops, no result found!', 'tm-beans' ) );
+				beans_output_e( 'beans_no_post_article_title_text', esc_html__( 'Whoops, no result found!', 'tm-beans' ) );
 
 			beans_close_markup_e( 'beans_post_title', 'h1' );
 
@@ -791,7 +791,7 @@ function beans_no_post() {
 
 				beans_open_markup_e( 'beans_no_post_article_content', 'p', array( 'class' => 'uk-alert uk-alert-warning' ) );
 
-					beans_output_e( 'beans_no_post_article_content_text', __( 'It looks like nothing was found at this location. Maybe try a search?', 'tm-beans' ) );
+					beans_output_e( 'beans_no_post_article_content_text', esc_html__( 'It looks like nothing was found at this location. Maybe try a search?', 'tm-beans' ) );
 
 				beans_close_markup_e( 'beans_no_post_article_content', 'p' );
 
@@ -821,7 +821,7 @@ function beans_post_password_form() {
 	// Notice.
 	$output = beans_open_markup( 'beans_password_form_notice', 'p', array( 'class' => 'uk-alert uk-alert-warning' ) );
 
-		$output .= beans_output( 'beans_password_form_notice_text', __( 'This post is protected. To view it, enter the password below!', 'tm-beans' ) );
+		$output .= beans_output( 'beans_password_form_notice_text', esc_html__( 'This post is protected. To view it, enter the password below!', 'tm-beans' ) );
 
 	$output .= beans_close_markup( 'beans_password_form_notice', 'p' );
 
@@ -832,7 +832,7 @@ function beans_post_password_form() {
 		array(
 			'class'  => 'uk-form uk-margin-bottom',
 			'method' => 'post',
-			'action' => site_url( 'wp-login.php?action=postpass', 'login_post' ), // Automatically escaped.
+			'action' => site_url( 'wp-login.php?action=postpass', 'login_post' ), // Attributes are automatically escaped.
 		)
 	);
 
@@ -842,7 +842,7 @@ function beans_post_password_form() {
 			array(
 				'class'       => 'uk-margin-small-top uk-margin-small-right',
 				'type'        => 'password',
-				'placeholder' => apply_filters( 'beans_password_form_input_placeholder', __( 'Password', 'tm-beans' ) ), // Automatically escaped.
+				'placeholder' => apply_filters( 'beans_password_form_input_placeholder', __( 'Password', 'tm-beans' ) ), // Attributes are automatically escaped.
 				'name'        => 'post_password',
 			)
 		);
@@ -854,7 +854,7 @@ function beans_post_password_form() {
 				'class' => 'uk-button uk-margin-small-top',
 				'type'  => 'submit',
 				'name'  => 'submit',
-				'value' => esc_attr( apply_filters( 'beans_password_form_submit_text', __( 'Submit', 'tm-beans' ) ) ),
+				'value' => apply_filters( 'beans_password_form_submit_text', __( 'Submit', 'tm-beans' ) ), // Attributes are automatically escaped.
 			)
 		);
 
@@ -897,7 +897,7 @@ function beans_post_gallery( $output, $attr, $instance ) {
 	$atts     = shortcode_atts( $defaults, $attr, 'gallery' );
 	$id       = intval( $atts['id'] );
 
-	// Set attachements.
+	// Set attachments.
 	if ( ! empty( $atts['include'] ) ) {
 		$_attachments = get_posts(
 			array(
@@ -979,7 +979,7 @@ function beans_post_gallery( $output, $attr, $instance ) {
 		"beans_post_gallery[_{$id}]",
 		'div',
 		array(
-			'class'               => "uk-grid uk-grid-width-small-1-{$columns} gallery galleryid-{$id} gallery-columns-{$columns} gallery-size-{$size_class}", // Automatically escaped.
+			'class'               => "uk-grid uk-grid-width-small-1-{$columns} gallery galleryid-{$id} gallery-columns-{$columns} gallery-size-{$size_class}", // Attributes are automatically escaped.
 			'data-uk-grid-margin' => false,
 		),
 		$id,
@@ -1005,7 +1005,7 @@ function beans_post_gallery( $output, $attr, $instance ) {
 			$orientation = ( $image_meta['height'] > $image_meta['width'] ) ? 'portrait' : 'landscape';
 		}
 
-			// Set the image output.
+		// Set the image output.
 		if ( 'none' === $atts['link'] ) {
 			$image_output = wp_get_attachment_image( $attachment_id, $atts['size'], false, $attr );
 		} else {
@@ -1014,7 +1014,7 @@ function beans_post_gallery( $output, $attr, $instance ) {
 
 			$output .= beans_open_markup( "beans_post_gallery_item[_{$attachment_id}]", $atts['itemtag'], array( 'class' => 'gallery-item' ) );
 
-				$output .= beans_open_markup( "beans_post_gallery_icon[_{$attachment_id}]", $atts['icontag'], array( 'class' => "gallery-icon {$orientation}" ) ); // Automatically escaped.
+				$output .= beans_open_markup( "beans_post_gallery_icon[_{$attachment_id}]", $atts['icontag'], array( 'class' => "gallery-icon {$orientation}" ) ); // Attributes are automatically escaped.
 
 					$output .= beans_output( "beans_post_gallery_icon[_{$attachment_id}]", $image_output, $attachment_id, $atts );
 

--- a/lib/templates/fragments/post.php
+++ b/lib/templates/fragments/post.php
@@ -71,7 +71,7 @@ function beans_post_search_title() {
 
 	beans_open_markup_e( 'beans_search_title', 'h1', array( 'class' => 'uk-article-title' ) );
 
-		printf( '%1$s%2$s', beans_output( 'beans_search_title_text', __( 'Search results for: ', 'tm-beans' ) ), get_search_query() ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Pending security audit.
+		printf( '%1$s%2$s', beans_output( 'beans_search_title_text', esc_html__( 'Search results for: ', 'tm-beans' ) ), get_search_query() ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped -- Each placeholder is escaped.
 
 	beans_close_markup_e( 'beans_search_title', 'h1' );
 }

--- a/lib/templates/fragments/widget.php
+++ b/lib/templates/fragments/widget.php
@@ -86,7 +86,7 @@ function beans_no_widget() {
 		beans_output_e(
 			'beans_no_widget_notice_text',
 			// translators: Name of the widget area.
-			sprintf( __( '%s does not have any widget assigned!', 'tm-beans' ), beans_get_widget_area( 'name' ) )
+			sprintf( esc_html__( '%s does not have any widget assigned!', 'tm-beans' ), beans_get_widget_area( 'name' ) )
 		);
 
 	beans_close_markup_e( 'beans_no_widget_notice', 'p' );
@@ -101,10 +101,9 @@ beans_add_filter( 'beans_widget_content_rss_output', 'beans_widget_rss_content' 
  * @return string The RSS widget content.
  */
 function beans_widget_rss_content() {
-
 	$options = beans_get_widget( 'options' );
 
-	return '<p><a class="uk-button" href="' . beans_get( 'url', $options ) . '" target="_blank">' . __( 'Read feed', 'tm-beans' ) . '</a><p>';
+	return '<p><a class="uk-button" href="' . beans_get( 'url', $options ) . '" target="_blank">' . esc_html__( 'Read feed', 'tm-beans' ) . '</a><p>';
 }
 
 beans_add_filter( 'beans_widget_content_attributes', 'beans_modify_widget_content_attributes' );


### PR DESCRIPTION
I had left 6 or so "pending security audit" messages in the codebase.  Thank you @christophherr for reminding me.  Each of those has been audited, corrected, and updated.

In reviewing, I noticed an inconsistency in our translation escaping.  Fixed to be:

1. Use `esc_html__()` when not an attribute and is being rendered out directly or as part of `beans_open_markup`, `beans_output`, etc.
2. Do not escape directly when it's an attribute.  Why?  Attributes are automatically escaped in Beans.