### PR TITLE
Fixed _Beans_Image_Editor::run() can return path instead of url

### DIFF
--- a/lib/api/image/class-beans-image-editor.php
+++ b/lib/api/image/class-beans-image-editor.php
@@ -83,7 +83,7 @@ final class _Beans_Image_Editor {
 			return $this->get_image_info( beans_path_to_url( $this->rebuilt_path ), true );
 		}
 
-		return $this->get_image_info( $this->src );
+		return $this->get_image_info( beans_path_to_url( $this->src ) );
 	}
 
 	/**

--- a/tests/phpunit/integration/api/image/beans-image-editor/run.php
+++ b/tests/phpunit/integration/api/image/beans-image-editor/run.php
@@ -72,7 +72,7 @@ class Tests_BeansImageEditor_Run extends Image_Test_Case {
 	 * Test _Beans_Image_Editor::run() should return original src when the image does not exist.
 	 */
 	public function test_should_return_original_src_when_no_image() {
-		$src    = 'path/does/not/exist/image.jpg';
+		$src    = 'http://example.org/path/does/not/exist/image.jpg';
 		$editor = new _Beans_Image_Editor( $src, [ 'resize' => [ 800, false ] ] );
 
 		// Run the tests.
@@ -138,7 +138,7 @@ class Tests_BeansImageEditor_Run extends Image_Test_Case {
 	 * Test _Beans_Image_Editor::run() should return an indexed array with the original src when the image does not exist.
 	 */
 	public function test_should_return_indexed_array_with_original_src_when_no_image() {
-		$src    = 'path/does/not/exist/image.jpg';
+		$src    = 'http://example.org/path/does/not/exist/image.jpg';
 		$editor = new _Beans_Image_Editor( $src, [ 'resize' => [ 800, false ] ], ARRAY_N );
 
 		// Run the tests.
@@ -207,7 +207,7 @@ class Tests_BeansImageEditor_Run extends Image_Test_Case {
 	 * Test _Beans_Image_Editor::run() should return an object with the original src when the image does not exist.
 	 */
 	public function test_should_return_object_with_original_src_when_no_image() {
-		$src    = 'path/does/not/exist/image.jpg';
+		$src    = 'http://example.org/path/does/not/exist/image.jpg';
 		$editor = new _Beans_Image_Editor( $src, [ 'resize' => [ 800, false ] ], OBJECT );
 
 		// Run the tests.
@@ -289,7 +289,7 @@ class Tests_BeansImageEditor_Run extends Image_Test_Case {
 	 * Test _Beans_Image_Editor::run() should return an array with the original src when the image does not exist.
 	 */
 	public function test_should_return_associative_array_with_original_src_when_no_image() {
-		$src    = 'path/does/not/exist/image.jpg';
+		$src    = 'http://example.org/path/does/not/exist/image.jpg';
 		$editor = new _Beans_Image_Editor( $src, [ 'resize' => [ 800, false ] ], ARRAY_A );
 
 		// Run the tests.

--- a/tests/phpunit/integration/api/image/beansEditImage.php
+++ b/tests/phpunit/integration/api/image/beansEditImage.php
@@ -42,7 +42,7 @@ class Tests_BeansEditImage extends Image_Test_Case {
 	 * Test beans_edit_image() should return original src when the image does not exist.
 	 */
 	public function test_should_return_original_src_when_no_image() {
-		$src = 'path/does/not/exist/image.jpg';
+		$src = 'http://example.org/path/does/not/exist/image.jpg';
 
 		// Run the tests.
 		$this->assertFileNotExists( $src );
@@ -53,7 +53,7 @@ class Tests_BeansEditImage extends Image_Test_Case {
 	 * Test beans_edit_image() should return an indexed array with the original src when the image does not exist.
 	 */
 	public function test_should_return_indexed_array_with_original_src_when_no_image() {
-		$src = 'path/does/not/exist/image.jpg';
+		$src = 'http://example.org/path/does/not/exist/image.jpg';
 
 		// Run the tests.
 		$this->assertFileNotExists( $src );
@@ -67,7 +67,7 @@ class Tests_BeansEditImage extends Image_Test_Case {
 	 * Test beans_edit_image() should return an object with the original src when the image does not exist.
 	 */
 	public function test_should_return_object_with_original_src_when_no_image() {
-		$src = 'path/does/not/exist/image.jpg';
+		$src = 'http://example.org/path/does/not/exist/image.jpg';
 
 		// Run the tests.
 		$this->assertFileNotExists( $src );
@@ -82,7 +82,7 @@ class Tests_BeansEditImage extends Image_Test_Case {
 	 * Test beans_edit_image() should return an associative array with the original src when the image does not exist.
 	 */
 	public function test_should_return_associative_array_with_original_src_when_no_image() {
-		$src = 'path/does/not/exist/image.jpg';
+		$src = 'http://example.org/path/does/not/exist/image.jpg';
 
 		// Run the tests.
 		$this->assertFileNotExists( $src );

--- a/tests/phpunit/unit/api/image/beans-image-editor/run.php
+++ b/tests/phpunit/unit/api/image/beans-image-editor/run.php
@@ -71,7 +71,7 @@ class Tests_BeansImageEditor_Run extends Image_Test_Case {
 	 * Test _Beans_Image_Editor::run() should return original src when the image does not exist.
 	 */
 	public function test_should_return_original_src_when_no_image() {
-		$src    = 'path/does/not/exist/image.jpg';
+		$src    = 'http://example.org/path/does/not/exist/image.jpg';
 		$editor = new _Beans_Image_Editor( $src, [ 'resize' => [ 800, false ] ] );
 
 		// Set up the mocks.
@@ -145,7 +145,7 @@ class Tests_BeansImageEditor_Run extends Image_Test_Case {
 	 * Test _Beans_Image_Editor::run() should return an indexed array with the original src when the image does not exist.
 	 */
 	public function test_should_return_indexed_array_with_original_src_when_no_image() {
-		$src    = 'path/does/not/exist/image.jpg';
+		$src    = 'http://example.org/path/does/not/exist/image.jpg';
 		$editor = new _Beans_Image_Editor( $src, [ 'resize' => [ 800, false ] ], ARRAY_N );
 
 		// Set up the mocks.
@@ -222,7 +222,7 @@ class Tests_BeansImageEditor_Run extends Image_Test_Case {
 	 * Test _Beans_Image_Editor::run() should return an object with the original src when the image does not exist.
 	 */
 	public function test_should_return_object_with_original_src_when_no_image() {
-		$src    = 'path/does/not/exist/image.jpg';
+		$src    = 'http://example.org/path/does/not/exist/image.jpg';
 		$editor = new _Beans_Image_Editor( $src, [ 'resize' => [ 800, false ] ], OBJECT );
 
 		// Set up the mocks.
@@ -311,7 +311,7 @@ class Tests_BeansImageEditor_Run extends Image_Test_Case {
 	 * Test _Beans_Image_Editor::run() should return an associative array with the original src when the image does not exist.
 	 */
 	public function test_should_return_associative_array_with_original_src_when_no_image() {
-		$src    = 'path/does/not/exist/image.jpg';
+		$src    = 'http://example.org/path/does/not/exist/image.jpg';
 		$editor = new _Beans_Image_Editor( $src, [ 'resize' => [ 800, false ] ], ARRAY_A );
 
 		// Set up the mocks.


### PR DESCRIPTION
If the image doesn't exist, and image editing fails, the absolute path is returned instead of the src.