### PR TITLE
 Fixed Beans Compiler path handling on some systems.

### DIFF
--- a/lib/api/compiler/class-beans-compiler.php
+++ b/lib/api/compiler/class-beans-compiler.php
@@ -431,7 +431,16 @@ final class _Beans_Compiler {
 			// Replace URL with path.
 			$fragment = beans_url_to_path( $fragment );
 
-			// Stop here if it isn't a valid file.
+			// Fix path on some Windows and Ubuntu systems.
+			// @ticket 332
+			if ( ! file_exists( $fragment ) || 0 === @filesize( $fragment ) ) { // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged  -- Valid use case.
+
+				if ( false !== strpos( $fragment, '/wp-' ) ) {
+					$fragment = beans_sanitize_path('.' . $fragment );
+				}
+			}
+
+			// Stop here if it still isn't a valid file.
 			if ( ! file_exists( $fragment ) || 0 === @filesize( $fragment ) ) { // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged  -- Valid use case.
 				return false;
 			}

--- a/lib/api/compiler/class-beans-compiler.php
+++ b/lib/api/compiler/class-beans-compiler.php
@@ -432,12 +432,17 @@ final class _Beans_Compiler {
 			$fragment = beans_url_to_path( $fragment );
 
 			// Fix path on some Windows and Ubuntu systems.
-			// @ticket 332
+			// @ticket 332.
 			if ( ! file_exists( $fragment ) || 0 === @filesize( $fragment ) ) { // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged  -- Valid use case.
 
 				if ( false !== strpos( $fragment, '/wp-' ) ) {
-					$fragment = beans_sanitize_path('.' . $fragment );
+					$fragment = beans_sanitize_path( '.' . $fragment );
 				}
+			}
+
+			// Account for edge cases not covered before.
+			if ( ! file_exists( $fragment ) || 0 === @filesize( $fragment ) ) { // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged  -- Valid use case.
+				$fragment = $this->resolve_fragment_location_by_url_parse( $fragment );
 			}
 
 			// Stop here if it still isn't a valid file.
@@ -448,6 +453,20 @@ final class _Beans_Compiler {
 
 		// It is safe to access the filesystem because we made sure it was set.
 		return $GLOBALS['wp_filesystem']->get_contents( $fragment );
+	}
+
+	/**
+	 * Resolve an edge case asset location by running through Beans's URL parsing.
+	 *
+	 * @since 1.6.0
+	 * @param string $fragment Unresolved asset fragment path.
+	 *
+	 * @return string The fragment path as modified by URL parsing.
+	 */
+	public function resolve_fragment_location_by_url_parse( $fragment ) {
+		$fragment = beans_path_to_url( $fragment );
+
+		return beans_url_to_path( $fragment );
 	}
 
 	/**

--- a/tests/phpunit/unit/api/compiler/beans-compiler/combineFragments.php
+++ b/tests/phpunit/unit/api/compiler/beans-compiler/combineFragments.php
@@ -94,6 +94,9 @@ class Tests_BeansCompiler_CombineFragments extends Compiler_Test_Case {
 		Monkey\Functions\when( 'beans_url_to_path' )->returnArg();
 		Monkey\Functions\when( 'wp_remote_get' )->justReturn();
 		Monkey\Functions\when( 'is_wp_error' )->justReturn( true );
+		Monkey\Functions\when( 'is_main_site' )->justReturn();
+		Monkey\Functions\when( 'get_blog_details' )->justReturn();
+		Monkey\Functions\when( 'get_current_blog_id' )->justReturn();
 
 		// Run the test.
 		$compiler->combine_fragments();


### PR DESCRIPTION
When the path of an asset starts with a `/`, e.g. `/wp-includes/js/jquery/jquery.js`, the `get_internal_content()` method of the Beans Compiler cannot resolve this to a valid path on Windows and some Ubuntu systems (there might be others).

This does not seem to be a regression in version 1.5. 
It doesn't work for me in version 1.4 on Windows. 

This PR adds additional `file_exists` checks to `get_internal_content()`.
The first one checks if the path starts with `wp-` and then adds a `.` to the beginning of the path and runs it through `beans_sanitize_path()`.
The second one runs a still unresolved path through `beans_path_to_url()` and then `beans_url_to_path()` to catch edge cases not covered before, e.g. if the wp-content directory has been changed.

Please see #332 for the discussion on the approach. 

Special thanks to @iCaspar 💯 

closes #332