### PR TITLE
restore v1.4 behavior for beans_replace_attribute()

### DIFF
--- a/lib/api/html/class-beans-attribute.php
+++ b/lib/api/html/class-beans-attribute.php
@@ -117,10 +117,17 @@ final class _Beans_Attribute {
 	 */
 	public function replace( array $attributes ) {
 
-		if ( $this->has_attribute( $attributes ) && ! empty( $this->value ) ) {
+		if ( $this->new_value ) {
+
+		    if ( isset( $attributes[ $this->attribute ] ) ) {
 			$attributes[ $this->attribute ] = $this->replace_value( $attributes[ $this->attribute ] );
-		} else {
+		    } else {
 			$attributes[ $this->attribute ] = $this->new_value;
+		    }   
+		} else {
+
+		    $attributes[ $this->attribute ] = $this->value;
+
 		}
 
 		return $attributes;

--- a/lib/api/html/class-beans-attribute.php
+++ b/lib/api/html/class-beans-attribute.php
@@ -106,7 +106,7 @@ final class _Beans_Attribute {
 	}
 
 	/**
-	 * Replace the attribute's value. If the attribute does not exist, it is added with the new value.
+	 * Replace the attribute's value. If the attribute does not exist, it is added with the value.
 	 *
 	 * @since 1.0.0
 	 * @since 1.5.0 Allows replacement of all values.
@@ -117,17 +117,10 @@ final class _Beans_Attribute {
 	 */
 	public function replace( array $attributes ) {
 
-		if ( $this->new_value ) {
-
-		    if ( $this->has_attribute( $attributes ) ) {
+		if ( $this->has_attribute( $attributes ) && ! empty( $this->new_value ) ) {
 			$attributes[ $this->attribute ] = $this->replace_value( $attributes[ $this->attribute ] );
-		    } else {
-			$attributes[ $this->attribute ] = $this->new_value;
-		    }   
 		} else {
-
-		    $attributes[ $this->attribute ] = $this->value;
-
+			$attributes[ $this->attribute ] = $this->value;
 		}
 
 		return $attributes;

--- a/lib/api/html/class-beans-attribute.php
+++ b/lib/api/html/class-beans-attribute.php
@@ -119,7 +119,7 @@ final class _Beans_Attribute {
 
 		if ( $this->new_value ) {
 
-		    if ( isset( $attributes[ $this->attribute ] ) ) {
+		    if ( $this->has_attribute( $attributes ) ) {
 			$attributes[ $this->attribute ] = $this->replace_value( $attributes[ $this->attribute ] );
 		    } else {
 			$attributes[ $this->attribute ] = $this->new_value;

--- a/tests/phpunit/integration/api/html/beansReplaceAttribute.php
+++ b/tests/phpunit/integration/api/html/beansReplaceAttribute.php
@@ -72,9 +72,9 @@ class Tests_BeansReplaceAttribute extends HTML_Test_Case {
 
 	/**
 	 * Test the end result of beans_replace_attribute() by firing the expected filter event for the given ID. Test should replace
-	 * (overwrite) all attribute's values with the new value when the target value is empty (null, empty string, etc.).
+	 * (overwrite) all attribute's values with the target value when the new value is empty (null, empty string, etc.).
 	 */
-	public function test_should_overwrite_attribute_values_when_target_value_is_empty() {
+	public function test_should_overwrite_attribute_values_when_new_value_is_empty() {
 
 		foreach ( static::$test_attributes as $beans_id => $markup ) {
 			$name = key( $markup['attributes'] );
@@ -86,20 +86,20 @@ class Tests_BeansReplaceAttribute extends HTML_Test_Case {
 			$this->assertNull( $actual[ $name ] );
 			remove_filter( $hook, [ $instance, 'replace' ], 10 );
 
-			// Check when the target value is null.
-			$instance = beans_replace_attribute( $beans_id, $name, null, '' );
+			// Check when the new value is null.
+			$instance = beans_replace_attribute( $beans_id, $name, 'foo', null );
 			$actual   = apply_filters( $hook, $markup['attributes'] ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
-			$this->assertSame( '', $actual[ $name ] );
+			$this->assertSame( 'foo', $actual[ $name ] );
 			remove_filter( $hook, [ $instance, 'replace' ], 10 );
 
 			// Check when the target value is an empty string.
-			$instance = beans_replace_attribute( $beans_id, $name, '', 'foo' );
+			$instance = beans_replace_attribute( $beans_id, $name, 'foo', '' );
 			$actual   = apply_filters( $hook, $markup['attributes'] ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
 			$this->assertSame( 'foo', $actual[ $name ] );
 			remove_filter( $hook, [ $instance, 'replace' ], 10 );
 
 			// Check when the target value is false.
-			$instance = beans_replace_attribute( $beans_id, $name, false, 'foo' );
+			$instance = beans_replace_attribute( $beans_id, $name, 'foo', false );
 			$actual   = apply_filters( $hook, $markup['attributes'] ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.
 			$this->assertSame( 'foo', $actual[ $name ] );
 			remove_filter( $hook, [ $instance, 'replace' ], 10 );
@@ -113,7 +113,7 @@ class Tests_BeansReplaceAttribute extends HTML_Test_Case {
 	public function test_should_add_attribute_when_it_does_not_exist() {
 
 		foreach ( static::$test_attributes as $beans_id => $markup ) {
-			$instance = beans_replace_attribute( $beans_id, 'data-test', 'foo', 'beans-test' );
+			$instance = beans_replace_attribute( $beans_id, 'data-test', 'beans-test' );
 
 			// Check that the attribute does not exist.
 			$this->assertArrayNotHasKey( 'data-test', $markup['attributes'] );
@@ -144,7 +144,7 @@ class Tests_BeansReplaceAttribute extends HTML_Test_Case {
 		foreach ( static::$test_attributes as $beans_id => $markup ) {
 			$name     = key( $markup['attributes'] );
 			$value    = current( $markup['attributes'] );
-			$instance = beans_replace_attribute( $beans_id, $name, $value, 'beans-test' );
+			$instance = beans_replace_attribute( $beans_id, $name, 'beans-test', $value );
 
 			// Fire the event to run the replace.
 			$actual = apply_filters( "{$beans_id}_attributes", [] ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- The hook's name is in the value.

--- a/tests/phpunit/unit/api/html/beans-attribute/replace.php
+++ b/tests/phpunit/unit/api/html/beans-attribute/replace.php
@@ -50,7 +50,7 @@ class Tests_BeansAttribute_Replace extends HTML_Test_Case {
 	}
 
 	/**
-	 * Test _Beans_Attribute::replace() should replace (overwrite) all attribute's values with the new value when the target value is
+	 * Test _Beans_Attribute::replace() should replace (overwrite) all attribute's values with the value when the new value is
 	 * empty (null, empty string, etc.).
 	 */
 	public function test_should_overwrite_attribute_values_with_new_value() {
@@ -62,16 +62,16 @@ class Tests_BeansAttribute_Replace extends HTML_Test_Case {
 			$actual = ( new _Beans_Attribute( 'beans_post', $name ) )->replace( $markup['attributes'] );
 			$this->assertNull( $actual[ $name ] );
 
-			// Check when the value is null.
-			$actual = ( new _Beans_Attribute( 'beans_post', $name, null, '' ) )->replace( $markup['attributes'] );
-			$this->assertSame( '', $actual[ $name ] );
-
-			// Check when the value is an empty string.
-			$actual = ( new _Beans_Attribute( 'beans_post', $name, '', 'foo' ) )->replace( $markup['attributes'] );
+			// Check when new value is null.
+			$actual = ( new _Beans_Attribute( 'beans_post', $name, 'foo', null ) )->replace( $markup['attributes'] );
 			$this->assertSame( 'foo', $actual[ $name ] );
 
-			// Check when the target value is false.
-			$actual = ( new _Beans_Attribute( 'beans_post', $name, false, 'foo' ) )->replace( $markup['attributes'] );
+			// Check when the new value is an empty string.
+			$actual = ( new _Beans_Attribute( 'beans_post', $name, 'foo', '' ) )->replace( $markup['attributes'] );
+			$this->assertSame( 'foo', $actual[ $name ] );
+
+			// Check when the new value is false.
+			$actual = ( new _Beans_Attribute( 'beans_post', $name, 'foo', false ) )->replace( $markup['attributes'] );
 			$this->assertSame( 'foo', $actual[ $name ] );
 		}
 	}
@@ -83,7 +83,7 @@ class Tests_BeansAttribute_Replace extends HTML_Test_Case {
 
 		foreach ( static::$test_attributes as $beans_id => $markup ) {
 
-			$instance = new _Beans_Attribute( $beans_id, 'data-test', 'foo', 'beans-test' );
+			$instance = new _Beans_Attribute( $beans_id, 'data-test', 'beans-test' );
 
 			// Check that the attribute does not exist.
 			$this->assertArrayNotHasKey( 'data-test', $markup['attributes'] );
@@ -110,7 +110,7 @@ class Tests_BeansAttribute_Replace extends HTML_Test_Case {
 		foreach ( static::$test_attributes as $beans_id => $markup ) {
 			$name   = key( $markup['attributes'] );
 			$value  = current( $markup['attributes'] );
-			$actual = ( new _Beans_Attribute( $beans_id, $name, $value, 'beans-test' ) )->replace( [] );
+			$actual = ( new _Beans_Attribute( $beans_id, $name, 'beans-test', $value ) )->replace( [] );
 
 			// Check that it did add the attribute.
 			$this->assertArrayHasKey( $name, $actual );


### PR DESCRIPTION
In Beans v1.4, it was possible to call beans_replace_attribute with an empty "new_value" which replaced all values of the attribute with "value".

This behavior was broken in version 1.5.x

